### PR TITLE
fix(web): モバイル時の記事本文に左右パディングを付与

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -122,8 +122,8 @@
 - **フッター** (`Footer.tsx`)
   - 固定配置 (`absolute bottom-0`)、フォントサイズ `caption`。
 - **記事本文ラッパ** (`.article-content-wrapper`)
-  - 背景 `--color-surface`、角丸 `15px`、ボーダー 1px `--color-border-subtle`、パディング `3.2em 16px`（デスクトップ）／ `0`（sm 以下）。
-  - **To-be**: 単位を `rem` と 4px 基点スケールに寄せる（`padding: 3rem 1rem` 等）。
+  - 背景 `--color-surface`、角丸 `15px`、ボーダー 1px `--color-border-subtle`、パディング `3rem 1rem`（デスクトップ）／ `1.5rem 1rem`（sm 以下）。
+  - sm 以下で外側 `BaseLayout` の `px-4` (16px) と合わせて左右合計 32px の余白を確保し、本文・コード・画像が画面端に張り付かないようにする。
 - **右サイドバー / TOC** (`.right-sidebar`, `.toc`)
   - 幅 `296px`（`--layout-sidebar-w: 296px`）。
   - `position: sticky; top: 112px;` はヘッダー + タイプナビ分の高さ。ヘッダー高さが変わったら一緒に変える。**マジックナンバーを避けるため `calc(var(--layout-header-h) + var(--layout-nav-h) + 16px)` で算出するのが理想**。
@@ -222,7 +222,7 @@
   - `margin-bottom: 13px`（リスト項目）→ `--space-3` (12px) に寄せる。
   - `margin-top: 10px`（ul / ol）→ `--space-2` (8px) or `--space-3` (12px)。
   - `pb-[58px]`（コンテナ下）→ フッター高さトークン `--layout-footer-h: 58px`。
-  - `padding: 3.2em 16px`（`.article-content-wrapper`）→ `3rem 1rem`（`--space-6 × --space-4`）で揃える。
+  - `padding: 3.2em 16px`（`.article-content-wrapper`）→ `3rem 1rem`（`--space-6 × --space-4`）で揃え済み。sm 以下は `1.5rem 1rem`（`--space-5 × --space-4`）。
 
 ### 5.2 コンテナ幅トークン
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -522,7 +522,7 @@ a:hover {
 
 /* Article Content Wrapper */
 .article-content-wrapper {
-  padding: 3.2em 16px;
+  padding: 3rem 1rem;
   background: var(--article-area-color);
   border-radius: 15px;
   border: 1px solid var(--article-area-border-color);
@@ -530,7 +530,7 @@ a:hover {
 
 @media (max-width: 576px) {
   .article-content-wrapper {
-    padding: 0;
+    padding: 1.5rem 1rem;
   }
 }
 


### PR DESCRIPTION
## 概要

- 記事詳細ページ（`/[userName]/articles/[slug]`）のモバイル幅（≤576px）で、`.article-content-wrapper` の padding が `0` になっており本文・コード・画像が画面端に張り付いていた
- モバイル時の内側余白として `1.5rem 1rem` を新規付与し、`BaseLayout` の `px-4` と合わせて左右合計 32px を確保
- デスクトップ既存値 `3.2em 16px` を `DESIGN.md` §5.1 のトークンに合わせて `3rem 1rem` に正規化

## 変更ファイル

- `apps/web/src/app/globals.css`
  - `.article-content-wrapper` デスクトップ: `3.2em 16px` → `3rem 1rem`
  - `@media (max-width: 576px)`: `padding: 0` → `padding: 1.5rem 1rem`
- `apps/web/DESIGN.md`
  - §4.1「記事本文ラッパ」と §5.1「現状のマジックナンバーとの対応」の記述を新しい値に追従更新

## Test plan

- [ ] `bun run dev` で web を起動し、任意の記事ページを開く
- [ ] DevTools のレスポンシブモードで 360 / 414 / 576px に切り替え、本文左右の余白が増えていること（カード状の見た目になること）を確認
- [ ] コードブロック・画像・引用が画面端に張り付かないこと
- [ ] 横スクロールが発生していないこと
- [ ] デスクトップ幅（≥577px）で見た目が崩れていないこと
- [ ] `bun run lint` 通過
