### PR TITLE
refactor(web): optimize images, fonts and SEO with Next.js

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,43 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'res.cloudinary.com',
+        pathname: '/dkerzyk09/**',
+      },
+    ],
+  },
+  experimental: {
+    optimizePackageImports: ['tocbot'],
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-XSS-Protection',
+            value: '1; mode=block',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/apps/web/src/app/[userName]/articles/[slug]/error.tsx
+++ b/apps/web/src/app/[userName]/articles/[slug]/error.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function ArticleError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Article error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center">
+      <h2 className="mb-4 text-xl font-bold">記事の読み込みに失敗しました</h2>
+      <p className="mb-4 text-gray-600">{error.message}</p>
+      <button
+        type="button"
+        onClick={() => reset()}
+        className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+      >
+        再試行
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/[userName]/articles/[slug]/page.tsx
+++ b/apps/web/src/app/[userName]/articles/[slug]/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next';
+import Image from 'next/image';
 import { notFound } from 'next/navigation';
 import { ArticleContent } from '@/components/ArticleContent';
 import { BaseLayout } from '@/components/BaseLayout';
+import { ArticleJsonLd } from '@/components/JsonLd';
 import { TableOfContents } from '@/components/TableOfContents';
 import { getArticleBySlug } from '@/lib/api';
 import { SITE_URL } from '@/lib/constants';
@@ -75,34 +77,51 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
     notFound();
   }
 
+  const articleUrl = `${SITE_URL}/${userName}/articles/${slug}`;
+
   return (
-    <BaseLayout>
-      <div className="article-header">
-        <div className="article-title">{article.title}</div>
-        <div className="article-info">
-          <div className="article-time">
-            <p>{formatDate(article.publishedAt)}</p>
-            <p>{formatDate(article.updatedAt)}</p>
+    <>
+      <ArticleJsonLd
+        title={article.title}
+        description={article.description}
+        publishedAt={article.publishedAt}
+        updatedAt={article.updatedAt}
+        authorName={userName}
+        url={articleUrl}
+        imageUrl={article.thumbnail ?? article.ogpUrl}
+      />
+      <BaseLayout>
+        <div className="article-header">
+          <div className="article-title">{article.title}</div>
+          <div className="article-info">
+            <div className="article-time">
+              <p>{formatDate(article.publishedAt)}</p>
+              <p>{formatDate(article.updatedAt)}</p>
+            </div>
           </div>
         </div>
-      </div>
-      <div className="article-body">
-        <article className="article-content">
-          {article.thumbnail && (
-            <img
-              src={article.thumbnail}
-              alt={article.title}
-              className="article-thumbnail"
-            />
-          )}
-          <div className="article-content-wrapper">
-            <ArticleContent html={article.contentHtml ?? ''} />
-          </div>
-        </article>
-        <aside className="right-sidebar">
-          <TableOfContents />
-        </aside>
-      </div>
-    </BaseLayout>
+        <div className="article-body">
+          <article className="article-content">
+            {article.thumbnail && (
+              <Image
+                src={article.thumbnail}
+                alt={article.title}
+                width={800}
+                height={450}
+                className="article-thumbnail"
+                priority
+                sizes="(max-width: 768px) 100vw, 800px"
+              />
+            )}
+            <div className="article-content-wrapper">
+              <ArticleContent html={article.contentHtml ?? ''} />
+            </div>
+          </article>
+          <aside className="right-sidebar">
+            <TableOfContents />
+          </aside>
+        </div>
+      </BaseLayout>
+    </>
   );
 }

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Application error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center">
+      <h2 className="mb-4 text-xl font-bold">エラーが発生しました</h2>
+      <p className="mb-4 text-gray-600">{error.message}</p>
+      <button
+        type="button"
+        onClick={() => reset()}
+        className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+      >
+        再試行
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -114,8 +114,9 @@ html {
 body {
   height: 100%;
   font-family:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-    Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+    var(--font-inter), var(--font-noto-sans-jp), -apple-system,
+    BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
+    "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   word-wrap: break-word;
   background: var(--bg-color);
   color: var(--text-color);

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -114,7 +114,7 @@ html {
 body {
   height: 100%;
   font-family:
-    var(--font-inter), var(--font-noto-sans-jp), -apple-system,
+    var(--font-lato), var(--font-noto-sans-jp), -apple-system,
     BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
     "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   word-wrap: break-word;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -114,7 +114,7 @@ html {
 body {
   height: 100%;
   font-family:
-    var(--font-lato), var(--font-noto-sans-jp), -apple-system,
+    var(--font-roboto), var(--font-noto-sans-jp), -apple-system,
     BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
     "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   word-wrap: break-word;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { Lato, Noto_Sans_JP } from 'next/font/google';
+import { Noto_Sans_JP, Roboto } from 'next/font/google';
 import './globals.css';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -9,11 +9,11 @@ import { NavigationProgressProvider } from '@/components/NavigationProgressProvi
 import { ThemeProvider } from '@/components/ThemeProvider';
 import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '@/lib/constants';
 
-const lato = Lato({
+const roboto = Roboto({
   subsets: ['latin'],
   weight: ['400', '700'],
   display: 'swap',
-  variable: '--font-lato',
+  variable: '--font-roboto',
 });
 
 const notoSansJP = Noto_Sans_JP({
@@ -69,7 +69,7 @@ export default function RootLayout({
   return (
     <html
       lang="ja"
-      className={`${lato.variable} ${notoSansJP.variable}`}
+      className={`${roboto.variable} ${notoSansJP.variable}`}
       suppressHydrationWarning
     >
       <GoogleTagManager />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { Inter, Noto_Sans_JP } from 'next/font/google';
 import './globals.css';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -8,12 +9,31 @@ import { NavigationProgressProvider } from '@/components/NavigationProgressProvi
 import { ThemeProvider } from '@/components/ThemeProvider';
 import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '@/lib/constants';
 
+const inter = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-inter',
+});
+
+const notoSansJP = Noto_Sans_JP({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-noto-sans-jp',
+});
+
 const OG_IMAGE_URL =
   'https://res.cloudinary.com/dkerzyk09/image/upload/v1767101809/blog/og/shuntaka.png';
 
 export const metadata: Metadata = {
   title: SITE_TITLE,
   description: SITE_DESCRIPTION,
+  metadataBase: new URL(SITE_URL),
+  alternates: {
+    canonical: '/',
+    types: {
+      'application/rss+xml': '/feed',
+    },
+  },
   icons: {
     icon: '/icons/icon.png',
     apple: '/icons/apple-icon.png',
@@ -36,6 +56,7 @@ export const metadata: Metadata = {
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     images: [OG_IMAGE_URL],
+    creator: '@shuntaka_jp',
   },
 };
 
@@ -45,7 +66,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja" suppressHydrationWarning>
+    <html
+      lang="ja"
+      className={`${inter.variable} ${notoSansJP.variable}`}
+      suppressHydrationWarning
+    >
       <GoogleTagManager />
       <body>
         <GoogleTagManagerNoscript />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { Inter, Noto_Sans_JP } from 'next/font/google';
+import { Lato, Noto_Sans_JP } from 'next/font/google';
 import './globals.css';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -9,10 +9,11 @@ import { NavigationProgressProvider } from '@/components/NavigationProgressProvi
 import { ThemeProvider } from '@/components/ThemeProvider';
 import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '@/lib/constants';
 
-const inter = Inter({
+const lato = Lato({
   subsets: ['latin'],
+  weight: ['400', '700'],
   display: 'swap',
-  variable: '--font-inter',
+  variable: '--font-lato',
 });
 
 const notoSansJP = Noto_Sans_JP({
@@ -68,7 +69,7 @@ export default function RootLayout({
   return (
     <html
       lang="ja"
-      className={`${inter.variable} ${notoSansJP.variable}`}
+      className={`${lato.variable} ${notoSansJP.variable}`}
       suppressHydrationWarning
     >
       <GoogleTagManager />

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from 'next';
+import { SITE_URL } from '@/lib/constants';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/', '/_next/'],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/apps/web/src/components/ArticleCard.tsx
+++ b/apps/web/src/components/ArticleCard.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { memo } from 'react';
 import type { Article } from '@/lib/api';
 
 interface ArticleCardProps {
@@ -17,10 +18,13 @@ function formatDate(dateString: string | null): string {
   });
 }
 
-export function ArticleCard({ article, userName }: ArticleCardProps) {
+export const ArticleCard = memo(function ArticleCard({
+  article,
+  userName,
+}: ArticleCardProps) {
   return (
     <Link href={`/${userName}/articles/${article.slug}`}>
-      <div
+      <article
         className="mb-4 block w-full border-b"
         style={{ borderColor: 'var(--article-record-underline)' }}
       >
@@ -42,7 +46,7 @@ export function ArticleCard({ article, userName }: ArticleCardProps) {
             </div>
           )}
         </div>
-      </div>
+      </article>
     </Link>
   );
-}
+});

--- a/apps/web/src/components/ArticleCard.tsx
+++ b/apps/web/src/components/ArticleCard.tsx
@@ -1,3 +1,4 @@
+import Image from 'next/image';
 import Link from 'next/link';
 import type { Article } from '@/lib/api';
 
@@ -30,10 +31,13 @@ export function ArticleCard({ article, userName }: ArticleCardProps) {
           </div>
           {article.thumbnail && (
             <div>
-              <img
+              <Image
                 src={article.thumbnail}
                 alt={article.title}
-                className="h-[100px] w-[150px] rounded-[10px] object-cover"
+                width={150}
+                height={100}
+                className="rounded-[10px] object-cover"
+                loading="lazy"
               />
             </div>
           )}

--- a/apps/web/src/components/ArticleContent.tsx
+++ b/apps/web/src/components/ArticleContent.tsx
@@ -158,6 +158,9 @@ export function ArticleContent({ html }: ArticleContentProps) {
     script.onload = () => {
       window.twttr?.widgets.load(container);
     };
+    script.onerror = () => {
+      console.error('Failed to load Twitter widgets.js');
+    };
     document.body.appendChild(script);
   }, [html]);
 

--- a/apps/web/src/components/BaseLayout.tsx
+++ b/apps/web/src/components/BaseLayout.tsx
@@ -33,7 +33,11 @@ export function BaseLayout({
 
       {/* Type Header (tech/note/who?) */}
       {showTypeHeader && (
-        <div className="w-full" style={{ background: 'var(--header-color)' }}>
+        <nav
+          className="w-full"
+          style={{ background: 'var(--header-color)' }}
+          aria-label="カテゴリーナビゲーション"
+        >
           <div className="mx-auto max-w-[1200px] px-8 max-sm:px-[2%] max-sm:pt-3">
             <div className="inline-block mr-2">
               <ProgressLink
@@ -79,7 +83,7 @@ export function BaseLayout({
               </ProgressLink>
             </div>
           </div>
-        </div>
+        </nav>
       )}
 
       {/* Page Body */}

--- a/apps/web/src/components/GoogleTagManager.tsx
+++ b/apps/web/src/components/GoogleTagManager.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Script from 'next/script';
 import { GTM_ID, isGtmEnabled } from '@/lib/gtm';
 

--- a/apps/web/src/components/JsonLd.tsx
+++ b/apps/web/src/components/JsonLd.tsx
@@ -1,0 +1,41 @@
+interface ArticleJsonLdProps {
+  title: string;
+  description: string;
+  publishedAt: string | null;
+  updatedAt: string | null;
+  authorName: string;
+  url: string;
+  imageUrl?: string;
+}
+
+export function ArticleJsonLd({
+  title,
+  description,
+  publishedAt,
+  updatedAt,
+  authorName,
+  url,
+  imageUrl,
+}: ArticleJsonLdProps) {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: title,
+    description,
+    author: {
+      '@type': 'Person',
+      name: authorName,
+    },
+    datePublished: publishedAt,
+    dateModified: updatedAt || publishedAt,
+    url,
+    ...(imageUrl && { image: imageUrl }),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+    />
+  );
+}

--- a/apps/web/src/components/TableOfContents.tsx
+++ b/apps/web/src/components/TableOfContents.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useEffect } from 'react';
-import tocbot from 'tocbot';
+import { useEffect, useRef } from 'react';
+import type tocbotModule from 'tocbot';
 
 export function TableOfContents() {
+  const tocbotRef = useRef<typeof tocbotModule | null>(null);
+
   useEffect(() => {
-    const initTocbot = () => {
+    const initTocbot = async () => {
       const content = document.querySelector('.prose');
       if (!content) return;
 
@@ -18,6 +20,10 @@ export function TableOfContents() {
           heading.id = `heading-${index}`;
         }
       });
+
+      // Dynamic import tocbot
+      const tocbot = (await import('tocbot')).default;
+      tocbotRef.current = tocbot;
 
       tocbot.init({
         tocSelector: '.toc',
@@ -34,7 +40,7 @@ export function TableOfContents() {
 
     return () => {
       clearTimeout(timer);
-      tocbot.destroy();
+      tocbotRef.current?.destroy();
     };
   }, []);
 

--- a/apps/web/src/components/ToggleSwitch.tsx
+++ b/apps/web/src/components/ToggleSwitch.tsx
@@ -17,9 +17,11 @@ export function ToggleSwitch() {
   const isDark = colorMode === 'dark';
 
   return (
-    <div
+    <button
+      type="button"
       className="toggle-switch"
       onClick={handleClick}
+      aria-label={isDark ? 'ライトモードに切り替え' : 'ダークモードに切り替え'}
       style={{ cursor: 'pointer' }}
     >
       <div
@@ -37,6 +39,7 @@ export function ToggleSwitch() {
             viewBox="0 0 24 24"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
           >
             <circle cx="12" cy="12" r="12" fill="#525457" />
             <path
@@ -48,6 +51,6 @@ export function ToggleSwitch() {
           </svg>
         </span>
       </div>
-    </div>
+    </button>
   );
 }

--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,7 @@
   "words": [
     "adoc",
     "apig",
+    "dkerzyk",
     "applicationautoscaling",
     "autobuild",
     "avenir",
@@ -57,6 +58,7 @@
     "nodegroup",
     "nofile",
     "nonroot",
+    "nosniff",
     "notesansjpmid",
     "ocha",
     "oembed",


### PR DESCRIPTION
## 概要
`apps/web/` のNext.jsアプリケーションをReact/Next.jsベストプラクティス（Vercel React Best Practices）に従って改善します。

## 変更内容

### Phase 1: 設定の最適化
- `next.config.ts`: 画像ドメイン（Cloudinary）、セキュリティヘッダー、`optimizePackageImports` 追加
- `robots.ts`: 新規作成（SEOクローラー設定）

### Phase 2: 画像最適化
- `ArticleCard.tsx`: `<img>` → `next/image` に変更（lazy loading）
- 記事詳細ページ: `<img>` → `next/image` に変更（priority, sizes属性）

少し冗長な感じがする、本格的にやるならCloudnaryだけにしても良い気がする 🤔 
```
  Cloudinary (最適化済み)
    ↓
  Vercel /_next/image (再最適化 + Edgeキャッシュ)
    ↓
  ブラウザ

  二重最適化になっていますが、VercelのEdgeキャッシュがCDNとして機能するので、Cloudinaryへのリクエスト数は減ります。
```

### Phase 3: 'use client' 最適化
- `GoogleTagManager.tsx`: `'use client'` ディレクティブ削除
- `TableOfContents.tsx`: tocbotをdynamic importに変更（バンドルサイズ削減）

### Phase 4: フォント最適化
- `layout.tsx`: `next/font` でInter + Noto Sans JP導入（FOIT防止）
- `globals.css`: CSS変数でフォント設定

### Phase 5: SEO/Metadata強化
- `JsonLd.tsx`: 新規作成（Article構造化データ）
- `layout.tsx`: metadataBase, alternates, twitter creator追加

