### PR TITLE
feat: replace X embed widgets.js with react-tweet

### DIFF
--- a/apps/blog-api/markdown/src/lib.rs
+++ b/apps/blog-api/markdown/src/lib.rs
@@ -228,24 +228,13 @@ fn is_x_url(url: &str) -> bool {
     url.starts_with("https://x.com/") && url.contains("/status/")
 }
 
-/// Fetch X embed HTML via oEmbed API
-fn fetch_x_oembed(url: &str) -> Option<String> {
-    let encoded_url = url::form_urlencoded::Serializer::new(String::new())
-        .append_pair("url", url)
-        .append_pair("omit_script", "true")
-        .finish();
-
-    let api_url = format!("https://publish.twitter.com/oembed?{encoded_url}");
-
-    let agent = ureq::Agent::config_builder()
-        .timeout_global(Some(Duration::from_secs(5)))
-        .build()
-        .new_agent();
-
-    let response = agent.get(&api_url).call().ok()?;
-    let body = response.into_body().read_to_string().ok()?;
-    let json: serde_json::Value = serde_json::from_str(&body).ok()?;
-    json["html"].as_str().map(|s| s.to_string())
+/// Extract tweet ID from X URL
+fn extract_x_tweet_id(url: &str) -> Option<&str> {
+    url.split("/status/")
+        .nth(1)?
+        .split(&['?', '/', '#'][..])
+        .next()
+        .filter(|id| !id.is_empty() && id.chars().all(|c| c.is_ascii_digit()))
 }
 
 /// Process X embeds in markdown
@@ -273,16 +262,16 @@ fn process_x_embeds(markdown: &str) -> (String, bool) {
         let trimmed = line.trim();
 
         // Check if line is a standalone X URL
-        if is_x_url(trimmed) && !line.contains('[') && !line.contains('(') {
-            // Try to fetch oEmbed HTML
-            if let Some(embed_html) = fetch_x_oembed(trimmed) {
-                has_x_embed = true;
-                result.push('\n');
-                result.push_str(&embed_html);
-                result.push_str("\n\n");
-                continue;
-            }
-            // Fallback: keep original URL
+        if is_x_url(trimmed)
+            && !line.contains('[')
+            && !line.contains('(')
+            && let Some(tweet_id) = extract_x_tweet_id(trimmed)
+        {
+            has_x_embed = true;
+            result.push('\n');
+            result.push_str(&format!("<div data-tweet-id=\"{tweet_id}\"></div>"));
+            result.push_str("\n\n");
+            continue;
         }
 
         result.push_str(line);
@@ -296,10 +285,6 @@ fn process_x_embeds(markdown: &str) -> (String, bool) {
 
     (result, has_x_embed)
 }
-
-/// X widgets.js script tag
-const X_WIDGETS_SCRIPT: &str =
-    r#"<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>"#;
 
 /// Process link cards in markdown
 /// Only processes standalone URLs at the start of a line (excluding GitHub blob URLs)
@@ -921,8 +906,8 @@ impl MarkdownConverter {
         // Process GitHub embeds (fetch code and render)
         let with_github = process_github_embeds(&escaped, self);
 
-        // Process X embeds (fetch oEmbed HTML)
-        let (with_x, has_x_embed) = process_x_embeds(&with_github);
+        // Process X embeds (output placeholder divs with tweet IDs)
+        let (with_x, _has_x_embed) = process_x_embeds(&with_github);
 
         // Process link cards (OGP cards) for standalone URLs
         let with_link_cards = process_link_cards(&with_x);
@@ -941,11 +926,6 @@ impl MarkdownConverter {
 
         // 外部リンクに target="_blank" を追加
         html = self.add_target_blank_to_external_links(&html);
-
-        // Add X widgets.js script if there are X embeds
-        if has_x_embed {
-            html.push_str(X_WIDGETS_SCRIPT);
-        }
 
         html
     }
@@ -1433,6 +1413,27 @@ mod tests {
         assert!(!is_x_url("https://x.com/user"));
         assert!(!is_x_url("https://twitter.com/user/status/1234567890"));
         assert!(!is_x_url("https://example.com"));
+    }
+
+    #[test]
+    fn test_extract_x_tweet_id() {
+        assert_eq!(
+            extract_x_tweet_id("https://x.com/user/status/1234567890"),
+            Some("1234567890")
+        );
+        assert_eq!(
+            extract_x_tweet_id("https://x.com/user/status/1234567890?s=20"),
+            Some("1234567890")
+        );
+        assert_eq!(extract_x_tweet_id("https://x.com/user"), None);
+    }
+
+    #[test]
+    fn test_x_embed_produces_placeholder() {
+        let markdown = "https://x.com/user/status/1234567890";
+        let (result, has_embed) = process_x_embeds(markdown);
+        assert!(result.contains("<div data-tweet-id=\"1234567890\"></div>"));
+        assert!(has_embed);
     }
 
     #[test]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "nprogress": "^0.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-tweet": "^3.3.0",
     "rss": "^1.2.2",
     "tocbot": "^4.36.4"
   },

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -982,37 +982,19 @@ a:hover {
   }
 }
 
-/* X (Twitter) Embed */
-/* Common styles for twitter-tweet blockquote (overrides .prose blockquote) */
-.prose blockquote.twitter-tweet {
-  border-left: none;
+/* X (Twitter) Embed - react-tweet */
+.tweet-container {
   margin: 1.5rem auto;
-  padding-left: 0;
   max-width: 550px;
 }
 
-/* Rendered iframe container (after widgets.js loads) */
-.twitter-tweet-rendered {
-  margin: 1.5rem auto !important;
-  max-width: 550px;
+/* Prevent .prose styles from interfering with react-tweet internals */
+.prose .tweet-container img {
+  margin: 0;
+  display: initial;
 }
 
-/* Fallback styles before widgets.js loads */
-blockquote.twitter-tweet:not(.twitter-tweet-rendered) {
-  border: 1px solid var(--github-embed-border);
-  border-radius: 12px;
-  padding: 12px 16px;
-  background: var(--github-embed-header-bg);
-  max-width: 550px;
-  margin: 1.5rem auto;
-}
-
-blockquote.twitter-tweet:not(.twitter-tweet-rendered) p {
-  margin: 0 0 0.5rem 0;
-  color: var(--text-color);
-}
-
-blockquote.twitter-tweet:not(.twitter-tweet-rendered) a {
-  color: var(--tag-a-color);
-  word-break: break-all;
+[data-theme='dark'] .tweet-container {
+  --tweet-bg-color: var(--card-bg);
+  --tweet-border: 1px solid var(--github-embed-border);
 }

--- a/apps/web/src/components/ArticleContent.tsx
+++ b/apps/web/src/components/ArticleContent.tsx
@@ -1,20 +1,42 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import type { ComponentProps } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+import { Tweet } from 'react-tweet';
 import { useNavigationProgress } from '@/components/NavigationProgressProvider';
 
-declare global {
-  interface Window {
-    twttr?: {
-      widgets: {
-        load: (element?: HTMLElement) => Promise<void>;
-      };
-    };
-  }
+function AvatarImg({ src, ...props }: ComponentProps<'img'>) {
+  const hiResSrc = typeof src === 'string' ? src.replace('_normal.', '_bigger.') : src;
+  // biome-ignore lint/a11y/useAltText: alt is passed via ...props
+  return <img src={hiResSrc} {...props} />;
 }
 
 interface ArticleContentProps {
   html: string;
+}
+
+type ContentPart = { type: 'html'; content: string } | { type: 'tweet'; id: string };
+
+const TWEET_PLACEHOLDER_REGEX = /<div data-tweet-id="(\d+)"><\/div>/g;
+
+function parseHtmlWithTweets(html: string): ContentPart[] {
+  const parts: ContentPart[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  TWEET_PLACEHOLDER_REGEX.lastIndex = 0;
+  while ((match = TWEET_PLACEHOLDER_REGEX.exec(html)) !== null) {
+    if (match.index > lastIndex) {
+      parts.push({ type: 'html', content: html.slice(lastIndex, match.index) });
+    }
+    parts.push({ type: 'tweet', id: match[1] });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < html.length) {
+    parts.push({ type: 'html', content: html.slice(lastIndex) });
+  }
+
+  return parts;
 }
 
 const COPY_ICON = `<svg viewBox="0 0 16 16" fill="currentColor"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"/><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"/></svg>`;
@@ -23,9 +45,10 @@ export function ArticleContent({ html }: ArticleContentProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const { doneProgress } = useNavigationProgress();
 
+  const parts = useMemo(() => parseHtmlWithTweets(html), [html]);
+
   // Complete navigation progress after content is painted
   useEffect(() => {
-    // Wait for browser to paint the content
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         doneProgress();
@@ -40,19 +63,15 @@ export function ArticleContent({ html }: ArticleContentProps) {
 
     const preElements = container.querySelectorAll('pre');
     preElements.forEach((pre) => {
-      // Skip if already has a copy button
       if (pre.querySelector('.copy-btn')) {
         return;
       }
 
-      // Make pre position relative for absolute positioning of button
       pre.style.position = 'relative';
 
-      // Get code content
       const codeElement = pre.querySelector('code');
       const code = codeElement?.textContent || pre.textContent || '';
 
-      // Create copy button
       const button = document.createElement('button');
       button.className = 'copy-btn';
       button.setAttribute('data-code', code);
@@ -79,13 +98,11 @@ export function ArticleContent({ html }: ArticleContentProps) {
 
       navigator.clipboard.writeText(code).then(
         () => {
-          // Create floating "Copied!" text
           const floatingText = document.createElement('span');
           floatingText.className = 'copied-float';
           floatingText.textContent = 'Copied!';
           button.appendChild(floatingText);
 
-          // Remove after animation
           setTimeout(() => {
             floatingText.remove();
           }, 800);
@@ -136,52 +153,17 @@ export function ArticleContent({ html }: ArticleContentProps) {
     };
   }, [html]);
 
-  // Load X (Twitter) widgets.js and initialize embeds
-  // biome-ignore lint/correctness/useExhaustiveDependencies: Re-run when html changes to detect new X embeds
-  useEffect(() => {
-    const container = contentRef.current;
-    if (!container) return;
-
-    // Check if there are any X embeds
-    const xEmbeds = container.querySelectorAll('.twitter-tweet');
-    if (xEmbeds.length === 0) return;
-
-    // If widgets.js is already loaded, just reinitialize
-    if (window.twttr?.widgets) {
-      void window.twttr.widgets.load(container);
-      return;
-    }
-
-    // Check if script is already being loaded
-    const existingScript = document.querySelector(
-      'script[src="https://platform.twitter.com/widgets.js"]',
-    );
-    if (existingScript) {
-      // Wait for it to load
-      existingScript.addEventListener('load', () => {
-        void window.twttr?.widgets.load(container);
-      });
-      return;
-    }
-
-    // Load widgets.js dynamically
-    const script = document.createElement('script');
-    script.src = 'https://platform.twitter.com/widgets.js';
-    script.async = true;
-    script.onload = () => {
-      void window.twttr?.widgets.load(container);
-    };
-    script.onerror = () => {
-      console.error('Failed to load Twitter widgets.js');
-    };
-    document.body.appendChild(script);
-  }, [html]);
-
   return (
-    <div
-      ref={contentRef}
-      className="prose prose-lg max-w-none"
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
+    <div ref={contentRef} className="prose prose-lg max-w-none">
+      {parts.map((part, i) =>
+        part.type === 'html' ? (
+          <div key={i} dangerouslySetInnerHTML={{ __html: part.content }} />
+        ) : (
+          <div key={i} className="tweet-container">
+            <Tweet id={part.id} components={{ AvatarImg }} />
+          </div>
+        ),
+      )}
+    </div>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "nprogress": "^0.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-tweet": "^3.3.0",
         "rss": "^1.2.2",
         "tocbot": "^4.36.4",
       },
@@ -797,6 +798,8 @@
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -832,6 +835,8 @@
     "cspell-trie-lib": ["cspell-trie-lib@9.7.0", "", { "peerDependencies": { "@cspell/cspell-types": "9.7.0" } }, "sha512-a2YqmcraL3g6I/4gY7SYWEZfP73oLluUtxO7wxompk/kOG2K1FUXyQfZXaaR7HxVv10axT1+NrjhOmXpfbI6LA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -1035,6 +1040,8 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-tweet": ["react-tweet@3.3.0", "", { "dependencies": { "@swc/helpers": "^0.5.3", "clsx": "^2.0.0", "swr": "^2.2.4" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-gSIG2169ZK7UH6rBzuU+j1xnQbH3IlOTLEkuGrRiJJTMgETik+h+26yHyyVKrLkzwrOaYPk4K3OtEKycqKgNLw=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
@@ -1079,6 +1086,8 @@
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
+    "swr": ["swr@2.4.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA=="],
+
     "table": ["table@6.9.0", "", { "dependencies": { "ajv": "^8.0.1", "lodash.truncate": "^4.4.2", "slice-ansi": "^4.0.0", "string-width": "^4.2.3", "strip-ansi": "^6.0.1" } }, "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A=="],
 
     "tailwindcss": ["tailwindcss@4.2.2", "", {}, "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q=="],
@@ -1110,6 +1119,8 @@
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 


### PR DESCRIPTION
## Summary

- Replace Twitter's `widgets.js`-based oEmbed rendering with `react-tweet` for X embeds
- Eliminate CLS (layout shift) and CSS timing issues caused by blockquote-to-iframe replacement
- Use higher-resolution avatar images (`_bigger` instead of `_normal`) for Retina displays

## Changes

### Backend (`apps/blog-api/markdown/src/lib.rs`)
- Replace `fetch_x_oembed()` (oEmbed API call) with `extract_x_tweet_id()` (pure ID extraction)
- `process_x_embeds()` now outputs `<div data-tweet-id="..."></div>` placeholders instead of oEmbed HTML
- Remove `X_WIDGETS_SCRIPT` constant and widgets.js injection logic
- Add tests for `extract_x_tweet_id` and placeholder output

### Frontend (`apps/web/src/components/ArticleContent.tsx`)
- Parse HTML string for tweet placeholders and render `<Tweet>` components from `react-tweet`
- Custom `AvatarImg` component to serve higher-resolution profile images
- Remove `window.twttr` type declaration and `widgets.js` dynamic loading logic

### Styles (`apps/web/src/app/globals.css`)
- Replace old Twitter embed CSS (blockquote fallback, `.twitter-tweet-rendered`) with `.tweet-container` styles
- Add `.prose .tweet-container img` reset to prevent `.prose img` margin from misaligning avatars

