### PR TITLE
fix(renovate): disable lockFileMaintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "dependencyDashboard": false,
   "ignoreTests": true,
   "lockFileMaintenance": {
-    "enabled": true,
+    "enabled": false,
     "extends": ["schedule:daily"]
   },
   "automerge": false,


### PR DESCRIPTION
Lock files are automatically updated when package.json changes, so separate lockFileMaintenance is unnecessary.