### PR TITLE
fix(ci): disable node_modules cache by default in setup-node action

### DIFF
--- a/.github/actions/setup-node/action.yaml
+++ b/.github/actions/setup-node/action.yaml
@@ -1,6 +1,12 @@
 name: Setup node
 description: Setup Node and restore cache
 
+inputs:
+  use-cache:
+    description: "Whether to use GitHub Actions cache for node_modules"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -14,6 +20,7 @@ runs:
         bun-version-file: ".bun-version"
 
     - name: Cache node_modules
+      if: inputs.use-cache == 'true'
       id: cache-node-modules
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
@@ -21,6 +28,6 @@ runs:
         key: ${{ runner.os }}-node-modules-${{ hashFiles('bun.lockb') }}
 
     - name: Install node modules
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      if: inputs.use-cache != 'true' || steps.cache-node-modules.outputs.cache-hit != 'true'
       shell: bash
       run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Add `use-cache` parameter to setup-node action (default: `false`)
- Disable node_modules cache by default to improve deploy speed on self-hosted runners

## Background

The GitHub Actions cache for node_modules was causing slowdowns on self-hosted runners.

### Problem Analysis

**Cache hit case**: Downloading 173MB cache from GitHub servers takes ~100 seconds
**Cache miss case**: `bun install` completes in ~1s, but uploading cache takes 25-77 seconds

### Measured Times (deploy workflow, cache enabled)

| Run | Title | Cache | setup-node | Post | Total |
|-----|-------|-------|------------|------|-------|
| [21321631378](https://github.com/shuntaka9576/shuntaka-dev/actions/runs/21321631378) | rust-workspace update | **Hit** | 101s | 0s | **101s** |
| [21321628472](https://github.com/shuntaka9576/shuntaka-dev/actions/runs/21321628472) | docs update | **Hit** | 98s | 0s | **98s** |
| [21321599833](https://github.com/shuntaka9576/shuntaka-dev/actions/runs/21321599833) | bun update | **Hit** | 99s | 16s | **115s** |
| [21321783217](https://github.com/shuntaka9576/shuntaka-dev/actions/runs/21321783217) | cspell update | Miss | 6s | 25s | **31s** |
| [21321717919](https://github.com/shuntaka9576/shuntaka-dev/actions/runs/21321717919) | prettier update | Miss | 5s | 77s | **82s** |

### Key Findings

- **Cache hit is slower than cache miss**: Download speed is ~1.5 MB/s, taking ~100s for 173MB
- **bun install is very fast**: 668ms-2.5s even without cache
- **Self-hosted runner cleanup**: `actions/checkout` runs `git clean -ffdx` which removes `node_modules`, negating local persistence benefits

### Expected Improvement

With cache disabled, `bun install` will run every time but complete in **~1-3 seconds**, compared to:
- Cache hit: 98-115 seconds
- Cache miss: 31-82 seconds

