### PR TITLE
fix(iac): migrate to moduleResolution node16 for TypeScript 6

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "prettier": "^3.8.1",
         "tsx": "^4.21.0",
         "turbo": "^2.8.20",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.2",
         "vite-plus": "^0.1.14",
       },
     },
@@ -1118,7 +1118,7 @@
 
     "turbo": ["turbo@2.8.20", "", { "optionalDependencies": { "@turbo/darwin-64": "2.8.20", "@turbo/darwin-arm64": "2.8.20", "@turbo/linux-64": "2.8.20", "@turbo/linux-arm64": "2.8.20", "@turbo/windows-64": "2.8.20", "@turbo/windows-arm64": "2.8.20" }, "bin": { "turbo": "bin/turbo" } }, "sha512-Rb4qk5YT8RUwwdXtkLpkVhNEe/lor6+WV7S5tTlLpxSz6MjV5Qi8jGNn4gS6NAvrYGA/rNrE6YUQM85sCZUDbQ=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/iac/aws/bin/cdk.ts
+++ b/iac/aws/bin/cdk.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
-import { MainStack } from '../lib/api/main-stack';
-import { getConfig } from '../lib/config';
-import { DeployRoleStack } from '../lib/deployment/deploy-role-stack';
-import { OidcProviderStack } from '../lib/deployment/oidc-provider-stack';
-import { GlobalDnsStack } from '../lib/dns/global-dns-stack';
-import { TokyoCertificateStack } from '../lib/dns/tokyo-certificate-stack';
+import { MainStack } from '../lib/api/main-stack.js';
+import { getConfig } from '../lib/config.js';
+import { DeployRoleStack } from '../lib/deployment/deploy-role-stack.js';
+import { OidcProviderStack } from '../lib/deployment/oidc-provider-stack.js';
+import { GlobalDnsStack } from '../lib/dns/global-dns-stack.js';
+import { TokyoCertificateStack } from '../lib/dns/tokyo-certificate-stack.js';
 
 const REGIONS = {
   TOKYO: 'ap-northeast-1',

--- a/iac/aws/lib/api/main-stack.ts
+++ b/iac/aws/lib/api/main-stack.ts
@@ -4,7 +4,7 @@ import * as dsql from 'aws-cdk-lib/aws-dsql';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import type { Construct } from 'constructs';
-import { BlogAPIConstruct } from './blog-api-construct';
+import { BlogAPIConstruct } from './blog-api-construct.js';
 
 export class MainStack extends cdk.Stack {
   constructor(

--- a/iac/aws/test/api.test.ts
+++ b/iac/aws/test/api.test.ts
@@ -2,7 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import type * as lambda from 'aws-cdk-lib/aws-lambda';
 import type { Construct } from 'constructs';
-import { MainStack } from '../lib/api/main-stack';
+import { MainStack } from '../lib/api/main-stack.js';
 
 // DockerImageFunctionをモックしてDockerビルドをスキップ
 vi.mock('aws-cdk-lib/aws-lambda', async (importOriginal) => {

--- a/iac/aws/test/deployment.test.ts
+++ b/iac/aws/test/deployment.test.ts
@@ -1,7 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { DeployRoleStack } from '../lib/deployment/deploy-role-stack';
-import { OidcProviderStack } from '../lib/deployment/oidc-provider-stack';
+import { DeployRoleStack } from '../lib/deployment/deploy-role-stack.js';
+import { OidcProviderStack } from '../lib/deployment/oidc-provider-stack.js';
 
 describe('OidcProviderStack', () => {
   it('snapshot', () => {

--- a/iac/aws/test/dns.test.ts
+++ b/iac/aws/test/dns.test.ts
@@ -1,7 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { GlobalDnsStack } from '../lib/dns/global-dns-stack';
-import { TokyoCertificateStack } from '../lib/dns/tokyo-certificate-stack';
+import { GlobalDnsStack } from '../lib/dns/global-dns-stack.js';
+import { TokyoCertificateStack } from '../lib/dns/tokyo-certificate-stack.js';
 
 describe('GlobalDnsStack', () => {
   it('snapshot', () => {

--- a/iac/aws/tsconfig.json
+++ b/iac/aws/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "types": ["vitest/globals"],
     "target": "es2022",
-    "module": "es2022",
+    "module": "node16",
     "declaration": true,
     "strict": true,
     "noImplicitAny": true,
@@ -18,7 +18,7 @@
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
     "skipLibCheck": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prettier": "^3.8.1",
     "tsx": "^4.21.0",
     "turbo": "^2.8.20",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.2",
     "vite-plus": "^0.1.14"
   },
   "packageManager": "bun@1.3.6"


### PR DESCRIPTION
## Summary
- Change `module`/`moduleResolution` to `node16` in `iac/aws/tsconfig.json`
- Add explicit `.js` extensions to all relative imports (required since `node10` is deprecated in TypeScript 6)

## Test plan
- [x] `bun run type-check` (iac/aws) passes
- [x] Lint and spell check all pass