### PR TITLE
chore: 各 workspace に clean スクリプトを追加

### DIFF
--- a/apps/blog-api/package.json
+++ b/apps/blog-api/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "cargo make run",
     "lint": "cargo clippy --all --all-targets -- -D warnings",
-    "test": "cargo test --all"
+    "test": "cargo test --all",
+    "clean": "cargo clean"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p ${WEB_PORT:-3000}",
     "build": "next build",
     "start": "next start",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "clean": "rm -rf .next .turbo"
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build-docs": "uv run sphinx-build source build",
     "dev": "uv run sphinx-autobuild source build --port ${DOCS_PORT:-8000}",
-    "doc-gen": "tbls doc --force"
+    "doc-gen": "tbls doc --force",
+    "clean": "rm -rf build .turbo"
   },
   "devDependencies": {}
 }

--- a/iac/aws/package.json
+++ b/iac/aws/package.json
@@ -7,7 +7,8 @@
     "deploy": "dotenv -- cdk deploy",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:update": "vitest run --update"
+    "test:update": "vitest run --update",
+    "clean": "rm -rf cdk.out .turbo"
   },
   "dependencies": {
     "aws-cdk-lib": "^2.251.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "turbo lint",
     "fix": "vp fmt && prettier --write '**/*.{json,yaml}'",
     "deploy": "bun --filter @shuntaka-dev/aws deploy",
+    "clean": "turbo clean",
     "postinstall": "lefthook install"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -70,6 +70,9 @@
     "test": {
       "inputs": ["src/**"],
       "cache": true
+    },
+    "clean": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## 経緯

ローカル `bun run dev` (Next.js 16 Turbopack + Tailwind CSS 4) で `apps/web` の CSS が当たっていないように見える事象が発生。本番 (https://shuntaka.dev) では正しく適用されており、`curl` で配信 CSS を比較した結果、コミット fec9212 で追加したセマンティックトークン (`--color-bg`, `--color-surface`, `--space-*`, `--radius-md`, `--layout-max`, `--motion-base` など) が**dev 側のチャンクからのみ脱落**していた。Tailwind v4 / コードの問題ではなく Turbopack の HMR キャッシュ持ち越しが原因で、`rm -rf apps/web/.next && bun run dev` で復旧することを確認。

毎回手で `rm -rf apps/web/.next` を打つのは煩雑なため、Turbo モノレポ標準の `clean` タスクとして整備する。

## 変更概要

- root: `bun run clean` → `turbo clean` で全 workspace 並列実行
- `turbo.json` に `clean` タスクを追加 (`cache: false`)
- 各 workspace に `clean` スクリプトを追加

| workspace        | clean コマンド                |
| ---------------- | ----------------------------- |
| `apps/web`       | `rm -rf .next .turbo`         |
| `apps/blog-api`  | `cargo clean`                 |
| `iac/aws`        | `rm -rf cdk.out .turbo`       |
| `docs`           | `rm -rf build .turbo`         |

`tools/dsql-cli` は中間生成物がないため対象外（`turbo clean` 実行時は単に skip される）。

## 使い方

```bash
# 全 workspace 一括
bun run clean

# Web の Turbopack キャッシュだけ消す
bun --filter @shuntaka-dev/web clean
```

