### PR TITLE
feat(ci): add setup-rust action to parse rust-toolchain.toml

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -1,0 +1,25 @@
+name: Setup Rust
+description: Setup Rust toolchain from rust-toolchain.toml
+
+runs:
+  using: "composite"
+  steps:
+    - name: Parse rust-toolchain.toml
+      id: parse
+      shell: bash
+      run: |
+        TOOLCHAIN_FILE="rust-toolchain.toml"
+        if [[ ! -f "$TOOLCHAIN_FILE" ]]; then
+          echo "rust-toolchain.toml not found" >&2
+          exit 1
+        fi
+        CHANNEL=$(grep '^channel' "$TOOLCHAIN_FILE" | sed 's/.*= *"\([^"]*\)".*/\1/')
+        COMPONENTS=$(grep '^components' "$TOOLCHAIN_FILE" | sed 's/.*\[\(.*\)\].*/\1/' | tr -d '"' | tr -d ' ')
+        echo "channel=$CHANNEL" >> $GITHUB_OUTPUT
+        echo "components=$COMPONENTS" >> $GITHUB_OUTPUT
+
+    - name: Setup Rust toolchain
+      uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # master
+      with:
+        toolchain: ${{ steps.parse.outputs.channel }}
+        components: ${{ steps.parse.outputs.components }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: ./.github/actions/setup-node
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # master
+        uses: ./.github/actions/setup-rust
 
       - name: Lint
         shell: bash

--- a/.github/workflows/reusable-deploy.yaml
+++ b/.github/workflows/reusable-deploy.yaml
@@ -30,7 +30,7 @@ jobs:
       - uses: ./.github/actions/setup-node
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561 # master
+        uses: ./.github/actions/setup-rust
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1


### PR DESCRIPTION
### Problem
The CI was using `actions-rust-lang/setup-rust-toolchain` which failed on the self-hosted macOS runner with a permission error:
```
error: could not amend shell profile: '/Users/shuntaka/.zshenv': Permission denied (os error 13)
```

This occurred because the action tries to install rustup, and rustup's installer attempts to modify shell profile files.

### Attempted Solutions

1. **Switch to `dtolnay/rust-toolchain`** - This action doesn't install rustup from scratch (assumes it's already installed), so it avoids the shell profile modification issue.

2. **Problem with dtolnay/rust-toolchain** - Unlike `setup-rust-toolchain`, it does NOT auto-detect `rust-toolchain.toml`. The `toolchain` parameter is required, resulting in:
   ```
   'toolchain' is a required input
   ```

### Final Solution

Created a custom composite action `.github/actions/setup-rust/action.yaml` that:
1. Parses `rust-toolchain.toml` to extract `channel` and `components`
2. Passes them to `dtolnay/rust-toolchain`

This maintains a single source of truth (`rust-toolchain.toml`) while using an action that works on self-hosted runners.
