### PR TITLE
fix(renovate): add rangeStrategy bump to update package.json versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
   },
   "automergeStrategy": "squash",
   "minimumReleaseAge": "21 days",
+  "rangeStrategy": "bump",
   "packageRules": [
     {
       "description": "Group GitHub Actions",


### PR DESCRIPTION
Without this setting, semver-compatible updates (e.g., ^24.10.3 → ^24.10.4) only modify the lock file. With "bump", package.json versions are also updated.