### PR TITLE
ci: add workflow for auto-updating Cargo.lock on Renovate PRs

### DIFF
--- a/.github/actions/ci/action.yaml
+++ b/.github/actions/ci/action.yaml
@@ -1,0 +1,21 @@
+name: CI Steps
+description: Run lint, spell-check, type-check, and test
+
+runs:
+  using: "composite"
+  steps:
+    - name: Lint
+      shell: bash
+      run: pnpm lint
+
+    - name: Spell check
+      shell: bash
+      run: pnpm spell-check
+
+    - name: Type check
+      shell: bash
+      run: pnpm type-check
+
+    - name: Test
+      shell: bash
+      run: pnpm run test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,18 +19,5 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
 
-      - name: Lint
-        shell: bash
-        run: pnpm lint
-
-      - name: Spell check
-        shell: bash
-        run: pnpm spell-check
-
-      - name: Type check
-        shell: bash
-        run: pnpm type-check
-
-      - name: Test
-        shell: bash
-        run: pnpm run test
+      - name: Run CI
+        uses: ./.github/actions/ci

--- a/.github/workflows/renovate-cargo-update.yaml
+++ b/.github/workflows/renovate-cargo-update.yaml
@@ -1,0 +1,40 @@
+name: Renovate Cargo Update
+
+on:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "apps/blog-api/**/Cargo.toml"
+
+permissions:
+  contents: write
+
+jobs:
+  update-and-ci:
+    if: github.actor == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup node
+        uses: ./.github/actions/setup-node
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Update Cargo.lock
+        run: cargo update
+
+      - name: Run CI
+        uses: ./.github/actions/ci
+
+      - name: Commit Cargo.lock
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Cargo.lock
+          git diff --staged --quiet || git commit -m "chore: update Cargo.lock"
+          git push


### PR DESCRIPTION
## Summary

- Add composite action for CI steps (lint, spell-check, type-check, test)
- Add workflow to auto-update Cargo.lock when Renovate updates Cargo.toml
- Refactor ci.yaml to use the new composite action

## Changes

### `.github/actions/ci/action.yaml` (new)
- Composite action containing CI steps extracted from ci.yaml

### `.github/workflows/ci.yaml`
- Replaced inline CI steps with composite action call

### `.github/workflows/renovate-cargo-update.yaml` (new)
- Triggers on PRs from renovate[bot] that modify Cargo.toml
- Runs `cargo update` to update Cargo.lock
- Runs CI via composite action
- Commits Cargo.lock only if CI passes

