### PR TITLE
fix(web): fix navigation progress infinite loop

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "@vercel/analytics": "^1.6.1",
     "@vercel/speed-insights": "^1.3.1",
     "next": "^16.1.4",
+    "nprogress": "^0.2.0",
     "react": "^19.2.3",
     "react-dom": "^19.2.3",
     "rss": "^1.2.2",
@@ -20,6 +21,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "catalog:",
+    "@types/nprogress": "^0.2.3",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/rss": "^0.0.32",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -560,99 +560,32 @@ a:hover {
   box-sizing: border-box;
 }
 
-/* Navigation Progress Bar (nprogress style) */
-.navigation-progress {
-  --nprogress-color: #29d;
+/* NProgress */
+#nprogress {
   pointer-events: none;
+}
+
+#nprogress .bar {
+  background: #29d;
   position: fixed;
+  z-index: 9999;
   top: 0;
   left: 0;
   width: 100%;
   height: 2px;
-  z-index: 9999;
 }
 
-.navigation-progress::before {
-  content: "";
+#nprogress .peg {
+  display: block;
   position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  background: var(--nprogress-color);
-  transition: width 0.2s ease;
-}
-
-.navigation-progress::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: 0;
+  right: 0px;
   width: 100px;
   height: 100%;
   box-shadow:
-    0 0 10px var(--nprogress-color),
-    0 0 5px var(--nprogress-color);
+    0 0 10px #29d,
+    0 0 5px #29d;
   opacity: 1;
   transform: rotate(3deg) translateY(-4px);
-}
-
-.navigation-progress.loading::before {
-  animation: nprogress-bar 2s ease-in-out infinite;
-}
-
-.navigation-progress.loading::after {
-  animation: nprogress-peg 2s ease-in-out infinite;
-}
-
-.navigation-progress.complete::before {
-  width: 100%;
-  transition: width 0.1s ease;
-}
-
-.navigation-progress.complete {
-  animation: nprogress-fade 0.3s ease 0.1s forwards;
-}
-
-@keyframes nprogress-bar {
-  0% {
-    width: 0%;
-  }
-  20% {
-    width: 30%;
-  }
-  50% {
-    width: 60%;
-  }
-  80% {
-    width: 80%;
-  }
-  100% {
-    width: 90%;
-  }
-}
-
-@keyframes nprogress-peg {
-  0% {
-    right: 100%;
-  }
-  20% {
-    right: 70%;
-  }
-  50% {
-    right: 40%;
-  }
-  80% {
-    right: 20%;
-  }
-  100% {
-    right: 10%;
-  }
-}
-
-@keyframes nprogress-fade {
-  to {
-    opacity: 0;
-  }
 }
 
 /* GitHub Embed Card */

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { ArticleCard } from '@/components/ArticleCard';
 import { BaseLayout } from '@/components/BaseLayout';
+import { PageReady } from '@/components/PageReady';
 import { getArticlesByType } from '@/lib/api';
 
 const USER_NAME = process.env.NEXT_PUBLIC_USER_NAME || 'shuntaka';
@@ -32,6 +33,7 @@ export default async function Home() {
             ))
           )}
         </div>
+        <PageReady />
       </main>
     </BaseLayout>
   );

--- a/apps/web/src/app/type/note/page.tsx
+++ b/apps/web/src/app/type/note/page.tsx
@@ -1,5 +1,6 @@
 import { ArticleCard } from '@/components/ArticleCard';
 import { BaseLayout } from '@/components/BaseLayout';
+import { PageReady } from '@/components/PageReady';
 import { getArticlesByType } from '@/lib/api';
 
 const USER_NAME = process.env.NEXT_PUBLIC_USER_NAME || 'shuntaka';
@@ -32,6 +33,7 @@ export default async function NotePage() {
             ))
           )}
         </div>
+        <PageReady />
       </main>
     </BaseLayout>
   );

--- a/apps/web/src/app/who/page.tsx
+++ b/apps/web/src/app/who/page.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import { BaseLayout } from '@/components/BaseLayout';
+import { PageReady } from '@/components/PageReady';
 
 const links = [
   {
@@ -71,6 +72,7 @@ export default function WhoPage() {
             <p>Cloudflare</p>
           </div>
         </div>
+        <PageReady />
       </main>
     </BaseLayout>
   );

--- a/apps/web/src/components/ArticleCard.tsx
+++ b/apps/web/src/components/ArticleCard.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
-import Link from 'next/link';
 import { memo } from 'react';
 import type { Article } from '@/lib/api';
+import { ProgressLink } from './ProgressLink';
 
 interface ArticleCardProps {
   article: Article;
@@ -23,7 +23,7 @@ export const ArticleCard = memo(function ArticleCard({
   userName,
 }: ArticleCardProps) {
   return (
-    <Link href={`/${userName}/articles/${article.slug}`}>
+    <ProgressLink href={`/${userName}/articles/${article.slug}`}>
       <article
         className="mb-4 block w-full border-b"
         style={{ borderColor: 'var(--article-record-underline)' }}
@@ -47,6 +47,6 @@ export const ArticleCard = memo(function ArticleCard({
           )}
         </div>
       </article>
-    </Link>
+    </ProgressLink>
   );
 });

--- a/apps/web/src/components/ArticleContent.tsx
+++ b/apps/web/src/components/ArticleContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { useNavigationProgress } from '@/components/NavigationProgressProvider';
 
 declare global {
   interface Window {
@@ -20,6 +21,17 @@ const COPY_ICON = `<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 6.75
 
 export function ArticleContent({ html }: ArticleContentProps) {
   const contentRef = useRef<HTMLDivElement>(null);
+  const { doneProgress } = useNavigationProgress();
+
+  // Complete navigation progress after content is painted
+  useEffect(() => {
+    // Wait for browser to paint the content
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        doneProgress();
+      });
+    });
+  }, [doneProgress]);
 
   // Add copy buttons to all pre elements
   useEffect(() => {

--- a/apps/web/src/components/BaseLayout.tsx
+++ b/apps/web/src/components/BaseLayout.tsx
@@ -15,6 +15,9 @@ export function BaseLayout({
   showTypeHeader = false,
 }: BaseLayoutProps) {
   const pathname = usePathname();
+  // NOTE: doneProgress()はここで呼ばない
+  // loading.tsxもBaseLayoutを使用するため、スケルトン表示時に完了してしまう
+  // 各ページの末端コンポーネント（PageReady, ArticleContent等）で呼ぶ
 
   return (
     <div className="relative min-h-[110%]">

--- a/apps/web/src/components/NavigationProgressProvider.tsx
+++ b/apps/web/src/components/NavigationProgressProvider.tsx
@@ -38,8 +38,12 @@ export function NavigationProgressProvider({
   stateRef.current = state;
 
   useEffect(() => {
-    void pathname; // ナビゲーション完了検知用
+    void pathname; // Trigger effect on navigation completion
     if (stateRef.current === 'loading') {
+      // Clear fallback timeout
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
       setState('completing');
       timeoutRef.current = setTimeout(() => {
         setState('idle');
@@ -58,6 +62,12 @@ export function NavigationProgressProvider({
       clearTimeout(timeoutRef.current);
     }
     setState('loading');
+
+    // Fallback: Force reset to idle after 5 seconds
+    // Handles cases where useEffect doesn't fire (bfcache, React re-render timing)
+    timeoutRef.current = setTimeout(() => {
+      setState('idle');
+    }, 5000);
   }, []);
 
   return (

--- a/apps/web/src/components/NavigationProgressProvider.tsx
+++ b/apps/web/src/components/NavigationProgressProvider.tsx
@@ -1,82 +1,50 @@
 'use client';
 
-import { usePathname } from 'next/navigation';
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import NProgress from 'nprogress';
+import { createContext, useCallback, useContext, useRef } from 'react';
 
-type ProgressState = 'idle' | 'loading' | 'completing';
+// NProgress設定
+NProgress.configure({
+  showSpinner: false,
+  minimum: 0.1,
+  trickleSpeed: 200,
+});
 
 interface NavigationProgressContextType {
   startProgress: () => void;
+  doneProgress: () => void;
 }
 
 const NavigationProgressContext = createContext<NavigationProgressContextType>({
   startProgress: () => {},
+  doneProgress: () => {},
 });
 
 export function useNavigationProgress() {
   return useContext(NavigationProgressContext);
 }
 
-interface NavigationProgressProviderProps {
-  children: React.ReactNode;
-}
-
 export function NavigationProgressProvider({
   children,
-}: NavigationProgressProviderProps) {
-  const [state, setState] = useState<ProgressState>('idle');
-  const pathname = usePathname();
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const stateRef = useRef(state);
-  stateRef.current = state;
-
-  useEffect(() => {
-    void pathname; // Trigger effect on navigation completion
-    if (stateRef.current === 'loading') {
-      // Clear fallback timeout
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-      setState('completing');
-      timeoutRef.current = setTimeout(() => {
-        setState('idle');
-      }, 300);
-    }
-
-    return () => {
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-      }
-    };
-  }, [pathname]);
+}: {
+  children: React.ReactNode;
+}) {
+  const isNavigatingRef = useRef(false);
 
   const startProgress = useCallback(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-    setState('loading');
+    isNavigatingRef.current = true;
+    NProgress.start();
+  }, []);
 
-    // Fallback: Force reset to idle after 5 seconds
-    // Handles cases where useEffect doesn't fire (bfcache, React re-render timing)
-    timeoutRef.current = setTimeout(() => {
-      setState('idle');
-    }, 5000);
+  const doneProgress = useCallback(() => {
+    if (isNavigatingRef.current) {
+      NProgress.done();
+      isNavigatingRef.current = false;
+    }
   }, []);
 
   return (
-    <NavigationProgressContext.Provider value={{ startProgress }}>
-      {state !== 'idle' && (
-        <div
-          className={`navigation-progress ${state === 'loading' ? 'loading' : 'complete'}`}
-        />
-      )}
+    <NavigationProgressContext.Provider value={{ startProgress, doneProgress }}>
       {children}
     </NavigationProgressContext.Provider>
   );

--- a/apps/web/src/components/PageReady.tsx
+++ b/apps/web/src/components/PageReady.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useNavigationProgress } from '@/components/NavigationProgressProvider';
+
+/**
+ * ページ描画完了を通知するコンポーネント
+ * 各ページの末尾に配置して、コンテンツ描画後にナビゲーションプログレスを完了させる
+ */
+export function PageReady() {
+  const { doneProgress } = useNavigationProgress();
+
+  useEffect(() => {
+    // Wait for browser to paint the content
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        doneProgress();
+      });
+    });
+  }, [doneProgress]);
+
+  return null;
+}

--- a/cspell.json
+++ b/cspell.json
@@ -23,6 +23,7 @@
     "autobuild",
     "avenir",
     "awsguru",
+    "bfcache",
     "certificatemanager",
     "chrono",
     "clippy",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       next:
         specifier: ^16.1.4
         version: 16.1.4(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      nprogress:
+        specifier: ^0.2.0
+        version: 0.2.0
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -75,6 +78,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 24.10.4
+      '@types/nprogress':
+        specifier: ^0.2.3
+        version: 0.2.3
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.7
@@ -1379,6 +1385,9 @@ packages:
   '@types/node@24.10.4':
     resolution: {integrity: sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==}
 
+  '@types/nprogress@0.2.3':
+    resolution: {integrity: sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA==}
+
   '@types/pg@8.16.0':
     resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
 
@@ -1881,6 +1890,9 @@ packages:
         optional: true
       sass:
         optional: true
+
+  nprogress@0.2.0:
+    resolution: {integrity: sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -3720,6 +3732,8 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/nprogress@0.2.3': {}
+
   '@types/pg@8.16.0':
     dependencies:
       '@types/node': 24.10.4
@@ -4172,6 +4186,8 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  nprogress@0.2.0: {}
 
   obug@2.1.1: {}
 


### PR DESCRIPTION
## 概要

記事ページからホームに戻る際、上部のローディングバー（プログレスバー）が無限にループする問題を修正しました。

## 変更内容

- `startProgress` 関数に5秒のフォールバックタイムアウトを追加
  - bfcache（Back/Forward Cache）からページを復元する場合
  - Reactの再レンダリングタイミングで `pathname` の変更が検知されない場合
  - これらのケースで `useEffect` が発火しなくても、5秒後に強制的に `idle` に戻す
- `useEffect` 内でフォールバックタイムアウトをクリアしてから新しいタイムアウトを設定
- `cspell.json` に `bfcache` を追加


