### PR TITLE
fix(docker): update Rust version to 1.92 to match rust-toolchain.toml

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,4 @@
 **/out
 **/target
 bun.lock
+.claude

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG RUST_VERSION=1.88
+ARG RUST_VERSION=1.92
 
 FROM lukemathwalker/cargo-chef:latest-rust-${RUST_VERSION} AS chef
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,18 @@
     "enabled": true,
     "schedule": ["at any time"]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update ARG RUST_VERSION in Dockerfile",
+      "managerFilePatterns": ["/(^|/)Dockerfile$/"],
+      "matchStrings": ["ARG RUST_VERSION=(?<currentValue>\\d+\\.\\d+)\\n"],
+      "depNameTemplate": "rust",
+      "packageNameTemplate": "rust-lang/rust",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)"
+    }
+  ],
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "minor", "major"],
@@ -76,6 +88,12 @@
       "description": "Immediate updates for bun",
       "matchManagers": ["bun"],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "description": "Group Rust toolchain updates (rust-toolchain.toml + Dockerfile)",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["rust-lang/rust"],
+      "groupName": "rust-toolchain"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Update `RUST_VERSION` in Dockerfile from 1.88 to 1.92 to match `rust-toolchain.toml`
- Fixes CD build failure where `cargo chef cook` panics due to Rust version mismatch

## Details

The `rust-toolchain.toml` specifies Rust 1.92.0, but the Dockerfile was still using 1.88. This caused `cargo chef cook --release` to fail with exit code 101 during the Docker build in GitHub Actions CD.

## Test plan

- [ ] Verify GitHub Actions CD pipeline completes successfully
