### PR TITLE
feat(markdown): add link card (OGP card) support

### DIFF
--- a/apps/blog-api/Cargo.lock
+++ b/apps/blog-api/Cargo.lock
@@ -25,6 +25,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +892,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c66d1cd8ed61bf80b38432613a7a2f09401ab8d0501110655f8b341484a3e3"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +984,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +1022,21 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
 
 [[package]]
 name = "dunce"
@@ -1019,6 +1081,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "ego-tree"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c6ba7d4eec39eaa9ab24d44a0e73a7949a1095a8b3f3abb11eddf27dbb56a53"
 
 [[package]]
 name = "either"
@@ -1207,6 +1275,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,6 +1402,15 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1456,6 +1552,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "match_token",
 ]
 
 [[package]]
@@ -1983,13 +2091,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "markdown"
 version = "0.1.0"
 dependencies = [
  "comrak",
  "regex",
+ "scraper",
  "syntect",
  "ureq",
+ "url",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2076,6 +2217,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2311,6 +2458,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2385,6 +2584,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "primeorder"
@@ -2863,6 +3068,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0e749d29b2064585327af5038a5a8eb73aeebad4a3472e83531a436563f7208"
+dependencies = [
+ "ahash",
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,6 +3141,25 @@ checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "fxhash",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -3008,6 +3248,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3088,6 +3337,12 @@ dependencies = [
  "thiserror",
  "time",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
@@ -3348,6 +3603,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,6 +3729,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -3777,6 +4068,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode_categories"

--- a/apps/blog-api/markdown/Cargo.toml
+++ b/apps/blog-api/markdown/Cargo.toml
@@ -8,3 +8,5 @@ comrak = { version = "0.49", default-features = false, features = ["syntect"] }
 regex = "1.12.2"
 ureq = { version = "3", features = ["rustls"] }
 syntect = "5.3.0"
+scraper = "0.21"
+url = "2"

--- a/apps/blog-api/markdown/src/lib.rs
+++ b/apps/blog-api/markdown/src/lib.rs
@@ -1,7 +1,9 @@
 use comrak::Options;
 use comrak::plugins::syntect::SyntectAdapter;
 use regex::Regex;
+use scraper::{Html, Selector};
 use std::time::Duration;
+use url::Url;
 
 /// GitHub link information extracted from URL
 #[derive(Debug, Clone)]
@@ -13,6 +15,263 @@ struct GitHubLink {
     start_line: Option<usize>,
     end_line: Option<usize>,
     original_url: String,
+}
+
+/// OGP information extracted from a webpage
+#[derive(Debug, Clone)]
+struct OgpInfo {
+    url: String,
+    title: String,
+    description: Option<String>,
+    image: Option<String>,
+    favicon: Option<String>,
+}
+
+/// Fetch HTML content from URL
+fn fetch_ogp_html(url: &str) -> Result<String, String> {
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(5)))
+        .build()
+        .new_agent();
+
+    let response = agent
+        .get(url)
+        .header("User-Agent", "Mozilla/5.0 (compatible; LinkCardBot/1.0)")
+        .call()
+        .map_err(|e| e.to_string())?;
+
+    response.into_body().read_to_string().map_err(|e| e.to_string())
+}
+
+/// Parse OGP information from HTML
+fn parse_ogp(html_content: &str, original_url: &str) -> OgpInfo {
+    let document = Html::parse_document(html_content);
+
+    // OGP meta tag selectors
+    let og_title_sel = Selector::parse("meta[property='og:title']").unwrap();
+    let og_description_sel = Selector::parse("meta[property='og:description']").unwrap();
+    let og_image_sel = Selector::parse("meta[property='og:image']").unwrap();
+
+    // Fallback selectors
+    let title_sel = Selector::parse("title").unwrap();
+    let meta_description_sel = Selector::parse("meta[name='description']").unwrap();
+
+    // Extract title (OGP first, then <title> tag, then URL)
+    let title = document
+        .select(&og_title_sel)
+        .next()
+        .and_then(|e| e.value().attr("content"))
+        .map(|s| s.to_string())
+        .or_else(|| {
+            document
+                .select(&title_sel)
+                .next()
+                .map(|e| e.text().collect::<String>())
+        })
+        .unwrap_or_else(|| original_url.to_string());
+
+    // Extract description
+    let description = document
+        .select(&og_description_sel)
+        .next()
+        .and_then(|e| e.value().attr("content"))
+        .map(|s| s.to_string())
+        .or_else(|| {
+            document
+                .select(&meta_description_sel)
+                .next()
+                .and_then(|e| e.value().attr("content"))
+                .map(|s| s.to_string())
+        });
+
+    // Extract image
+    let image = document
+        .select(&og_image_sel)
+        .next()
+        .and_then(|e| e.value().attr("content"))
+        .map(|s| resolve_url(original_url, s));
+
+    // Extract favicon
+    let favicon = extract_favicon(&document, original_url);
+
+    OgpInfo {
+        url: original_url.to_string(),
+        title,
+        description,
+        image,
+        favicon,
+    }
+}
+
+/// Extract favicon URL from HTML document
+fn extract_favicon(document: &Html, base_url: &str) -> Option<String> {
+    let icon_sel = Selector::parse("link[rel='icon'], link[rel='shortcut icon']").unwrap();
+
+    if let Some(element) = document.select(&icon_sel).next() {
+        if let Some(href) = element.value().attr("href") {
+            return Some(resolve_url(base_url, href));
+        }
+    }
+
+    // Fallback: /favicon.ico
+    if let Ok(url) = Url::parse(base_url) {
+        if let Some(host) = url.host_str() {
+            return Some(format!("{}://{}/favicon.ico", url.scheme(), host));
+        }
+    }
+
+    None
+}
+
+/// Resolve relative URL to absolute URL
+fn resolve_url(base_url: &str, href: &str) -> String {
+    if href.starts_with("http://") || href.starts_with("https://") {
+        return href.to_string();
+    }
+
+    if let Ok(base) = Url::parse(base_url) {
+        if let Ok(resolved) = base.join(href) {
+            return resolved.to_string();
+        }
+    }
+
+    href.to_string()
+}
+
+/// Extract domain from URL
+fn extract_domain(url: &str) -> String {
+    Url::parse(url)
+        .ok()
+        .and_then(|u| u.host_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| url.to_string())
+}
+
+/// Render link card HTML (Zenn-style)
+fn render_link_card(ogp: &OgpInfo) -> String {
+    let domain = extract_domain(&ogp.url);
+
+    let description_html = ogp
+        .description
+        .as_ref()
+        .map(|d| {
+            format!(
+                r#"<div class="link-card-description">{}</div>"#,
+                html_escape(d)
+            )
+        })
+        .unwrap_or_default();
+
+    let image_html = ogp
+        .image
+        .as_ref()
+        .map(|i| {
+            format!(
+                r#"<div class="link-card-image"><img src="{}" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div>"#,
+                html_escape(i)
+            )
+        })
+        .unwrap_or_default();
+
+    let favicon_html = ogp
+        .favicon
+        .as_ref()
+        .map(|f| {
+            format!(
+                r#"<img class="link-card-favicon" src="{}" alt="" onerror="this.style.display='none'">"#,
+                html_escape(f)
+            )
+        })
+        .unwrap_or_default();
+
+    // Wrap in <div> to ensure it's treated as a block-level HTML element by comrak
+    format!(
+        r#"<div class="link-card-wrapper"><a href="{url}" class="link-card" target="_blank" rel="noopener noreferrer"><div class="link-card-content"><div class="link-card-text"><div class="link-card-title">{title}</div>{description}</div>{image}</div><div class="link-card-footer">{favicon}<span class="link-card-domain">{domain}</span></div></a></div>"#,
+        url = html_escape(&ogp.url),
+        title = html_escape(&ogp.title),
+        description = description_html,
+        image = image_html,
+        favicon = favicon_html,
+        domain = html_escape(&domain)
+    )
+}
+
+/// Check if a line contains only a standalone URL (not inside markdown link syntax)
+fn is_standalone_url(line: &str) -> bool {
+    let trimmed = line.trim();
+    if !trimmed.starts_with("http://") && !trimmed.starts_with("https://") {
+        return false;
+    }
+    // Make sure it's not part of a markdown link
+    !line.contains('[') && !line.contains('(')
+}
+
+/// Check if URL is a GitHub URL (to be processed by GitHub embed instead)
+fn is_github_blob_url(url: &str) -> bool {
+    url.starts_with("https://github.com/") && url.contains("/blob/")
+}
+
+/// Process link cards in markdown
+/// Only processes standalone URLs at the start of a line (excluding GitHub blob URLs)
+fn process_link_cards(markdown: &str) -> String {
+    let mut result = String::new();
+    let mut in_code_block = false;
+
+    for line in markdown.lines() {
+        // Track code block state
+        if line.starts_with("```") {
+            in_code_block = !in_code_block;
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        if in_code_block {
+            result.push_str(line);
+            result.push('\n');
+            continue;
+        }
+
+        let trimmed = line.trim();
+
+        // Check if line is a standalone URL (not GitHub blob)
+        if is_standalone_url(trimmed) && !is_github_blob_url(trimmed) {
+            // Skip localhost and internal network URLs
+            if trimmed.contains("localhost") || trimmed.contains("127.0.0.1") {
+                result.push_str(line);
+                result.push('\n');
+                continue;
+            }
+
+            // Try to fetch OGP info
+            match fetch_ogp_html(trimmed) {
+                Ok(html_content) => {
+                    let ogp = parse_ogp(&html_content, trimmed);
+                    let card_html = render_link_card(&ogp);
+                    // Add blank lines before and after to ensure HTML block recognition
+                    result.push('\n');
+                    result.push_str(&card_html);
+                    result.push_str("\n\n");
+                    continue;
+                }
+                Err(_) => {
+                    // Fallback: keep original URL
+                    result.push_str(line);
+                    result.push('\n');
+                    continue;
+                }
+            }
+        }
+
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    // Remove trailing newline if original didn't have one
+    if !markdown.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    result
 }
 
 /// Parse a GitHub blob URL into its components
@@ -573,8 +832,11 @@ impl MarkdownConverter {
         // Process GitHub embeds (fetch code and render)
         let with_github = process_github_embeds(&escaped, self);
 
+        // Process link cards (OGP cards) for standalone URLs
+        let with_link_cards = process_link_cards(&with_github);
+
         // Process code blocks with filename (e.g., ```json:package.json)
-        let with_code_blocks = process_code_blocks_with_filename(&with_github, self);
+        let with_code_blocks = process_code_blocks_with_filename(&with_link_cards, self);
 
         // Preprocess custom embed syntax
         let preprocessed = preprocess_embeds(&with_code_blocks);
@@ -898,5 +1160,168 @@ mod tests {
         assert!(html.contains("code-block-filename-container"));
         assert!(html.contains("src/main.rs"));
         assert!(html.contains("<pre")); // syntect generates <pre style="...">
+    }
+
+    // Link Card (OGP) tests
+
+    #[test]
+    fn test_is_standalone_url() {
+        assert!(is_standalone_url("https://example.com"));
+        assert!(is_standalone_url("http://example.com"));
+        assert!(is_standalone_url("  https://example.com  "));
+        assert!(!is_standalone_url("[link](https://example.com)"));
+        assert!(!is_standalone_url("Check this: https://example.com"));
+        assert!(!is_standalone_url("not a url"));
+    }
+
+    #[test]
+    fn test_is_github_blob_url() {
+        assert!(is_github_blob_url("https://github.com/owner/repo/blob/main/file.rs"));
+        assert!(!is_github_blob_url("https://github.com/owner/repo"));
+        assert!(!is_github_blob_url("https://example.com"));
+    }
+
+    #[test]
+    fn test_extract_domain() {
+        assert_eq!(extract_domain("https://example.com/path"), "example.com");
+        assert_eq!(extract_domain("https://sub.example.com"), "sub.example.com");
+        assert_eq!(extract_domain("invalid"), "invalid");
+    }
+
+    #[test]
+    fn test_resolve_url_absolute() {
+        assert_eq!(
+            resolve_url("https://example.com", "https://other.com/image.png"),
+            "https://other.com/image.png"
+        );
+    }
+
+    #[test]
+    fn test_resolve_url_relative() {
+        assert_eq!(
+            resolve_url("https://example.com/page", "/favicon.ico"),
+            "https://example.com/favicon.ico"
+        );
+        assert_eq!(
+            resolve_url("https://example.com/dir/page", "image.png"),
+            "https://example.com/dir/image.png"
+        );
+    }
+
+    #[test]
+    fn test_parse_ogp() {
+        let html = r#"
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta property="og:title" content="Test Title">
+            <meta property="og:description" content="Test Description">
+            <meta property="og:image" content="https://example.com/image.png">
+            <link rel="icon" href="/favicon.ico">
+        </head>
+        <body></body>
+        </html>
+        "#;
+        let ogp = parse_ogp(html, "https://example.com");
+        assert_eq!(ogp.title, "Test Title");
+        assert_eq!(ogp.description, Some("Test Description".to_string()));
+        assert_eq!(ogp.image, Some("https://example.com/image.png".to_string()));
+        assert_eq!(ogp.favicon, Some("https://example.com/favicon.ico".to_string()));
+    }
+
+    #[test]
+    fn test_parse_ogp_fallback_to_title_tag() {
+        let html = r#"
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <title>Fallback Title</title>
+            <meta name="description" content="Fallback Description">
+        </head>
+        <body></body>
+        </html>
+        "#;
+        let ogp = parse_ogp(html, "https://example.com");
+        assert_eq!(ogp.title, "Fallback Title");
+        assert_eq!(ogp.description, Some("Fallback Description".to_string()));
+    }
+
+    #[test]
+    fn test_render_link_card() {
+        let ogp = OgpInfo {
+            url: "https://example.com".to_string(),
+            title: "Test Title".to_string(),
+            description: Some("Test Description".to_string()),
+            image: Some("https://example.com/image.png".to_string()),
+            favicon: Some("https://example.com/favicon.ico".to_string()),
+        };
+        let html = render_link_card(&ogp);
+        assert!(html.contains("link-card"));
+        assert!(html.contains("Test Title"));
+        assert!(html.contains("Test Description"));
+        assert!(html.contains("link-card-image"));
+        assert!(html.contains("link-card-favicon"));
+        assert!(html.contains("example.com"));
+        assert!(html.contains(r#"target="_blank""#));
+    }
+
+    #[test]
+    fn test_render_link_card_without_image() {
+        let ogp = OgpInfo {
+            url: "https://example.com".to_string(),
+            title: "Test Title".to_string(),
+            description: None,
+            image: None,
+            favicon: None,
+        };
+        let html = render_link_card(&ogp);
+        assert!(html.contains("link-card"));
+        assert!(html.contains("Test Title"));
+        assert!(!html.contains("link-card-image"));
+        assert!(!html.contains("link-card-description"));
+    }
+
+    #[test]
+    fn test_link_card_xss_prevention() {
+        let ogp = OgpInfo {
+            url: "https://example.com".to_string(),
+            title: "<script>alert('xss')</script>".to_string(),
+            description: Some("<img onerror='alert(1)'>".to_string()),
+            image: None,
+            favicon: None,
+        };
+        let html = render_link_card(&ogp);
+        // Angle brackets should be escaped
+        assert!(!html.contains("<script>"));
+        assert!(!html.contains("<img"));
+        assert!(html.contains("&lt;script&gt;"));
+        assert!(html.contains("&lt;img"));
+    }
+
+    #[test]
+    fn test_link_cards_not_in_code_block() {
+        let markdown = "```\nhttps://example.com\n```";
+        let result = process_link_cards(markdown);
+        // Should not be processed (inside code block)
+        assert!(result.contains("https://example.com"));
+        assert!(!result.contains("link-card"));
+    }
+
+    #[test]
+    fn test_link_cards_skip_localhost() {
+        let markdown = "https://localhost:3000/test";
+        let result = process_link_cards(markdown);
+        // Should not be processed (localhost)
+        assert!(result.contains("https://localhost:3000/test"));
+        assert!(!result.contains("link-card"));
+    }
+
+    #[test]
+    fn test_link_cards_skip_github_blob() {
+        let markdown = "https://github.com/owner/repo/blob/main/file.rs";
+        let result = process_link_cards(markdown);
+        // Should not be processed (GitHub blob - handled by GitHub embed)
+        assert!(result.contains("https://github.com/owner/repo/blob/main/file.rs"));
+        assert!(!result.contains("link-card"));
     }
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -868,3 +868,175 @@ a:hover {
     transform: translateY(-150%);
   }
 }
+
+/* Link Card (OGP Card) - Zenn-style */
+.link-card-wrapper {
+  margin: 1rem 0;
+}
+
+/* Override prose styles for link cards */
+.prose .link-card-wrapper,
+.prose .link-card,
+.prose .link-card:hover,
+.prose .link-card:visited {
+  color: inherit;
+  text-decoration: none;
+}
+
+.prose .link-card-wrapper img,
+.prose .link-card img {
+  margin: 0;
+  display: block;
+}
+
+.link-card {
+  display: block;
+  position: relative;
+  border: 1px solid var(--github-embed-border);
+  border-radius: 8px;
+  overflow: visible;
+  text-decoration: none;
+  color: inherit;
+  transition:
+    box-shadow 0.2s,
+    border-color 0.2s;
+}
+
+.link-card:hover {
+  border-color: var(--github-embed-link);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.link-card:visited {
+  color: inherit;
+}
+
+.link-card-text {
+  flex: 1;
+  padding: 12px 16px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.link-card-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  color: var(--text-color);
+  margin: 0;
+}
+
+.link-card-description {
+  margin-top: 6px;
+  font-size: 0.8rem;
+  color: var(--github-embed-meta);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-height: 1.5;
+}
+
+.link-card-content {
+  display: flex;
+  align-items: stretch;
+  min-height: 120px;
+  max-height: 120px;
+  overflow: hidden;
+  border-radius: 8px;
+}
+
+.link-card-image {
+  flex-shrink: 0;
+  width: 200px;
+  height: 120px;
+  background: var(--github-embed-header-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.link-card-image img {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  margin: 0;
+  display: block;
+}
+
+.link-card-footer {
+  position: absolute;
+  bottom: 8px;
+  right: 216px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  background: #fff;
+  border: 1px solid var(--github-embed-border);
+  border-radius: 14px;
+  font-size: 0.7rem;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+[data-theme="dark"] .link-card-footer {
+  background: #2d333b;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .link-card-footer {
+    background: #2d333b;
+  }
+}
+
+.link-card-favicon {
+  flex-shrink: 0;
+  width: 14px;
+  height: 14px;
+  object-fit: contain;
+  display: block;
+}
+
+.link-card-domain {
+  font-size: 0.75rem;
+  color: var(--github-embed-meta);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+/* Link Card responsive */
+@media (max-width: 576px) {
+  .link-card-image {
+    width: 120px;
+  }
+
+  .link-card-title {
+    font-size: 0.85rem;
+  }
+
+  .link-card-description {
+    font-size: 0.75rem;
+    -webkit-line-clamp: 1;
+  }
+
+  .link-card-text {
+    padding: 10px 12px;
+  }
+
+  .link-card-footer {
+    padding: 6px 12px;
+  }
+}


### PR DESCRIPTION
- Add OGP fetching and parsing for standalone URLs
- Render Zenn-style link cards with title, description, image, and favicon
- Skip GitHub blob URLs (handled by existing GitHub embed)
- Skip localhost and internal network URLs
- Add XSS prevention with HTML escaping
- Add comprehensive tests for link card functionality
- Add CSS styles for link card with dark mode support