### PR TITLE
fix(renovate): correct package grouping rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,8 +42,13 @@
       "groupName": "iac/aws"
     },
     {
+      "description": "Group docs (Python/uv)",
+      "matchFileNames": ["docs/**"],
+      "groupName": "docs"
+    },
+    {
       "description": "Group root dependencies",
-      "matchFileNames": ["package.json", "pnpm-lock.yaml"],
+      "matchFileNames": ["./package.json"],
       "groupName": "root"
     },
     {


### PR DESCRIPTION
- Add docs group for Python/uv dependencies
- Change root matchFileNames from ["package.json", "pnpm-lock.yaml"] to ["./package.json"] to prevent matching all package.json files