### PR TITLE
chore: デザインシステムを apps/web 配下に移管し Storybook 導入

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,6 +6,7 @@ on:
       - preview
     paths:
       - 'docs/**'
+      - 'apps/web/**'
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/docs.yaml'
@@ -23,7 +24,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,13 +38,24 @@ jobs:
         working-directory: docs
         run: uv python install
 
-      - name: Install dependencies
+      - name: Install Sphinx dependencies
         working-directory: docs
         run: uv sync
 
       - name: Build Sphinx documentation
         working-directory: docs
         run: uv run sphinx-build source build
+
+      - name: Setup node
+        uses: ./.github/actions/setup-node
+
+      - name: Build Storybook into docs/build/storybook/
+        env:
+          STORYBOOK_BASE_PATH: /shuntaka-dev/storybook/
+        run: |
+          bun --filter @shuntaka-dev/web build-storybook
+          mkdir -p docs/build/storybook
+          cp -r apps/web/storybook-static/. docs/build/storybook/
 
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ tsconfig.tsbuildinfo
 
 .legacy
 target
+
+# storybook
+storybook-static

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ docs/             # Sphinx ドキュメント (Python/uv)
 
 環境構築、デプロイ手順、ツールの詳細な使い方は `docs/source/01_development.md` を参照。
 
+apps/web の作業時は `apps/web/CLAUDE.md` を参照（workspace 専用ガイド + ブランド仕様 `apps/web/DESIGN.md`）。
+
 ## Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # shuntaka-dev
 
-[Site](https://shuntaka.dev/) | [Docs](https://shuntaka9576.github.io/shuntaka-dev/)
+[![shuntaka.dev](https://img.shields.io/badge/-shuntaka.dev-e4007f?style=flat-square)](https://shuntaka.dev/)
+[![dev](https://img.shields.io/badge/-dev-2d333b?style=flat-square)](https://shuntaka.tech/)
+[![Docs](https://img.shields.io/badge/-Docs-3b82f6?style=flat-square)](https://shuntaka9576.github.io/shuntaka-dev/)
+[![Storybook](https://img.shields.io/badge/-Storybook-FF4785?style=flat-square&logo=storybook&logoColor=white)](https://shuntaka9576.github.io/shuntaka-dev/storybook/)

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -1,0 +1,20 @@
+import type { StorybookConfig } from '@storybook/nextjs-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(ts|tsx|mdx)'],
+  addons: ['@storybook/addon-themes'],
+  framework: {
+    name: '@storybook/nextjs-vite',
+    options: {},
+  },
+  staticDirs: ['../public'],
+  viteFinal: async (viteConfig) => {
+    const base = process.env.STORYBOOK_BASE_PATH;
+    if (base) {
+      viteConfig.base = base;
+    }
+    return viteConfig;
+  },
+};
+
+export default config;

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -1,0 +1,28 @@
+import { withThemeByDataAttribute } from '@storybook/addon-themes';
+import type { Preview } from '@storybook/nextjs-vite';
+import { NavigationProgressProvider } from '../src/components/NavigationProgressProvider';
+import { ThemeProvider } from '../src/components/ThemeProvider';
+import '../src/app/globals.css';
+
+const preview: Preview = {
+  parameters: {
+    layout: 'padded',
+    backgrounds: { disable: true },
+  },
+  decorators: [
+    withThemeByDataAttribute({
+      themes: { light: 'light', dark: 'dark' },
+      defaultTheme: 'light',
+      attributeName: 'data-theme',
+    }),
+    (Story) => (
+      <ThemeProvider>
+        <NavigationProgressProvider>
+          <Story />
+        </NavigationProgressProvider>
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export default preview;

--- a/apps/web/.storybook/storybook.d.ts
+++ b/apps/web/.storybook/storybook.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -29,8 +29,8 @@ shuntaka.dev の本番フロントエンド。Next.js 16 + React 19 + Tailwind C
 
 - 単一アクセント色: `#e4007f`（`--color-accent`）。他のアクセントを増やさない
 - グラデーション禁止、静止カードへの drop-shadow 禁止
-- UI に絵文字を入れない（mascot ochaIcon 🍵 のみが視覚的アクセント）
-- 本文 line-height は `1.9`、見出し `1.4`、リスト `1.7`
+- UI に絵文字を入れない（mascot `ochaIcon` フルカラー SVG のみが視覚的アクセント）
+- 本文 line-height は `--lh-body`、見出し `--lh-heading`、リスト `--lh-list`（実値は `globals.css`）
 - 日付は常に `YYYY/MM/DD`
 - nav / tab ラベルは小文字（`tech`、`note`、`who?`）
 - Tailwind preset 色クラス（`bg-blue-500` 等）禁止 → CSS 変数を使う

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,44 @@
+# apps/web
+
+shuntaka.dev の本番フロントエンド。Next.js 16 + React 19 + Tailwind CSS 4 + TypeScript。
+
+## デザイン仕様 / カタログ
+
+- **ブランドルール / Hard rules**: `./DESIGN.md`（voice、color、layout、iconography 全部）
+- **視覚カタログ (Storybook)**: `bun run storybook` (http://localhost:6006)。本番マージで GitHub Pages へ自動デプロイ
+- **Token 実装**: `src/app/globals.css`（`:root` / `[data-theme='dark']`）
+
+## 主要ディレクトリ
+
+- `src/app/` — App Router（page.tsx、layout.tsx、globals.css）
+- `src/components/` — Client/Server components（BaseLayout、ArticleCard、ToggleSwitch、TableOfContents 等）
+- `src/lib/` — API client (`api.ts`)、定数 (`constants.ts`)
+- `.storybook/` — Storybook 設定（main.ts、preview.tsx）と `*.stories.tsx`
+
+## 開発コマンド
+
+| 用途                 | コマンド                  |
+| -------------------- | ------------------------- |
+| 開発サーバー         | `bun run dev`             |
+| 本番ビルド           | `bun run build`           |
+| 型チェック           | `bun run type-check`      |
+| Storybook 開発       | `bun run storybook`       |
+| Storybook 静的ビルド | `bun run build-storybook` |
+
+## ハードルール (要約 — 詳細は `DESIGN.md`)
+
+- 単一アクセント色: `#e4007f`（`--color-accent`）。他のアクセントを増やさない
+- グラデーション禁止、静止カードへの drop-shadow 禁止
+- UI に絵文字を入れない（mascot ochaIcon 🍵 のみが視覚的アクセント）
+- 本文 line-height は `1.9`、見出し `1.4`、リスト `1.7`
+- 日付は常に `YYYY/MM/DD`
+- nav / tab ラベルは小文字（`tech`、`note`、`who?`）
+- Tailwind preset 色クラス（`bg-blue-500` 等）禁止 → CSS 変数を使う
+- インライン `style={{ color: '#…' }}` 禁止
+
+## 新しいコンポーネントを追加するとき
+
+1. `src/components/Foo.tsx` に実装（既存コンポーネントの命名・props スタイルに揃える）
+2. `src/components/Foo.stories.tsx` に Story を追加（最低 1 つ、できれば variant 別）
+3. `globals.css` の既存トークン（`--color-*`、`--radius-*`、`--lh-*`、`--space-*` 等）から外れる値を入れない
+4. `bun run type-check` と `bun run lint` を通す

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -1,6 +1,6 @@
 # shuntaka.dev デザインシステム
 
-**shuntaka.dev**（髙橋俊一 / shuntaka による、読み物中心の静かな日本語テックブログ）のデザインシステム。ブランドは 1 つのマスコット **抹茶カップ (ochaIcon)** 🍵、1 色のアクセント **マゼンタピンク `#e4007f`**、そして GitHub-Dark 風のダークモードで構成される。
+**shuntaka.dev**（髙橋俊一 / shuntaka による、読み物中心の静かな日本語テックブログ）のデザインシステム。ブランドは 1 つのマスコット **抹茶カップ (ochaIcon)**、1 色のアクセント **マゼンタピンク (`--color-accent`)**、そして GitHub-Dark 風のダークモードで構成される。
 
 ## 仕様の出どころ
 
@@ -16,69 +16,58 @@ shuntaka.dev は、日本人ソフトウェアエンジニア（現在クラス�
 - 写真ではなく **コードブロック・リンクカード・埋め込み** を視覚の中心に
 - マゼンタというただ 1 つの落ち着いたアクセント色（ブランドマークまたはフォーカス状態のみで使用）
 
-兄弟プロジェクト：`blog.hozi.dev`（レガシーフロントエンド）。抹茶カップのマスコットは両方に登場する。
-
----
-
-## コンテンツの基本
-
-ブログは **バイリンガルだが日本語ファースト**。UI ラベルやマイクロコピーは小文字英単語（`tech`, `note`, `who?`, `Career`, `Like`）と日本語本文を混ぜる。voice はエンジニア向けに事実ベース、装飾を抑え、技術スタックを淡々と並べる文体。
-
-- **Voice / 人称.** 三人称・非人称（"I" や "you" は使わない）。プロフィールも `Career` と `Like` を並べるだけ。マーケティングコピーは書かない。
-- **大文字小文字.** タブラベルは小文字（`tech`, `note`, `who?`）。サイトタイトルも小文字（`shuntaka.dev`）。記事内の見出しは日本語の文章ケース、Title Case にしない。
-- **句読点.** `who?` だけがナビ唯一の句読点付きラベルで、抑制的な UI に少しの遊び心を加える。
-- **日付.** 常に `YYYY/MM/DD`（例: `2021/03/12`）の日本語ロケール。記事タイムスタンプは `MM/DD HH:mm YYYY` を追加する。
-- **タグ.** ハッシュ前置き（`#NestJS`, `#Rust`）。タグチップ形状：角丸長方形、1px 黒ボーダー、塗りなし。
-- **絵文字.** コミット / PR タイトルでは **控えめに** 使う（🍵, 🍞, 🍙, 📝）が、プロダクト UI では **絶対に使わない**。マスコットがすでにあたたかみを担っているので UI に絵文字を入れない。
-- **数字 / 統計.** 出さない。閲覧数・フォロワー数・「トレンド」バッジなどはブログに表示しない。data slop を避ける。
-- **トーン例**
-  - `No articles found.` — 空状態
-  - `ライトモードに切り替え` / `ダークモードに切り替え` — アクセシブルラベル
-  - `Posted on blog.hozi.dev/ 1 days ago` — Timeline レコード
-  - `Career` `201204 TDU EC` `201604 株式会社QUICK` — 略式の日付前置き bio エントリ
-- **Don't.** "Welcome!" 見出しなし、"Subscribe to my newsletter" CTA なし、絵文字ボタンなし、本文の感嘆符なし。
-
 ---
 
 ## ビジュアル基盤
 
 ### Color
 
-- **Light:** オフホワイト `#f7fafc` をページ背景に、`#ffffff` をサーフェスに、ヘッダーはほぼ白の `#fffefc`。本文テキストは `#525457` の暖色寄りダークグレー（純黒では **ない**）。
-- **Dark:** GitHub-Dark のネイビー。`#22272e` ページ、`#2d333b` 持ち上げ、本文 `#c9d5e1`。
-- **Accent:** **`#e4007f`** マゼンタピンク。用途：ダークモードトグル ON のトラック、NProgress バー、focus-visible アウトライン、danger callout のボーダー。本文テキストには **絶対** 使わない、カードの fill にも **絶対** 使わない。
-- **Borders:** 一般用途は `#c4c4c4`、記事リスト下線は `rgba(162,177,202,0.3)`（ほぼ見えない、タイポグラフィのベースライン的な存在）。
+- **Light:** ページ背景は `--color-bg`（オフホワイト）、サーフェスは `--color-surface`、ヘッダーなど持ち上げ面は `--color-surface-raised`。本文テキストは `--color-text`（暖色寄りダークグレー、純黒では **ない**）。
+- **Dark:** GitHub-Dark 系のネイビー。同じ `--color-*` トークンを `[data-theme='dark']` で上書きする。実値は `globals.css` を参照。
+- **Accent:** **マゼンタピンク (`--color-accent`)**。用途：ダークモードトグル ON のトラック、NProgress バー、focus-visible アウトライン、danger callout のボーダー。本文テキストには **絶対** 使わない、カードの fill にも **絶対** 使わない。
+- **Borders:** 一般用途は `--color-border`、記事リスト下線は `--color-border-subtle`（ほぼ見えない、タイポグラフィのベースライン的な存在）。
 
 ### Typography
 
 - **英語:** Roboto (400/700) — `next/font/google` で読み込み、`--font-roboto` で公開。
 - **日本語:** Noto Sans JP — `--font-noto-sans-jp` で公開。（Figma 下書きは Hiragino Sans を使うが、本番は macOS 限定を避けて Noto Sans JP）
 - **Mono:** システムスタック（`ui-monospace, SFMono-Regular, …`）。
-- **スケール（rem ベース、1rem = 16px）.** `display 32 / h1 27 / h2 24 / h3 20 / h4 18 / body-lg 16 / body 15 / caption 13 / code 14`。
-- **行高.** 本文 `1.9`（読書体験のため大きめ）。見出し `1.4`。リスト `1.7`。
+- **スケール.** 9 段階の `--fs-display` / `--fs-h1` / `--fs-h2` / `--fs-h3` / `--fs-h4` / `--fs-body-lg` / `--fs-body` / `--fs-caption` / `--fs-code`。実値は `globals.css` と Storybook `Design System/Tokens` を参照。
+- **行高.** 本文 `--lh-body`（読書体験のため大きめ）。見出し `--lh-heading`。リスト `--lh-list`。
 - **`em` と `px` を混ぜない.** タイポは `rem`、レイアウトは `px` またはレイアウトトークン。
 - **強調は `<strong>` のみ.** 着色強調・全大文字・letter-spacing いじりはしない。
 
+### ラベル / 表記
+
+- **大文字小文字.** タブラベルとサイトタイトルは小文字（`tech`, `note`, `who?`, `shuntaka.dev`）。記事内見出しを Title Case にしない。
+- **日付.** 常に `YYYY/MM/DD`（例: `2021/03/12`）。記事タイムスタンプは `MM/DD HH:mm YYYY`。
+- **絵文字.** プロダクト UI に絵文字を入れない。あたたかみはマスコット (`ochaIcon`、フルカラー SVG) が担う。
+
+### タグ
+
+- ハッシュ前置き（`#NestJS`, `#Rust`）。
+- 形状: 角丸長方形、1px ボーダー、塗りなし。
+
 ### 背景
 
-- **画像なし.** ヒーロー写真・全画面グラデーション・パターン・グレインはなし。サーフェスはフラット `#fff`（light）またはフラットネイビー（dark）。
+- **画像なし.** ヒーロー写真・全画面グラデーション・パターン・グレインはなし。サーフェスはフラットな `--color-surface`（light / dark どちらも同様にフラット）。
 - **グラデーション禁止.** "rainbow gradients, neon shadows" は明示的に拒絶される。
-- **記事ラッパー** はフラット `#fff` パネル、コーナー半径 `15px`、subtle な 1px ボーダー。
+- **記事ラッパー** はフラットなサーフェスパネル、コーナー半径 `--radius-lg`、subtle な 1px ボーダー。
 
 ### ボーダー / 角
 
-- **半径は 4 段階.** `4px`（ボタン、タグ）、`10px`（カード、サムネイル）、`15px`（記事ラッパー）、`9999px`（トグル、円形アイコン）。
-- **ボーダーは 1px solid のみ.** 色は通常 `--color-border` または `subtle` 兄弟。double / dashed なし。
+- **半径は 4 段階.** `--radius-sm`（ボタン、タグ）、`--radius-md`（カード、サムネイル）、`--radius-lg`（記事ラッパー）、`--radius-full`（トグル、円形アイコン）。
+- **ボーダーは 1px solid のみ.** 色は通常 `--color-border` または `--color-border-subtle`。double / dashed なし。
 
 ### 影 / elevation
 
-- 本番 CSS で実際に使う影は **1 つだけ**：`link-card:hover` の `0 2px 8px rgba(0,0,0,0.10)`。
+- 本番 CSS で実際に使う影は **1 つだけ**：`link-card:hover` の `--shadow-2`。
 - 4 段階の elevation トークン（`--shadow-0`…`--shadow-3`）は将来のモーダル / ポップオーバー用に予約済みだが、現状未使用。
 - **静止状態のカードに drop-shadow を追加しない.** システムは flat-by-default で読まれる。
 
 ### Motion
 
-- **トークン:** `--motion-fast 150ms / --motion-base 250ms / --motion-slow 400ms`。easing はブラウザデフォルト（linear / ease）。
+- **トークン:** `--motion-fast` / `--motion-base` / `--motion-slow`（実値は `globals.css` 参照）。easing はブラウザデフォルト（linear / ease）。
 - **用途:** copy ボタンの opacity（`0.4 → 1.0`）、link-card の border-color と shadow、NProgress バー。
 - **bounce / spring / ページロード時のエントランスアニメーションなし.** ブログは「即座に表示される」感じを目指す。
 
@@ -91,19 +80,19 @@ shuntaka.dev は、日本人ソフトウェアエンジニア（現在クラス�
 
 ### レイアウトルール
 
-- 外側は `--layout-max: 1200px` の単一カラム中央寄せ。記事一覧は `--layout-list-max: 600px` で内側を絞る。
-- 記事ページ = 左コンテンツ + `296px` 固定の右 TOC サイドバーを `flex justify-between` で並べる。`lg` 以下でサイドバーは折りたたまれる。
+- 外側は `--layout-max` の単一カラム中央寄せ。記事一覧は `--layout-list-max` で内側を絞る。
+- 記事ページ = 左コンテンツ + `--layout-sidebar-w` 固定の右 TOC サイドバーを `flex justify-between` で並べる。`lg` 以下でサイドバーは折りたたまれる。
 - TOC の sticky オフセットは `top: calc(var(--layout-header-h) + var(--layout-nav-h) + var(--space-5))` で計算する。マジックナンバー禁止。
-- フッターは `position: absolute; bottom: 0;` で body 下部に `58px` の余白を予約。ヘッダーは sticky **にしない**。
+- フッターは `position: absolute; bottom: 0;` で body 下部に `--layout-footer-h` 分の余白を予約。ヘッダーは sticky **にしない**。
 - **`display: grid` を使わない.** マルチカラムは Flex + `gap`。
 
 ### 透過 / blur
 
-- **使わない.** `backdrop-filter` なし、glassmorphism なし、半透明オーバーレイなし。TOC の `is-active` トラックで opacity ベースの色（`#57595b87`）を使うのが唯一の例外。
+- **使わない.** `backdrop-filter` なし、glassmorphism なし、半透明オーバーレイなし。TOC の `is-active` トラックで opacity を載せた muted 色を使うのが唯一の例外。
 
 ### イメージの雰囲気
 
-- 記事サムネは user 提供の OGP 画像をコンテンツとして扱う。コンテナ：`150×100`、`object-cover`、`10px` radius、`loading="lazy"`。フィルタ・ティント・オーバーレイなし。
+- 記事サムネは user 提供の OGP 画像をコンテンツとして扱う。コンテナ：`150×100`（コンテンツ寸法）、`object-cover`、`--radius-md`、`loading="lazy"`。フィルタ・ティント・オーバーレイなし。
 
 ### このシステムが拒絶するもの
 
@@ -120,13 +109,13 @@ shuntaka.dev は、日本人ソフトウェアエンジニア（現在クラス�
 
 **方針.** `public/assets/` に小規模な手作りの単色 SVG セットがある。アイコンフォントもアイコンライブラリも使わない（Lucide も Heroicons も使わない）。新しいアイコンが必要なときは既存のスタイルに合わせる：単一 fill or stroke、グラデーション禁止、多色グリフ禁止。
 
-### マスコット — `ochaIcon` 🍵
+### マスコット — `ochaIcon`
 
 笑顔の抹茶カップ。これがブランドマーク。favicon、Timeline レコードの bullet、マーケティングコンセプトのロゴ、ソーシャルリンクの「homepage」アイコンとして登場する。**常にフルカラー**（抹茶ボディ `#6e9050`、フォーム `#bde030`、頬 `#fff9f9`）。反転したり再着色したりしない。
 
 ### ソーシャルリンクのグリフ
 
-単色ブランドマーク（light: `#525457`、dark: `#c9d5e1`、コンテナの `color: inherit` で切替）。すべて `24×24` ボックスサイズ。
+単色ブランドマーク（コンテナの `color: inherit` で `--color-text` を継承し、light/dark を自動切替）。すべて `24×24` ボックスサイズ。
 
 | ファイル                     | サービス                                     |
 | ---------------------------- | -------------------------------------------- |
@@ -150,11 +139,6 @@ shuntaka.dev は、日本人ソフトウェアエンジニア（現在クラス�
 
 404 ページで使う、独自にイラスト化された 404 マーク（Figma マーケティングフレームでも一度使われている）。
 
-### 絵文字 / unicode
-
-- **プロダクト UI では使わない.** `who?` ページの句読点だけが唯一のタイポグラフィの遊び。
-- コミットメッセージ / リポジトリ README でだけ使う（🍵 🍞 🍙 ✨ 📝）。
-
 ### 代替
 
 なし — 本番アイコンセットは小さく、すべてそのまま使える。`public/assets/` に無いグリフが必要な場合は **Lucide**（stroke スタイル：1.5px、塗りなし）を優先し、PR description で代替したことを明記する。
@@ -171,6 +155,7 @@ shuntaka.dev は、日本人ソフトウェアエンジニア（現在クラス�
 
 ## 実装ポインタ
 
+- **責務分離.** 値の唯一の真実は `globals.css`（トークン定義）。視覚的に値を確認したいときは Storybook の `Design System/Tokens` を開く。この `DESIGN.md` は voice / 原則 / 禁止事項を担い、具体値は **トークン名で参照する**（hex / px / ms / rem を直接書かない）。マスコット `ochaIcon` の 3 色だけは「再着色しない」設計上の例外として hex のまま残す。
 - **トークン実装.** すべてのデザイントークン（color、spacing、radius、line-height、type scale、motion、shadow）は `src/app/globals.css` にある。Light の値は `:root` に、Dark の上書きは `[data-theme='dark']` と `prefers-color-scheme: dark` ブロックに置く。
 - **視覚カタログ.** `apps/web/.storybook/` に Storybook（Storybook 10 + `@storybook/nextjs-vite`）を置く。Story は本番コンポーネントとトークンのスウォッチをカバーする。
   - ローカル起動: `bun run storybook`（`http://localhost:6006`）

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -1,179 +1,179 @@
-# shuntaka.dev Design System
+# shuntaka.dev デザインシステム
 
-A design system for **shuntaka.dev** — a quiet, reading-first Japanese tech blog by **髙橋俊一 (a.k.a. shuntaka)**. The brand is built around a single visual mascot, the **matcha tea cup (ochaIcon)** 🍵, a single accent color (**magenta-pink `#e4007f`**), and a GitHub-Dark-flavored dark mode.
+**shuntaka.dev**（髙橋俊一 / shuntaka による、読み物中心の静かな日本語テックブログ）のデザインシステム。ブランドは 1 つのマスコット **抹茶カップ (ochaIcon)** 🍵、1 色のアクセント **マゼンタピンク `#e4007f`**、そして GitHub-Dark 風のダークモードで構成される。
 
-## Source materials
+## 仕様の出どころ
 
-- **Source of truth** — this file (rules + voice) plus `src/app/globals.css` (token implementation).
-- **Visual catalog** — `apps/web/.storybook/` (run `bun run storybook`); deployed to GitHub Pages on `main` merge.
-- **Figma** (`shuntaka.dev.fig`) — early concept frames showing logo studies, share-button OGPs, MacBook Pro list view, search/tag view, and the Timeline reading-history widget. The Figma is _concept fidelity_ — the codebase is the source of truth where they conflict.
+- **Source of truth** — このファイル（ルール + voice）と `src/app/globals.css`（トークン実装）。
+- **視覚カタログ** — `apps/web/.storybook/`（`bun run storybook` で起動）。`main` マージで GitHub Pages に自動デプロイ。
+- **Figma**（`shuntaka.dev.fig`）— ロゴ検討、シェアボタン OGP、MacBook Pro 一覧ビュー、検索 / タグビュー、Timeline 読書履歴ウィジェットなどの初期コンセプト。Figma は _コンセプト精度_ であり、衝突した場合はコードベースが正。
 
-## Brand context
+## ブランドコンテキスト
 
-shuntaka.dev is the personal tech blog of a Japanese software engineer (currently at Classmethod). It hosts **tech**, **note**, and **who?** sections; articles are written in Markdown and converted server-side (Rust + comrak + syntect). The reader experience prioritises:
+shuntaka.dev は、日本人ソフトウェアエンジニア（現在クラスメソッド所属）の個人テックブログ。**tech**、**note**、**who?** の 3 セクション構成で、記事は Markdown で書かれサーバーサイド（Rust + comrak + syntect）で HTML に変換される。読書体験で重視するのは：
 
-- **Long-form readability** over flashy chrome
-- **Code blocks, link cards, and embeds** as the visual centerpiece (not photography)
-- A single calm accent — magenta — used only as a brand mark or a focused state
+- 派手な装飾より **長文の読みやすさ**
+- 写真ではなく **コードブロック・リンクカード・埋め込み** を視覚の中心に
+- マゼンタというただ 1 つの落ち着いたアクセント色（ブランドマークまたはフォーカス状態のみで使用）
 
-Sister project: `blog.hozi.dev` (legacy frontend). The matcha cup mascot appears on both.
-
----
-
-## Content fundamentals
-
-The blog is **bilingual but Japanese-first**. UI labels and microcopy mix lowercase English nouns (`tech`, `note`, `who?`, `Career`, `Like`) with Japanese body text. The voice is engineer-to-engineer: factual, low-frill, often listing tech stacks without commentary.
-
-- **Voice & person.** Third-person and impersonal (no "I"/"you"). Author bio simply lists `Career` and `Like`. No marketing copy.
-- **Casing.** Tab labels are lowercase (`tech`, `note`, `who?`). Site title is lowercase too (`shuntaka.dev`). Headings within articles follow Japanese sentence case — no Title Case.
-- **Punctuation.** `who?` is the only punctuated nav item — adds a touch of whimsy in an otherwise restrained interface.
-- **Dates.** Always `YYYY/MM/DD` (e.g. `2021/03/12`) in Japanese locale. Article timestamps add `MM/DD HH:mm YYYY`.
-- **Tags.** Hash-prefixed (`#NestJS`, `#Rust`). Tag chip shape: rounded rectangle, 1px black border, no fill.
-- **Emoji.** Used **sparingly** in commit/PR titles (🍵, 🍞, 🍙, 📝) but **never** in product UI. Do not introduce emoji into the UI; the mascot already carries the warmth.
-- **Numbers / stats.** None. The blog never advertises view counts, follower counts, or "trending" badges. Avoid data slop.
-- **Tone samples**
-  - `No articles found.` — empty state
-  - `ライトモードに切り替え` / `ダークモードに切り替え` — accessible labels
-  - `Posted on blog.hozi.dev/ 1 days ago` — timeline records
-  - `Career` `201204 TDU EC` `201604 株式会社QUICK` — bio entries (date-prefixed, terse)
-- **Don't.** No "Welcome!" headers, no "Subscribe to my newsletter" CTAs, no emoji buttons, no exclamation marks in prose.
+兄弟プロジェクト：`blog.hozi.dev`（レガシーフロントエンド）。抹茶カップのマスコットは両方に登場する。
 
 ---
 
-## Visual foundations
+## コンテンツの基本
+
+ブログは **バイリンガルだが日本語ファースト**。UI ラベルやマイクロコピーは小文字英単語（`tech`, `note`, `who?`, `Career`, `Like`）と日本語本文を混ぜる。voice はエンジニア向けに事実ベース、装飾を抑え、技術スタックを淡々と並べる文体。
+
+- **Voice / 人称.** 三人称・非人称（"I" や "you" は使わない）。プロフィールも `Career` と `Like` を並べるだけ。マーケティングコピーは書かない。
+- **大文字小文字.** タブラベルは小文字（`tech`, `note`, `who?`）。サイトタイトルも小文字（`shuntaka.dev`）。記事内の見出しは日本語の文章ケース、Title Case にしない。
+- **句読点.** `who?` だけがナビ唯一の句読点付きラベルで、抑制的な UI に少しの遊び心を加える。
+- **日付.** 常に `YYYY/MM/DD`（例: `2021/03/12`）の日本語ロケール。記事タイムスタンプは `MM/DD HH:mm YYYY` を追加する。
+- **タグ.** ハッシュ前置き（`#NestJS`, `#Rust`）。タグチップ形状：角丸長方形、1px 黒ボーダー、塗りなし。
+- **絵文字.** コミット / PR タイトルでは **控えめに** 使う（🍵, 🍞, 🍙, 📝）が、プロダクト UI では **絶対に使わない**。マスコットがすでにあたたかみを担っているので UI に絵文字を入れない。
+- **数字 / 統計.** 出さない。閲覧数・フォロワー数・「トレンド」バッジなどはブログに表示しない。data slop を避ける。
+- **トーン例**
+  - `No articles found.` — 空状態
+  - `ライトモードに切り替え` / `ダークモードに切り替え` — アクセシブルラベル
+  - `Posted on blog.hozi.dev/ 1 days ago` — Timeline レコード
+  - `Career` `201204 TDU EC` `201604 株式会社QUICK` — 略式の日付前置き bio エントリ
+- **Don't.** "Welcome!" 見出しなし、"Subscribe to my newsletter" CTA なし、絵文字ボタンなし、本文の感嘆符なし。
+
+---
+
+## ビジュアル基盤
 
 ### Color
 
-- **Light:** off-white `#f7fafc` page on `#ffffff` surfaces; nearly-white `#fffefc` for the header. Body text `#525457` — a warm dark grey, **not** pure black.
-- **Dark:** GitHub-Dark navy. `#22272e` page, `#2d333b` raised, body `#c9d5e1`.
-- **Accent:** **`#e4007f`** magenta-pink. Used for: the dark-mode toggle ON track, the NProgress bar, focus-visible outline, and the danger callout border. **Never** for body text, **never** as a fill on cards.
-- **Borders:** `#c4c4c4` for general; `rgba(162,177,202,0.3)` for the article-list under-line — almost invisible, just a typographic baseline.
+- **Light:** オフホワイト `#f7fafc` をページ背景に、`#ffffff` をサーフェスに、ヘッダーはほぼ白の `#fffefc`。本文テキストは `#525457` の暖色寄りダークグレー（純黒では **ない**）。
+- **Dark:** GitHub-Dark のネイビー。`#22272e` ページ、`#2d333b` 持ち上げ、本文 `#c9d5e1`。
+- **Accent:** **`#e4007f`** マゼンタピンク。用途：ダークモードトグル ON のトラック、NProgress バー、focus-visible アウトライン、danger callout のボーダー。本文テキストには **絶対** 使わない、カードの fill にも **絶対** 使わない。
+- **Borders:** 一般用途は `#c4c4c4`、記事リスト下線は `rgba(162,177,202,0.3)`（ほぼ見えない、タイポグラフィのベースライン的な存在）。
 
 ### Typography
 
-- **English:** Roboto (400/700) — loaded via `next/font/google`, exposed as `--font-roboto`.
-- **Japanese:** Noto Sans JP — exposed as `--font-noto-sans-jp`. (Figma drafts use Hiragino Sans; the production build uses Noto Sans JP because Hiragino is macOS-only.)
-- **Mono:** system stack (`ui-monospace, SFMono-Regular, …`).
-- **Scale (rem-based, 1rem = 16px).** `display 32 / h1 27 / h2 24 / h3 20 / h4 18 / body-lg 16 / body 15 / caption 13 / code 14`.
-- **Line-height.** Body `1.9` (generous — reading ergonomics). Headings `1.4`. Lists `1.7`.
-- **No `em`/`px` mixing.** Type uses `rem`; layout uses `px` or layout tokens.
-- **`<strong>` is the only emphasis.** No colored emphasis, no all-caps, no letter-spacing tweaks.
+- **英語:** Roboto (400/700) — `next/font/google` で読み込み、`--font-roboto` で公開。
+- **日本語:** Noto Sans JP — `--font-noto-sans-jp` で公開。（Figma 下書きは Hiragino Sans を使うが、本番は macOS 限定を避けて Noto Sans JP）
+- **Mono:** システムスタック（`ui-monospace, SFMono-Regular, …`）。
+- **スケール（rem ベース、1rem = 16px）.** `display 32 / h1 27 / h2 24 / h3 20 / h4 18 / body-lg 16 / body 15 / caption 13 / code 14`。
+- **行高.** 本文 `1.9`（読書体験のため大きめ）。見出し `1.4`。リスト `1.7`。
+- **`em` と `px` を混ぜない.** タイポは `rem`、レイアウトは `px` またはレイアウトトークン。
+- **強調は `<strong>` のみ.** 着色強調・全大文字・letter-spacing いじりはしない。
 
-### Backgrounds
+### 背景
 
-- **No imagery.** No hero photos, no full-bleed gradients, no patterns, no grain. Surfaces are flat `#fff` (light) or flat navy (dark).
-- **No gradients** anywhere. The system explicitly rejects "rainbow gradients, neon shadows".
-- **Article wrapper** is a flat `#fff` panel with `15px` corner radius, `1px` subtle border.
+- **画像なし.** ヒーロー写真・全画面グラデーション・パターン・グレインはなし。サーフェスはフラット `#fff`（light）またはフラットネイビー（dark）。
+- **グラデーション禁止.** "rainbow gradients, neon shadows" は明示的に拒絶される。
+- **記事ラッパー** はフラット `#fff` パネル、コーナー半径 `15px`、subtle な 1px ボーダー。
 
-### Borders & corners
+### ボーダー / 角
 
-- **Radii: 4 levels.** `4px` (buttons, tags), `10px` (cards, thumbnails), `15px` (article wrapper), `9999px` (toggle, circular icons).
-- **Borders are 1px solid.** Color usually `--color-border` or its `subtle` sibling. No double borders, no dashed.
+- **半径は 4 段階.** `4px`（ボタン、タグ）、`10px`（カード、サムネイル）、`15px`（記事ラッパー）、`9999px`（トグル、円形アイコン）。
+- **ボーダーは 1px solid のみ.** 色は通常 `--color-border` または `subtle` 兄弟。double / dashed なし。
 
-### Shadows / elevation
+### 影 / elevation
 
-- The production CSS uses **one** real shadow: `0 2px 8px rgba(0,0,0,0.10)` on `link-card:hover`.
-- A 4-step elevation token set is reserved (`--shadow-0`…`--shadow-3`) for future modals/popovers but is currently unused.
-- **Don't** add drop shadows to cards at rest. The system reads as flat-by-default.
+- 本番 CSS で実際に使う影は **1 つだけ**：`link-card:hover` の `0 2px 8px rgba(0,0,0,0.10)`。
+- 4 段階の elevation トークン（`--shadow-0`…`--shadow-3`）は将来のモーダル / ポップオーバー用に予約済みだが、現状未使用。
+- **静止状態のカードに drop-shadow を追加しない.** システムは flat-by-default で読まれる。
 
 ### Motion
 
-- **Tokens:** `--motion-fast 150ms / --motion-base 250ms / --motion-slow 400ms`. Easing is browser-default (linear / ease).
-- **Used for:** copy-button opacity (`0.4 → 1.0`), link-card border-color & shadow, NProgress bar.
-- **No bounces, no spring, no entrance animations** on page load. The blog is meant to feel "instant".
+- **トークン:** `--motion-fast 150ms / --motion-base 250ms / --motion-slow 400ms`。easing はブラウザデフォルト（linear / ease）。
+- **用途:** copy ボタンの opacity（`0.4 → 1.0`）、link-card の border-color と shadow、NProgress バー。
+- **bounce / spring / ページロード時のエントランスアニメーションなし.** ブログは「即座に表示される」感じを目指す。
 
 ### Hover / press / focus
 
-- **Hover.** Change _one_ property by one step — usually `filter: brightness(95%)` for buttons, or a border-color swap for link cards.
-- **Focus-visible.** Universal `outline: 2px solid var(--color-accent); outline-offset: 2px;` — applied to every `a`, `button`, `[role="button"]`, input, summary in `globals.css`. Critical accessibility primitive.
-- **Active.** `filter: brightness(90%)` for buttons.
-- **Disabled.** `opacity: 0.5; pointer-events: none;` + `aria-disabled="true"`.
+- **Hover.** 1 つのプロパティを 1 段階だけ変える — ボタンは `filter: brightness(95%)`、リンクカードは border-color を入れ替える程度。
+- **Focus-visible.** 全要素共通の `outline: 2px solid var(--color-accent); outline-offset: 2px;` を `globals.css` で `a`、`button`、`[role="button"]`、input、summary に当てる。アクセシビリティの基盤。
+- **Active.** ボタンは `filter: brightness(90%)`。
+- **Disabled.** `opacity: 0.5; pointer-events: none;` + `aria-disabled="true"`。
 
-### Layout rules
+### レイアウトルール
 
-- Single `--layout-max: 1200px` outer column, centered. Article list inside is capped to `--layout-list-max: 600px`.
-- Article page = `flex justify-between` of a left content column + `296px` sticky right TOC sidebar; sidebar collapses below `lg`.
-- Sticky TOC offset is computed: `top: calc(var(--layout-header-h) + var(--layout-nav-h) + var(--space-5))` — never magic numbers.
-- Footer is `position: absolute; bottom: 0;` with reserved `58px` of bottom padding on the body. Header is **not** sticky.
-- **No `display: grid`** in the codebase today. Multi-column layouts use Flex + `gap`.
+- 外側は `--layout-max: 1200px` の単一カラム中央寄せ。記事一覧は `--layout-list-max: 600px` で内側を絞る。
+- 記事ページ = 左コンテンツ + `296px` 固定の右 TOC サイドバーを `flex justify-between` で並べる。`lg` 以下でサイドバーは折りたたまれる。
+- TOC の sticky オフセットは `top: calc(var(--layout-header-h) + var(--layout-nav-h) + var(--space-5))` で計算する。マジックナンバー禁止。
+- フッターは `position: absolute; bottom: 0;` で body 下部に `58px` の余白を予約。ヘッダーは sticky **にしない**。
+- **`display: grid` を使わない.** マルチカラムは Flex + `gap`。
 
-### Transparency & blur
+### 透過 / blur
 
-- **None.** No `backdrop-filter`, no glassmorphism, no semi-transparent overlays. The TOC's `is-active` track uses an opacity-based color (`#57595b87`) but that's it.
+- **使わない.** `backdrop-filter` なし、glassmorphism なし、半透明オーバーレイなし。TOC の `is-active` トラックで opacity ベースの色（`#57595b87`）を使うのが唯一の例外。
 
-### Imagery vibe
+### イメージの雰囲気
 
-- Article thumbnails are user-supplied OGP images, treated as content. Container: `150×100`, `object-cover`, `10px` radius, `loading="lazy"`. No filters, no tints, no overlays.
+- 記事サムネは user 提供の OGP 画像をコンテンツとして扱う。コンテナ：`150×100`、`object-cover`、`10px` radius、`loading="lazy"`。フィルタ・ティント・オーバーレイなし。
 
-### What this system rejects
+### このシステムが拒絶するもの
 
-- Rainbow / blue-purple gradients
-- Neon shadows
-- Emoji-laden UI
-- Cards with rounded corners + colored left-border accent
-- Tailwind preset palette (`bg-blue-500`, `text-red-500`) — banned in favour of CSS variables
-- Hardcoded inline `style={{ color: '#…' }}` — banned
+- レインボー / 青紫グラデーション
+- ネオン影
+- 絵文字まみれの UI
+- 角丸 + 着色レフトボーダーアクセントのカード
+- Tailwind プリセットパレット（`bg-blue-500`, `text-red-500`）— CSS 変数を使う方針なので禁止
+- インラインの `style={{ color: '#…' }}` ハードコード — 禁止
 
 ---
 
-## Iconography
+## アイコン
 
-**Approach.** A small, hand-curated set of single-color SVGs sits in `public/assets/`. There is **no icon font** and **no icon library** (no Lucide, no Heroicons). When new icons are needed, copy the existing ones in style: a single fill or stroke, no gradients, no multi-color glyphs.
+**方針.** `public/assets/` に小規模な手作りの単色 SVG セットがある。アイコンフォントもアイコンライブラリも使わない（Lucide も Heroicons も使わない）。新しいアイコンが必要なときは既存のスタイルに合わせる：単一 fill or stroke、グラデーション禁止、多色グリフ禁止。
 
-### Mascot — `ochaIcon` 🍵
+### マスコット — `ochaIcon` 🍵
 
-A friendly matcha cup with a smile. It's the brand mark; it appears as the favicon, the timeline-record bullet, the logo on the marketing concept, and the social-link "homepage" icon. **Always full-color** (matcha green body `#6e9050`, foam `#bde030`, blush cheeks `#fff9f9`). Do not invert it, do not recolor it.
+笑顔の抹茶カップ。これがブランドマーク。favicon、Timeline レコードの bullet、マーケティングコンセプトのロゴ、ソーシャルリンクの「homepage」アイコンとして登場する。**常にフルカラー**（抹茶ボディ `#6e9050`、フォーム `#bde030`、頬 `#fff9f9`）。反転したり再着色したりしない。
 
-### Social-link glyphs
+### ソーシャルリンクのグリフ
 
-Single-color brand marks (`#525457` in light, `#c9d5e1` in dark via container `color: inherit`). All sized to a `24×24` box.
+単色ブランドマーク（light: `#525457`、dark: `#c9d5e1`、コンテナの `color: inherit` で切替）。すべて `24×24` ボックスサイズ。
 
-| File                         | Service                                   |
-| ---------------------------- | ----------------------------------------- |
-| `public/assets/github.svg`   | GitHub (`shuntaka9576`)                   |
-| `public/assets/x.svg`        | X / Twitter (`shuntaka_dev`)              |
-| `public/assets/zenn.svg`     | Zenn (`shuntaka`)                         |
-| `public/assets/sd.svg`       | SpeakerDeck                               |
-| `public/assets/devio.svg`    | DevelopersIO (Classmethod author profile) |
-| `public/assets/bluesky.svg`  | Bluesky                                   |
-| `public/assets/ochaIcon.svg` | the personal site itself                  |
+| ファイル                     | サービス                                     |
+| ---------------------------- | -------------------------------------------- |
+| `public/assets/github.svg`   | GitHub (`shuntaka9576`)                      |
+| `public/assets/x.svg`        | X / Twitter (`shuntaka_dev`)                 |
+| `public/assets/zenn.svg`     | Zenn (`shuntaka`)                            |
+| `public/assets/sd.svg`       | SpeakerDeck                                  |
+| `public/assets/devio.svg`    | DevelopersIO（Classmethod 著者プロフィール） |
+| `public/assets/bluesky.svg`  | Bluesky                                      |
+| `public/assets/ochaIcon.svg` | 個人サイト本体                               |
 
-### Functional glyphs
+### 機能アイコン
 
-Inlined SVG paths, not imported as files:
+ファイルとしてではなく、SVG パスをインライン埋め込みする：
 
-- **Toggle moon/sun** (in `ToggleSwitch.tsx`) — moon `circle` + sun `path` SVG, paired with a sliding pill knob.
-- **Copy button** (in `globals.css` + `ArticleContent.tsx` injected DOM) — clipboard glyph.
-- **GitHub-embed copy / check** — same family as the copy button.
+- **トグルの月 / 太陽**（`ToggleSwitch.tsx`）— moon `circle` + sun `path` SVG をスライド式 pill ノブと組み合わせ。
+- **コピーボタン**（`globals.css` + `ArticleContent.tsx` の DOM 注入）— クリップボードグリフ。
+- **GitHub-embed のコピー / チェック** — コピーボタンと同系列。
 
 ### `404.svg`
 
-A custom illustrated `404` mark used on the 404 page (and once in the Figma marketing frame).
+404 ページで使う、独自にイラスト化された 404 マーク（Figma マーケティングフレームでも一度使われている）。
 
-### Emoji & unicode
+### 絵文字 / unicode
 
-- **Not used in product UI.** The `who?` page punctuation is the only typographic flourish.
-- Used only in commit messages / repo READMEs (🍵 🍞 🍙 ✨ 📝).
+- **プロダクト UI では使わない.** `who?` ページの句読点だけが唯一のタイポグラフィの遊び。
+- コミットメッセージ / リポジトリ README でだけ使う（🍵 🍞 🍙 ✨ 📝）。
 
-### Substitutions
+### 代替
 
-None — the production icon set is small enough to use entirely. If you need a glyph not in `public/assets/`, prefer **Lucide** (matching stroke style: 1.5px, no fill) and flag the substitution in the PR description.
-
----
-
-## CAVEATS
-
-- **Fonts.** Production uses `next/font` for Roboto + Noto Sans JP, exposed as `--font-roboto` and `--font-noto-sans-jp`. No CDN dependency; `next/font` self-hosts subsets at build time.
-- **Hiragino Sans (Figma) → Noto Sans JP (production).** The Figma file lists Hiragino Sans because it's the macOS default; we use Noto Sans JP everywhere because it ships everywhere. Treat the two as visually equivalent.
-- **Dark mode.** Tokens are wired up via `[data-theme='dark']` on `<html>`, toggled by `ToggleSwitch`. The `prefers-color-scheme: dark` media query is also honored when no explicit theme is saved.
+なし — 本番アイコンセットは小さく、すべてそのまま使える。`public/assets/` に無いグリフが必要な場合は **Lucide**（stroke スタイル：1.5px、塗りなし）を優先し、PR description で代替したことを明記する。
 
 ---
 
-## Implementation pointers
+## 留意点
 
-- **Token implementation.** All design tokens (colors, spacing, radius, line-height, type scale, motion, shadows) live in `src/app/globals.css`. Light values are in `:root`, dark overrides in `[data-theme='dark']` and the `prefers-color-scheme: dark` block.
-- **Visual catalog.** `apps/web/.storybook/` hosts Storybook (Storybook 10 + `@storybook/nextjs-vite`). Stories cover real production components and token swatches.
-  - Run locally: `bun run storybook` (`http://localhost:6006`)
-  - Static build: `bun run build-storybook` → `apps/web/storybook-static/`
-  - Deploy: pushes to `main` trigger `.github/workflows/deploy-storybook.yaml`, which publishes to GitHub Pages with `STORYBOOK_BASE_PATH=/<repo>/`.
-- **Components.** `src/components/*.tsx` is the canonical UI. When introducing a new visual element, prefer extending an existing component or adding a new Story over hand-rolling raw HTML.
+- **フォント.** 本番は `next/font` で Roboto + Noto Sans JP を読み込み、`--font-roboto` / `--font-noto-sans-jp` として公開する。CDN 依存はなく、`next/font` がビルド時にサブセットをセルフホスト。
+- **Hiragino Sans (Figma) → Noto Sans JP（本番）.** Figma が macOS デフォルトの Hiragino Sans を表示しているのは見た目確認用。本番は環境を問わず動く Noto Sans JP を使う。視覚的にはほぼ等価とみなす。
+- **Dark mode.** トークンは `<html>` の `[data-theme='dark']` で切り替わり、`ToggleSwitch` がそれを操作する。明示的な theme が保存されていないとき `prefers-color-scheme: dark` も尊重する。
+
+---
+
+## 実装ポインタ
+
+- **トークン実装.** すべてのデザイントークン（color、spacing、radius、line-height、type scale、motion、shadow）は `src/app/globals.css` にある。Light の値は `:root` に、Dark の上書きは `[data-theme='dark']` と `prefers-color-scheme: dark` ブロックに置く。
+- **視覚カタログ.** `apps/web/.storybook/` に Storybook（Storybook 10 + `@storybook/nextjs-vite`）を置く。Story は本番コンポーネントとトークンのスウォッチをカバーする。
+  - ローカル起動: `bun run storybook`（`http://localhost:6006`）
+  - 静的ビルド: `bun run build-storybook` → `apps/web/storybook-static/`
+  - デプロイ: `main` への push で `.github/workflows/docs.yaml` がトリガーされ、Sphinx docs と同じ artifact に同梱されて GitHub Pages に公開される（`STORYBOOK_BASE_PATH=/shuntaka-dev/storybook/`）。
+- **コンポーネント.** `src/components/*.tsx` が UI の正本。新しい視覚要素を作るときは生 HTML を書くより、既存コンポーネントを拡張するか新しい Story を追加することを優先する。

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -1,0 +1,179 @@
+# shuntaka.dev Design System
+
+A design system for **shuntaka.dev** — a quiet, reading-first Japanese tech blog by **髙橋俊一 (a.k.a. shuntaka)**. The brand is built around a single visual mascot, the **matcha tea cup (ochaIcon)** 🍵, a single accent color (**magenta-pink `#e4007f`**), and a GitHub-Dark-flavored dark mode.
+
+## Source materials
+
+- **Source of truth** — this file (rules + voice) plus `src/app/globals.css` (token implementation).
+- **Visual catalog** — `apps/web/.storybook/` (run `bun run storybook`); deployed to GitHub Pages on `main` merge.
+- **Figma** (`shuntaka.dev.fig`) — early concept frames showing logo studies, share-button OGPs, MacBook Pro list view, search/tag view, and the Timeline reading-history widget. The Figma is _concept fidelity_ — the codebase is the source of truth where they conflict.
+
+## Brand context
+
+shuntaka.dev is the personal tech blog of a Japanese software engineer (currently at Classmethod). It hosts **tech**, **note**, and **who?** sections; articles are written in Markdown and converted server-side (Rust + comrak + syntect). The reader experience prioritises:
+
+- **Long-form readability** over flashy chrome
+- **Code blocks, link cards, and embeds** as the visual centerpiece (not photography)
+- A single calm accent — magenta — used only as a brand mark or a focused state
+
+Sister project: `blog.hozi.dev` (legacy frontend). The matcha cup mascot appears on both.
+
+---
+
+## Content fundamentals
+
+The blog is **bilingual but Japanese-first**. UI labels and microcopy mix lowercase English nouns (`tech`, `note`, `who?`, `Career`, `Like`) with Japanese body text. The voice is engineer-to-engineer: factual, low-frill, often listing tech stacks without commentary.
+
+- **Voice & person.** Third-person and impersonal (no "I"/"you"). Author bio simply lists `Career` and `Like`. No marketing copy.
+- **Casing.** Tab labels are lowercase (`tech`, `note`, `who?`). Site title is lowercase too (`shuntaka.dev`). Headings within articles follow Japanese sentence case — no Title Case.
+- **Punctuation.** `who?` is the only punctuated nav item — adds a touch of whimsy in an otherwise restrained interface.
+- **Dates.** Always `YYYY/MM/DD` (e.g. `2021/03/12`) in Japanese locale. Article timestamps add `MM/DD HH:mm YYYY`.
+- **Tags.** Hash-prefixed (`#NestJS`, `#Rust`). Tag chip shape: rounded rectangle, 1px black border, no fill.
+- **Emoji.** Used **sparingly** in commit/PR titles (🍵, 🍞, 🍙, 📝) but **never** in product UI. Do not introduce emoji into the UI; the mascot already carries the warmth.
+- **Numbers / stats.** None. The blog never advertises view counts, follower counts, or "trending" badges. Avoid data slop.
+- **Tone samples**
+  - `No articles found.` — empty state
+  - `ライトモードに切り替え` / `ダークモードに切り替え` — accessible labels
+  - `Posted on blog.hozi.dev/ 1 days ago` — timeline records
+  - `Career` `201204 TDU EC` `201604 株式会社QUICK` — bio entries (date-prefixed, terse)
+- **Don't.** No "Welcome!" headers, no "Subscribe to my newsletter" CTAs, no emoji buttons, no exclamation marks in prose.
+
+---
+
+## Visual foundations
+
+### Color
+
+- **Light:** off-white `#f7fafc` page on `#ffffff` surfaces; nearly-white `#fffefc` for the header. Body text `#525457` — a warm dark grey, **not** pure black.
+- **Dark:** GitHub-Dark navy. `#22272e` page, `#2d333b` raised, body `#c9d5e1`.
+- **Accent:** **`#e4007f`** magenta-pink. Used for: the dark-mode toggle ON track, the NProgress bar, focus-visible outline, and the danger callout border. **Never** for body text, **never** as a fill on cards.
+- **Borders:** `#c4c4c4` for general; `rgba(162,177,202,0.3)` for the article-list under-line — almost invisible, just a typographic baseline.
+
+### Typography
+
+- **English:** Roboto (400/700) — loaded via `next/font/google`, exposed as `--font-roboto`.
+- **Japanese:** Noto Sans JP — exposed as `--font-noto-sans-jp`. (Figma drafts use Hiragino Sans; the production build uses Noto Sans JP because Hiragino is macOS-only.)
+- **Mono:** system stack (`ui-monospace, SFMono-Regular, …`).
+- **Scale (rem-based, 1rem = 16px).** `display 32 / h1 27 / h2 24 / h3 20 / h4 18 / body-lg 16 / body 15 / caption 13 / code 14`.
+- **Line-height.** Body `1.9` (generous — reading ergonomics). Headings `1.4`. Lists `1.7`.
+- **No `em`/`px` mixing.** Type uses `rem`; layout uses `px` or layout tokens.
+- **`<strong>` is the only emphasis.** No colored emphasis, no all-caps, no letter-spacing tweaks.
+
+### Backgrounds
+
+- **No imagery.** No hero photos, no full-bleed gradients, no patterns, no grain. Surfaces are flat `#fff` (light) or flat navy (dark).
+- **No gradients** anywhere. The system explicitly rejects "rainbow gradients, neon shadows".
+- **Article wrapper** is a flat `#fff` panel with `15px` corner radius, `1px` subtle border.
+
+### Borders & corners
+
+- **Radii: 4 levels.** `4px` (buttons, tags), `10px` (cards, thumbnails), `15px` (article wrapper), `9999px` (toggle, circular icons).
+- **Borders are 1px solid.** Color usually `--color-border` or its `subtle` sibling. No double borders, no dashed.
+
+### Shadows / elevation
+
+- The production CSS uses **one** real shadow: `0 2px 8px rgba(0,0,0,0.10)` on `link-card:hover`.
+- A 4-step elevation token set is reserved (`--shadow-0`…`--shadow-3`) for future modals/popovers but is currently unused.
+- **Don't** add drop shadows to cards at rest. The system reads as flat-by-default.
+
+### Motion
+
+- **Tokens:** `--motion-fast 150ms / --motion-base 250ms / --motion-slow 400ms`. Easing is browser-default (linear / ease).
+- **Used for:** copy-button opacity (`0.4 → 1.0`), link-card border-color & shadow, NProgress bar.
+- **No bounces, no spring, no entrance animations** on page load. The blog is meant to feel "instant".
+
+### Hover / press / focus
+
+- **Hover.** Change _one_ property by one step — usually `filter: brightness(95%)` for buttons, or a border-color swap for link cards.
+- **Focus-visible.** Universal `outline: 2px solid var(--color-accent); outline-offset: 2px;` — applied to every `a`, `button`, `[role="button"]`, input, summary in `globals.css`. Critical accessibility primitive.
+- **Active.** `filter: brightness(90%)` for buttons.
+- **Disabled.** `opacity: 0.5; pointer-events: none;` + `aria-disabled="true"`.
+
+### Layout rules
+
+- Single `--layout-max: 1200px` outer column, centered. Article list inside is capped to `--layout-list-max: 600px`.
+- Article page = `flex justify-between` of a left content column + `296px` sticky right TOC sidebar; sidebar collapses below `lg`.
+- Sticky TOC offset is computed: `top: calc(var(--layout-header-h) + var(--layout-nav-h) + var(--space-5))` — never magic numbers.
+- Footer is `position: absolute; bottom: 0;` with reserved `58px` of bottom padding on the body. Header is **not** sticky.
+- **No `display: grid`** in the codebase today. Multi-column layouts use Flex + `gap`.
+
+### Transparency & blur
+
+- **None.** No `backdrop-filter`, no glassmorphism, no semi-transparent overlays. The TOC's `is-active` track uses an opacity-based color (`#57595b87`) but that's it.
+
+### Imagery vibe
+
+- Article thumbnails are user-supplied OGP images, treated as content. Container: `150×100`, `object-cover`, `10px` radius, `loading="lazy"`. No filters, no tints, no overlays.
+
+### What this system rejects
+
+- Rainbow / blue-purple gradients
+- Neon shadows
+- Emoji-laden UI
+- Cards with rounded corners + colored left-border accent
+- Tailwind preset palette (`bg-blue-500`, `text-red-500`) — banned in favour of CSS variables
+- Hardcoded inline `style={{ color: '#…' }}` — banned
+
+---
+
+## Iconography
+
+**Approach.** A small, hand-curated set of single-color SVGs sits in `public/assets/`. There is **no icon font** and **no icon library** (no Lucide, no Heroicons). When new icons are needed, copy the existing ones in style: a single fill or stroke, no gradients, no multi-color glyphs.
+
+### Mascot — `ochaIcon` 🍵
+
+A friendly matcha cup with a smile. It's the brand mark; it appears as the favicon, the timeline-record bullet, the logo on the marketing concept, and the social-link "homepage" icon. **Always full-color** (matcha green body `#6e9050`, foam `#bde030`, blush cheeks `#fff9f9`). Do not invert it, do not recolor it.
+
+### Social-link glyphs
+
+Single-color brand marks (`#525457` in light, `#c9d5e1` in dark via container `color: inherit`). All sized to a `24×24` box.
+
+| File                         | Service                                   |
+| ---------------------------- | ----------------------------------------- |
+| `public/assets/github.svg`   | GitHub (`shuntaka9576`)                   |
+| `public/assets/x.svg`        | X / Twitter (`shuntaka_dev`)              |
+| `public/assets/zenn.svg`     | Zenn (`shuntaka`)                         |
+| `public/assets/sd.svg`       | SpeakerDeck                               |
+| `public/assets/devio.svg`    | DevelopersIO (Classmethod author profile) |
+| `public/assets/bluesky.svg`  | Bluesky                                   |
+| `public/assets/ochaIcon.svg` | the personal site itself                  |
+
+### Functional glyphs
+
+Inlined SVG paths, not imported as files:
+
+- **Toggle moon/sun** (in `ToggleSwitch.tsx`) — moon `circle` + sun `path` SVG, paired with a sliding pill knob.
+- **Copy button** (in `globals.css` + `ArticleContent.tsx` injected DOM) — clipboard glyph.
+- **GitHub-embed copy / check** — same family as the copy button.
+
+### `404.svg`
+
+A custom illustrated `404` mark used on the 404 page (and once in the Figma marketing frame).
+
+### Emoji & unicode
+
+- **Not used in product UI.** The `who?` page punctuation is the only typographic flourish.
+- Used only in commit messages / repo READMEs (🍵 🍞 🍙 ✨ 📝).
+
+### Substitutions
+
+None — the production icon set is small enough to use entirely. If you need a glyph not in `public/assets/`, prefer **Lucide** (matching stroke style: 1.5px, no fill) and flag the substitution in the PR description.
+
+---
+
+## CAVEATS
+
+- **Fonts.** Production uses `next/font` for Roboto + Noto Sans JP, exposed as `--font-roboto` and `--font-noto-sans-jp`. No CDN dependency; `next/font` self-hosts subsets at build time.
+- **Hiragino Sans (Figma) → Noto Sans JP (production).** The Figma file lists Hiragino Sans because it's the macOS default; we use Noto Sans JP everywhere because it ships everywhere. Treat the two as visually equivalent.
+- **Dark mode.** Tokens are wired up via `[data-theme='dark']` on `<html>`, toggled by `ToggleSwitch`. The `prefers-color-scheme: dark` media query is also honored when no explicit theme is saved.
+
+---
+
+## Implementation pointers
+
+- **Token implementation.** All design tokens (colors, spacing, radius, line-height, type scale, motion, shadows) live in `src/app/globals.css`. Light values are in `:root`, dark overrides in `[data-theme='dark']` and the `prefers-color-scheme: dark` block.
+- **Visual catalog.** `apps/web/.storybook/` hosts Storybook (Storybook 10 + `@storybook/nextjs-vite`). Stories cover real production components and token swatches.
+  - Run locally: `bun run storybook` (`http://localhost:6006`)
+  - Static build: `bun run build-storybook` → `apps/web/storybook-static/`
+  - Deploy: pushes to `main` trigger `.github/workflows/deploy-storybook.yaml`, which publishes to GitHub Pages with `STORYBOOK_BASE_PATH=/<repo>/`.
+- **Components.** `src/components/*.tsx` is the canonical UI. When introducing a new visual element, prefer extending an existing component or adding a new Story over hand-rolling raw HTML.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "type-check": "tsc --noEmit",
-    "clean": "rm -rf .next .turbo"
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+    "clean": "rm -rf .next .turbo storybook-static"
   },
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
@@ -21,11 +23,15 @@
     "tocbot": "^4.36.4"
   },
   "devDependencies": {
+    "@storybook/addon-themes": "^10.3.5",
+    "@storybook/nextjs-vite": "^10.3.5",
     "@tailwindcss/postcss": "^4.2.4",
     "@types/nprogress": "^0.2.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/rss": "^0.0.32",
-    "tailwindcss": "^4.2.4"
+    "storybook": "^10.3.5",
+    "tailwindcss": "^4.2.4",
+    "vite": "^8.0.10"
   }
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,66 +1,92 @@
 @import 'tailwindcss';
 
 :root {
-  --bg-color: #f7fafc;
-  --header-color: #fffefc;
-  --text-color: #525457;
-  --article-record-underline: rgba(162, 177, 202, 0.3);
-  --article-area-color: #fff;
+  /* Surfaces & text */
+  --color-bg: #f7fafc;
+  --color-surface: #ffffff;
+  --color-surface-raised: #fffefc;
+  --color-text: #525457;
+  --color-text-muted: #57595b8a;
+  --color-border: #c4c4c4;
+  --color-border-subtle: rgba(162, 177, 202, 0.3);
+
+  /* Brand accent */
+  --color-accent: #e4007f;
+  --color-accent-alt: #e40067;
+
+  /* Links */
+  --color-link: #5c6eb1;
+  --color-link-hover: #6686ff;
+  --color-link-visited: #6200ac;
+
+  /* Code */
+  --color-code-inline-bg: rgb(27 31 35 / 5%);
+  --color-code-inline-fg: #333;
+  --color-code-block-bg: #1e1e1e;
+  --color-code-block-fg: #d4d4d4;
+  --color-code-tab-bg: #2b303b;
+  --color-code-tab-fg: #9da5b4;
+
+  /* Feedback (callouts) */
+  --color-info-bg: #e7f1ff;
+  --color-info-border: #3b82f6;
+  --color-success-bg: #e7f7ed;
+  --color-success-border: #16a34a;
+  --color-warning-bg: #fff2b8;
+  --color-warning-border: #fcc800;
+  --color-danger-bg: #eb6e9f36;
+  --color-danger-border: #e4007f;
+
+  /* Misc */
+  --color-toggle-moon: #525457;
+  --color-toggle-sun: #fff33f;
+  --color-progress: #29d;
+  --color-success-icon: #3fb950;
+
+  /* Domain-specific tokens (not yet migrated to --color-* naming) */
   --article-area-border-color: #fff;
-  --tag-a-color: #5c6eb1;
-  --tag-a-hover-color: #6686ff;
-  --tag-a-visited-color: #6200ac;
   --tag-th-background-color: #f7fafc;
   --tag-th-color: #525457;
   --tag-td-background-color: #fff;
   --tag-th-td-border-color: #525457;
-  --tag-h1-border-line-color: #c4c4c4;
   --tag-h2-border-line-color: #c4c4c4;
   --tag-h2-border-line-after-color: #525457;
   --tag-blockquote-color: #ddd;
   --tag-blockquote-font-color: #777;
-  --tag-code-background-color: rgb(27 31 35 / 5%);
-  --tag-code-color: #333;
   --toc-list-color: rgba(162, 177, 202, 0.3);
   --toc-list-text-color: #57595b87;
   --toc-list-color-active: #525457;
-  --message-warn-color: #fff2b8;
-  --message-warn-border-color: #fcc800;
-  --message-error-color: #eb6e9f36;
-  --message-error-border-color: #e4007f;
   --github-embed-border: #d0d7de;
   --github-embed-header-bg: #f6f8fa;
   --github-embed-code-bg: #ffffff;
   --github-embed-link: #0969da;
   --github-embed-meta: #656d76;
 
-  /* === Semantic design tokens === */
-  --color-bg: var(--bg-color);
-  --color-surface: var(--article-area-color);
-  --color-surface-raised: var(--header-color);
-  --color-text: var(--text-color);
-  --color-text-muted: #57595b8a;
-  --color-border: var(--tag-h1-border-line-color);
-  --color-border-subtle: var(--article-record-underline);
-  --color-accent: #e4007f;
-  --color-link: var(--tag-a-color);
-  --color-link-hover: var(--tag-a-hover-color);
-  --color-link-visited: var(--tag-a-visited-color);
-  --color-code-inline-bg: var(--tag-code-background-color);
-  --color-code-inline-fg: var(--tag-code-color);
-  --color-code-block-bg: #1e1e1e;
-  --color-code-block-fg: #d4d4d4;
-  --color-info-bg: #e7f1ff;
-  --color-info-border: #3b82f6;
-  --color-success-bg: #e7f7ed;
-  --color-success-border: #16a34a;
-  --color-warning-bg: var(--message-warn-color);
-  --color-warning-border: var(--message-warn-border-color);
-  --color-danger-bg: var(--message-error-color);
-  --color-danger-border: var(--message-error-border-color);
-  --color-toggle-moon: #525457;
-  --color-toggle-sun: #fff33f;
-  --color-progress: #29d;
+  /* Type scale (rem; 1rem = 16px) */
+  --fs-display: 2rem;
+  --fs-h1: 1.7rem;
+  --fs-h2: 1.5rem;
+  --fs-h3: 1.25rem;
+  --fs-h4: 1.125rem;
+  --fs-body-lg: 1rem;
+  --fs-body: 0.9375rem;
+  --fs-caption: 0.8125rem;
+  --fs-code: 0.875rem;
+
+  /* Line-height */
+  --lh-tight: 1.3;
+  --lh-heading: 1.4;
+  --lh-list: 1.7;
+  --lh-body: 1.9;
+
+  /* Font weight */
+  --fw-regular: 400;
+  --fw-medium: 500;
+  --fw-bold: 700;
+
+  /* Mono font stack (sans is supplied by next/font: --font-roboto, --font-noto-sans-jp) */
+  --font-mono:
+    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
 
   /* Spacing scale (4px base) */
   --space-1: 0.25rem;
@@ -90,89 +116,96 @@
   --motion-fast: 150ms;
   --motion-base: 250ms;
   --motion-slow: 400ms;
+  --ease-out: cubic-bezier(0.2, 0.6, 0.2, 1);
+
+  /* Elevation (reserved; only --shadow-2 is used today on link-card:hover) */
+  --shadow-0: none;
+  --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.06);
+  --shadow-2: 0 2px 8px rgba(0, 0, 0, 0.1);
+  --shadow-3: 0 8px 24px rgba(0, 0, 0, 0.14);
 }
 
 [data-theme='dark'] {
-  --bg-color: #22272e;
-  --header-color: #2d333b;
-  --text-color: #c9d5e1;
-  --article-record-underline: rgba(247, 250, 252, 0.3);
-  --article-area-color: #22272e;
+  --color-bg: #22272e;
+  --color-surface: #22272e;
+  --color-surface-raised: #2d333b;
+  --color-text: #c9d5e1;
+  --color-text-muted: rgb(255 255 255 / 47%);
+  --color-border: #30363d;
+  --color-border-subtle: rgba(247, 250, 252, 0.3);
+
+  --color-link: #539bf5;
+  --color-link-hover: #539bf5;
+  --color-link-visited: #539bf5;
+
+  --color-code-inline-bg: rgb(69 75 83);
+  --color-code-inline-fg: #c9d5e1;
+
+  --color-info-bg: #1f2a37;
+  --color-success-bg: #1c2b24;
+  --color-warning-bg: #2d333b;
+  --color-danger-bg: #2d333b;
+
+  /* Domain-specific overrides */
   --article-area-border-color: rgba(65, 132, 228, 0.4);
-  --tag-a-color: #539bf5;
-  --tag-a-hover-color: #539bf5;
-  --tag-a-visited-color: #539bf5;
   --tag-th-background-color: #2d333b;
   --tag-th-color: #c9d5e1;
   --tag-td-background-color: #2d333b;
   --tag-th-td-border-color: #c9d5e1;
-  --tag-h1-border-line-color: #c9d5e1;
   --tag-h2-border-line-color: #584f45;
   --tag-h2-border-line-after-color: #c9d5e1;
   --tag-blockquote-color: #c9d5e19e;
   --tag-blockquote-font-color: #c9d5e19e;
-  --tag-code-background-color: rgb(69 75 83);
-  --tag-code-color: #c9d5e1;
   --toc-list-color: rgba(247, 250, 252, 0.3);
   --toc-list-text-color: rgb(255 255 255 / 47%);
   --toc-list-color-active: #539bf5;
-  --message-warn-color: #2d333b;
-  --message-warn-border-color: #fcc800;
-  --message-error-color: #2d333b;
-  --message-error-border-color: #e4007f;
   --github-embed-border: #30363d;
   --github-embed-header-bg: #161b22;
   --github-embed-code-bg: #0d1117;
   --github-embed-link: #58a6ff;
   --github-embed-meta: #8b949e;
-
-  /* Semantic token overrides for dark */
-  --color-text-muted: rgb(255 255 255 / 47%);
-  --color-border: #30363d;
-  --color-info-bg: #1f2a37;
-  --color-success-bg: #1c2b24;
 }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme='light']) {
-    --bg-color: #22272e;
-    --header-color: #2d333b;
-    --text-color: #c9d5e1;
-    --article-record-underline: rgba(247, 250, 252, 0.3);
-    --article-area-color: #22272e;
+    --color-bg: #22272e;
+    --color-surface: #22272e;
+    --color-surface-raised: #2d333b;
+    --color-text: #c9d5e1;
+    --color-text-muted: rgb(255 255 255 / 47%);
+    --color-border: #30363d;
+    --color-border-subtle: rgba(247, 250, 252, 0.3);
+
+    --color-link: #539bf5;
+    --color-link-hover: #539bf5;
+    --color-link-visited: #539bf5;
+
+    --color-code-inline-bg: rgb(69 75 83);
+    --color-code-inline-fg: #c9d5e1;
+
+    --color-info-bg: #1f2a37;
+    --color-success-bg: #1c2b24;
+    --color-warning-bg: #2d333b;
+    --color-danger-bg: #2d333b;
+
+    /* Domain-specific overrides */
     --article-area-border-color: rgba(65, 132, 228, 0.4);
-    --tag-a-color: #539bf5;
-    --tag-a-hover-color: #539bf5;
-    --tag-a-visited-color: #539bf5;
     --tag-th-background-color: #2d333b;
     --tag-th-color: #c9d5e1;
     --tag-td-background-color: #2d333b;
     --tag-th-td-border-color: #c9d5e1;
-    --tag-h1-border-line-color: #c9d5e1;
     --tag-h2-border-line-color: #584f45;
     --tag-h2-border-line-after-color: #c9d5e1;
     --tag-blockquote-color: #c9d5e19e;
     --tag-blockquote-font-color: #c9d5e19e;
-    --tag-code-background-color: rgb(69 75 83);
-    --tag-code-color: #c9d5e1;
     --toc-list-color: rgba(247, 250, 252, 0.3);
     --toc-list-text-color: rgb(255 255 255 / 47%);
     --toc-list-color-active: #539bf5;
-    --message-warn-color: #2d333b;
-    --message-warn-border-color: #fcc800;
-    --message-error-color: #2d333b;
-    --message-error-border-color: #e4007f;
     --github-embed-border: #30363d;
     --github-embed-header-bg: #161b22;
     --github-embed-code-bg: #0d1117;
     --github-embed-link: #58a6ff;
     --github-embed-meta: #8b949e;
-
-    /* Semantic token overrides for dark */
-    --color-text-muted: rgb(255 255 255 / 47%);
-    --color-border: #30363d;
-    --color-info-bg: #1f2a37;
-    --color-success-bg: #1c2b24;
   }
 }
 
@@ -197,8 +230,8 @@ body {
     'Helvetica Neue',
     sans-serif;
   word-wrap: break-word;
-  background: var(--bg-color);
-  color: var(--text-color);
+  background: var(--color-bg);
+  color: var(--color-text);
 }
 
 a {
@@ -218,7 +251,7 @@ a:hover {
 
 /* Article prose styles */
 .prose {
-  line-height: 1.9;
+  line-height: var(--lh-body);
 }
 
 .prose h1 {
@@ -226,7 +259,7 @@ a:hover {
   margin-bottom: 1.1rem;
   padding-bottom: 0.2em;
   position: relative;
-  border-bottom: solid 1px var(--tag-h1-border-line-color);
+  border-bottom: solid 1px var(--color-border);
 }
 
 .prose h1:not(:first-child) {
@@ -294,20 +327,20 @@ a:hover {
 .prose p {
   margin-block-start: 1em;
   margin-block-end: 1em;
-  line-height: 1.9;
+  line-height: var(--lh-body);
 }
 
 .prose a {
-  color: var(--tag-a-color);
+  color: var(--color-link);
   word-break: break-all;
 }
 
 .prose a:hover {
-  color: var(--tag-a-hover-color);
+  color: var(--color-link-hover);
 }
 
 .prose a:visited {
-  color: var(--tag-a-visited-color);
+  color: var(--color-link-visited);
 }
 
 .prose ul {
@@ -328,21 +361,21 @@ a:hover {
 }
 
 .prose ul li::marker {
-  color: var(--text-color);
+  color: var(--color-text);
 }
 
 .prose code:not([class]) {
   padding: 0 0.4em;
-  color: var(--tag-code-color);
-  background-color: var(--tag-code-background-color);
-  border-radius: 5px;
+  color: var(--color-code-inline-fg);
+  background-color: var(--color-code-inline-bg);
+  border-radius: var(--radius-sm);
 }
 
 .prose pre {
   background: var(--color-code-block-bg);
   color: var(--color-code-block-fg);
   padding: 1rem;
-  border-radius: 0.5rem;
+  border-radius: var(--radius-md);
   overflow-x: auto;
   margin: 1rem 0;
 }
@@ -370,7 +403,7 @@ a:hover {
   width: auto;
   border-collapse: collapse;
   font-size: 0.95em;
-  line-height: 1.5;
+  line-height: var(--lh-list);
   word-break: normal;
   display: block;
   overflow: auto;
@@ -410,11 +443,11 @@ a:hover {
   position: relative;
   margin: 1.5rem 0;
   padding: 16px;
-  border-radius: 6px;
-  background: var(--message-warn-color);
-  border: 1px solid var(--message-warn-border-color);
+  border-radius: var(--radius-md);
+  background: var(--color-warning-bg);
+  border: 1px solid var(--color-warning-border);
   font-size: 14.5px;
-  line-height: 1.6;
+  line-height: var(--lh-body);
 }
 
 .message > * {
@@ -523,8 +556,8 @@ a:hover {
 /* Article Content Wrapper */
 .article-content-wrapper {
   padding: 3rem 1rem;
-  background: var(--article-area-color);
-  border-radius: 15px;
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
   border: 1px solid var(--article-area-border-color);
 }
 
@@ -537,7 +570,7 @@ a:hover {
 .article-thumbnail {
   height: auto;
   width: 100%;
-  border-radius: 5px;
+  border-radius: var(--radius-md);
   margin-bottom: 16px;
 }
 
@@ -560,7 +593,7 @@ a:hover {
 
 /* Table of Contents */
 .toc {
-  background: var(--article-area-color);
+  background: var(--color-surface);
   max-height: 600px;
   overflow-y: auto;
   max-width: var(--layout-sidebar-w);
@@ -571,7 +604,7 @@ a:hover {
   border-radius: var(--radius-md);
   border: 1px solid var(--article-area-border-color);
   padding: var(--space-2);
-  line-height: 1.6em;
+  line-height: var(--lh-list);
 }
 
 .toc > ol.toc-list {
@@ -586,7 +619,7 @@ a:hover {
   top: 10px;
   bottom: 0;
   left: 2px;
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
 }
 
 .toc ol li {
@@ -616,14 +649,14 @@ a:hover {
   height: 6px;
   width: 6px;
   left: 0;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
 }
 
 .toc ol ol ol li::before {
   height: 4px;
   width: 4px;
   left: 1px;
-  border-radius: 50%;
+  border-radius: var(--radius-full);
 }
 
 .toc a {
@@ -645,16 +678,16 @@ a:hover {
   width: 30px;
   height: 16px;
   display: inline-block;
-  border-radius: 46px;
+  border-radius: var(--radius-full);
   transition: 0.4s;
-  border: 1px solid #525457;
+  border: 1px solid var(--color-toggle-moon);
 }
 
 .dark-icon {
   position: absolute;
   width: 24px;
   height: 24px;
-  border-radius: 100%;
+  border-radius: var(--radius-full);
   top: -4px;
   transition: 0.2s;
   box-sizing: border-box;
@@ -691,7 +724,7 @@ a:hover {
 /* GitHub Embed Card */
 .github-embed-card {
   border: 1px solid var(--github-embed-border);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   overflow: hidden;
   margin: 1rem 0;
 }
@@ -782,7 +815,7 @@ a:hover {
   padding: 4px;
   background: transparent;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   cursor: pointer;
   color: var(--github-embed-meta);
   transition:
@@ -806,7 +839,7 @@ a:hover {
 
 .github-embed-check-icon {
   display: none;
-  color: #3fb950;
+  color: var(--color-success-icon);
 }
 
 .github-embed-copy.copied .github-embed-copy-icon {
@@ -826,25 +859,24 @@ a:hover {
 .code-block-filename-container {
   display: inline-block;
   padding: 6px 16px;
-  background: #2b303b;
-  border-radius: 6px 6px 0 0;
+  background: var(--color-code-tab-bg);
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
   font-size: 0.8rem;
-  font-family:
-    ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-family: var(--font-mono);
 }
 
 .code-block-filename {
-  color: #9da5b4;
+  color: var(--color-code-tab-fg);
 }
 
 .code-block-container pre {
   margin: 0;
   padding: 1rem;
-  border-radius: 0 6px 6px 6px;
+  border-radius: 0 var(--radius-md) var(--radius-md) var(--radius-md);
 }
 
 .code-block-container pre[style] {
-  background: #2b303b;
+  background: var(--color-code-tab-bg);
 }
 
 /* Generic copy button for all pre elements */
@@ -860,7 +892,7 @@ a:hover {
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  color: #9da5b4;
+  color: var(--color-code-tab-fg);
   opacity: 0.4;
   transition: opacity var(--motion-base);
 }
@@ -885,7 +917,7 @@ a:hover {
   transform: translateY(-50%);
   margin-right: 4px;
   font-size: 12px;
-  color: #3fb950;
+  color: var(--color-success-icon);
   white-space: nowrap;
   animation: float-up 0.8s ease-out forwards;
   pointer-events: none;
@@ -926,7 +958,7 @@ a:hover {
   display: block;
   position: relative;
   border: 1px solid var(--github-embed-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   overflow: visible;
   text-decoration: none;
   color: inherit;
@@ -937,7 +969,7 @@ a:hover {
 
 .link-card:hover {
   border-color: var(--github-embed-link);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-2);
 }
 
 .link-card:visited {
@@ -956,10 +988,10 @@ a:hover {
 .link-card-title {
   font-size: 0.95rem;
   font-weight: 600;
-  line-height: 1.4;
+  line-height: var(--lh-heading);
   word-break: break-word;
   overflow-wrap: break-word;
-  color: var(--text-color);
+  color: var(--color-text);
   margin: 0;
 }
 
@@ -969,7 +1001,7 @@ a:hover {
   color: var(--github-embed-meta);
   word-break: break-word;
   overflow-wrap: break-word;
-  line-height: 1.5;
+  line-height: var(--lh-heading);
   overflow: hidden;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -980,7 +1012,7 @@ a:hover {
   display: flex;
   align-items: stretch;
   overflow: hidden;
-  border-radius: 8px 8px 0 0;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
 }
 
 .link-card-image {
@@ -1011,10 +1043,9 @@ a:hover {
   margin: 6px 12px 8px;
   padding: 2px 8px;
   font-size: 0.7rem;
-  background: #fff;
+  background: var(--color-surface);
   border: 1px solid var(--github-embed-border);
-  border-radius: 12px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  border-radius: var(--radius-full);
 }
 
 [data-theme='dark'] .link-card-footer {

--- a/apps/web/src/components/ArticleCard.stories.tsx
+++ b/apps/web/src/components/ArticleCard.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import type { Article } from '@/lib/api';
+import { ArticleCard } from './ArticleCard';
+
+const baseArticle: Article = {
+  articleId: '01HX2YE5PG9N3CK1S3FZ6T2WJK',
+  title: 'shuntaka.dev のデザインシステムを skill 化した',
+  slug: 'design-system-as-skill',
+  content: '',
+  description: '',
+  type: 'tech',
+  thumbnail: 'https://res.cloudinary.com/dkerzyk09/image/upload/v1767101809/blog/og/shuntaka.png',
+  ogpUrl: '',
+  publishedAt: '2026-04-29T09:00:00.000Z',
+  createdAt: '2026-04-29T09:00:00.000Z',
+  updatedAt: '2026-04-29T09:00:00.000Z',
+};
+
+const meta = {
+  title: 'Components/ArticleCard',
+  component: ArticleCard,
+  args: {
+    userName: 'shuntaka',
+    article: baseArticle,
+  },
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof ArticleCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithThumbnail: Story = {};
+
+export const NoThumbnail: Story = {
+  args: {
+    article: { ...baseArticle, thumbnail: null },
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    article: {
+      ...baseArticle,
+      title:
+        'AWS DSQL に PostgreSQL レイヤーを乗せて Rust + SQLx で書いたバックエンドを動かすときに気をつけたこと',
+    },
+  },
+};
+
+export const NoPublishedAt: Story = {
+  args: {
+    article: { ...baseArticle, publishedAt: null },
+  },
+};

--- a/apps/web/src/components/Button.stories.tsx
+++ b/apps/web/src/components/Button.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Button } from './Button';
+
+const meta = {
+  title: 'Components/Button',
+  component: Button,
+  args: {
+    children: 'Button',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary', 'ghost', 'danger'],
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: { variant: 'primary' },
+};
+
+export const Secondary: Story = {
+  args: { variant: 'secondary' },
+};
+
+export const Ghost: Story = {
+  args: { variant: 'ghost' },
+};
+
+export const Danger: Story = {
+  args: { variant: 'danger' },
+};
+
+export const Loading: Story = {
+  args: { variant: 'primary', loading: true, children: 'Saving' },
+};
+
+export const Disabled: Story = {
+  args: { variant: 'primary', disabled: true, children: 'Disabled' },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+  ),
+};

--- a/apps/web/src/components/Callouts.stories.tsx
+++ b/apps/web/src/components/Callouts.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const Callouts = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', maxWidth: 600 }}>
+    <div className="message">
+      <p>これは warning スタイルのコールアウトです。注意喚起や補足情報に使います。</p>
+    </div>
+    <div className="message error">
+      <p>これは error スタイルのコールアウトです。アクセント色の枠で警告を示します。</p>
+    </div>
+  </div>
+);
+
+const meta = {
+  title: 'Design System/Callouts',
+  component: Callouts,
+  parameters: {
+    layout: 'padded',
+  },
+} satisfies Meta<typeof Callouts>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/web/src/components/ToggleSwitch.stories.tsx
+++ b/apps/web/src/components/ToggleSwitch.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ToggleSwitch } from './ToggleSwitch';
+
+const meta = {
+  title: 'Components/ToggleSwitch',
+  component: ToggleSwitch,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof ToggleSwitch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/apps/web/src/components/ToggleSwitch.tsx
+++ b/apps/web/src/components/ToggleSwitch.tsx
@@ -26,7 +26,14 @@ export function ToggleSwitch() {
     >
       <div
         className="toggle-label"
-        style={isDark ? { backgroundColor: '#e40067', borderColor: 'var(--header-color)' } : {}}
+        style={
+          isDark
+            ? {
+                backgroundColor: 'var(--color-accent-alt)',
+                borderColor: 'var(--color-surface-raised)',
+              }
+            : {}
+        }
       >
         <span className="dark-icon" style={{ left: isDark ? '22px' : '-6px' }}>
           <svg

--- a/apps/web/src/components/Tokens.stories.tsx
+++ b/apps/web/src/components/Tokens.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const Swatch = ({ name, value }: { name: string; value: string }) => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+    <div
+      style={{
+        width: 32,
+        height: 32,
+        borderRadius: 'var(--radius-sm)',
+        border: '1px solid var(--color-border)',
+        background: value,
+      }}
+    />
+    <code style={{ fontSize: '0.8125rem' }}>{name}</code>
+    <span style={{ fontSize: '0.8125rem', color: 'var(--color-text-muted)' }}>{value}</span>
+  </div>
+);
+
+const Colors = () => (
+  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem 2rem' }}>
+    <Swatch name="--color-bg" value="var(--color-bg)" />
+    <Swatch name="--color-surface" value="var(--color-surface)" />
+    <Swatch name="--color-surface-raised" value="var(--color-surface-raised)" />
+    <Swatch name="--color-text" value="var(--color-text)" />
+    <Swatch name="--color-border" value="var(--color-border)" />
+    <Swatch name="--color-accent" value="var(--color-accent)" />
+    <Swatch name="--color-accent-alt" value="var(--color-accent-alt)" />
+    <Swatch name="--color-link" value="var(--color-link)" />
+    <Swatch name="--color-info-border" value="var(--color-info-border)" />
+    <Swatch name="--color-success-border" value="var(--color-success-border)" />
+    <Swatch name="--color-warning-border" value="var(--color-warning-border)" />
+    <Swatch name="--color-danger-border" value="var(--color-danger-border)" />
+  </div>
+);
+
+const Radii = () => {
+  const radii = [
+    ['--radius-sm', 'var(--radius-sm)'],
+    ['--radius-md', 'var(--radius-md)'],
+    ['--radius-lg', 'var(--radius-lg)'],
+    ['--radius-full', 'var(--radius-full)'],
+  ] as const;
+  return (
+    <div style={{ display: 'flex', gap: '1.5rem' }}>
+      {radii.map(([name, value]) => (
+        <div key={name} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <div
+            style={{
+              width: 64,
+              height: 64,
+              background: 'var(--color-accent)',
+              borderRadius: value,
+            }}
+          />
+          <code style={{ fontSize: '0.75rem' }}>{name}</code>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const Typography = () => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+    <span style={{ fontSize: 'var(--fs-display)' }}>Display 32px</span>
+    <span style={{ fontSize: 'var(--fs-h1)' }}>H1 27.2px</span>
+    <span style={{ fontSize: 'var(--fs-h2)' }}>H2 24px</span>
+    <span style={{ fontSize: 'var(--fs-h3)' }}>H3 20px</span>
+    <span style={{ fontSize: 'var(--fs-body-lg)' }}>Body lg 16px</span>
+    <span style={{ fontSize: 'var(--fs-body)' }}>Body 15px</span>
+    <span style={{ fontSize: 'var(--fs-caption) ' }}>Caption 13px</span>
+  </div>
+);
+
+const meta = {
+  title: 'Design System/Tokens',
+  parameters: { layout: 'padded' },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ColorPalette: Story = { render: () => <Colors /> };
+export const RadiusScale: Story = { render: () => <Radii /> };
+export const TypeScale: Story = { render: () => <Typography /> };

--- a/bun.lock
+++ b/bun.lock
@@ -34,12 +34,16 @@
         "tocbot": "^4.36.4",
       },
       "devDependencies": {
+        "@storybook/addon-themes": "^10.3.5",
+        "@storybook/nextjs-vite": "^10.3.5",
         "@tailwindcss/postcss": "^4.2.4",
         "@types/nprogress": "^0.2.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@types/rss": "^0.0.32",
+        "storybook": "^10.3.5",
         "tailwindcss": "^4.2.4",
+        "vite": "^8.0.10",
       },
     },
     "docs": {
@@ -76,6 +80,8 @@
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@aws-cdk/asset-awscli-v1": ["@aws-cdk/asset-awscli-v1@2.2.273", "", {}, "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg=="],
@@ -151,6 +157,40 @@
     "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.19", "", { "dependencies": { "@smithy/types": "^4.14.1", "fast-xml-parser": "5.7.1", "tslib": "^2.6.2" } }, "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ=="],
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.3", "", {}, "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw=="],
+
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
     "@balena/dockerignore": ["@balena/dockerignore@1.0.2", "", {}, "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="],
 
@@ -298,7 +338,11 @@
 
     "@cspell/url": ["@cspell/url@10.0.0", "", {}, "sha512-q+0pHQ8DbqjemyaOn/mTtBRbCuKDqhnsVbZ6J9zkTsxPgMpccjy0s5oLXwomfrrxMRBH+UcbERwtUmE+SbnoIQ=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+    "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
 
@@ -402,6 +446,8 @@
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
+    "@joshwooding/vite-plugin-react-docgen-typescript": ["@joshwooding/vite-plugin-react-docgen-typescript@0.7.0", "", { "dependencies": { "glob": "^13.0.1", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "typescript": ">= 4.3.x", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["typescript"] }, "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -411,6 +457,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@next/env": ["@next/env@16.2.4", "", {}, "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw=="],
 
@@ -525,6 +573,40 @@
     "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.60.0", "", { "os": "win32", "cpu": "x64" }, "sha512-JOro4ZcfBLamJCyfURQmOQByoorgOdx3ZjAkSqnb/CyG/i+lN3KoV5LAgk5ZAW6DPq7/Cx7n23f8DuTWXTWgyQ=="],
 
     "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.17", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm" }, "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "ppc64" }, "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "s390x" }, "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.17", "", { "os": "linux", "cpu": "x64" }, "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.17", "", { "os": "none", "cpu": "arm64" }, "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.17", "", { "dependencies": { "@emnapi/core": "1.10.0", "@emnapi/runtime": "1.10.0", "@napi-rs/wasm-runtime": "^1.1.4" }, "cpu": "none" }, "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.17", "", { "os": "win32", "cpu": "x64" }, "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.17", "", {}, "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg=="],
+
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.56.0", "", { "os": "android", "cpu": "arm" }, "sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw=="],
 
@@ -662,6 +744,24 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@storybook/addon-themes": ["@storybook/addon-themes@10.3.5", "", { "dependencies": { "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.3.5" } }, "sha512-Mv+C7GuZ0MhGRx5C+rv8sCEjgYsDTLBvq68101V0s8Vwh3gKd6W9cbS31HoOeLAiIMiPPZ8C1iWudA3Oumdtlw=="],
+
+    "@storybook/builder-vite": ["@storybook/builder-vite@10.3.5", "", { "dependencies": { "@storybook/csf-plugin": "10.3.5", "ts-dedent": "^2.0.0" }, "peerDependencies": { "storybook": "^10.3.5", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-i4KwCOKbhtlbQIbhm53+Kk7bMnxa0cwTn1pxmtA/x5wm1Qu7FrrBQV0V0DNjkUqzcSKo1CjspASJV/HlY0zYlw=="],
+
+    "@storybook/csf-plugin": ["@storybook/csf-plugin@10.3.5", "", { "dependencies": { "unplugin": "^2.3.5" }, "peerDependencies": { "esbuild": "*", "rollup": "*", "storybook": "^10.3.5", "vite": "*", "webpack": "*" }, "optionalPeers": ["esbuild", "rollup", "vite", "webpack"] }, "sha512-qlEzNKxOjq86pvrbuMwiGD/bylnsXk1dg7ve0j77YFjEEchqtl7qTlrXvFdNaLA89GhW6D/EV6eOCu/eobPDgw=="],
+
+    "@storybook/global": ["@storybook/global@5.0.0", "", {}, "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ=="],
+
+    "@storybook/icons": ["@storybook/icons@2.0.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-/smVjw88yK3CKsiuR71vNgWQ9+NuY2L+e8X7IMrFjexjm6ZR8ULrV2DRkTA61aV6ryefslzHEGDInGpnNeIocg=="],
+
+    "@storybook/nextjs-vite": ["@storybook/nextjs-vite@10.3.5", "", { "dependencies": { "@storybook/builder-vite": "10.3.5", "@storybook/react": "10.3.5", "@storybook/react-vite": "10.3.5", "styled-jsx": "5.1.6", "vite-plugin-storybook-nextjs": "^3.1.9" }, "peerDependencies": { "next": "^14.1.0 || ^15.0.0 || ^16.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.3.5", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-PdgekGAnr4m/xhrvtl+ZVh68vKTfJN/AewxmqxqxSlwk0dO7B+uVGjO79WmEZwIlLvdT+3HIThTEfC1ozfpM7A=="],
+
+    "@storybook/react": ["@storybook/react@10.3.5", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/react-dom-shim": "10.3.5", "react-docgen": "^8.0.2", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.3.5", "typescript": ">= 4.9.x" }, "optionalPeers": ["typescript"] }, "sha512-tpLTLaVGoA6fLK3ReyGzZUricq7lyPaV2hLPpj5wqdXLV/LpRtAHClUpNoPDYSBjlnSjL81hMZijbkGC3mA+gw=="],
+
+    "@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.3.5", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.3.5" } }, "sha512-Gw8R7XZm0zSUH0XAuxlQJhmizsLzyD6x00KOlP6l7oW9eQHXGfxg3seNDG3WrSAcW07iP1/P422kuiriQlOv7g=="],
+
+    "@storybook/react-vite": ["@storybook/react-vite@10.3.5", "", { "dependencies": { "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0", "@rollup/pluginutils": "^5.0.2", "@storybook/builder-vite": "10.3.5", "@storybook/react": "10.3.5", "empathic": "^2.0.0", "magic-string": "^0.30.0", "react-docgen": "^8.0.0", "resolve": "^1.22.8", "tsconfig-paths": "^4.2.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.3.5", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-UB5sJHeh26bfd8sNMx2YPGYRYmErIdTRaLOT28m4bykQIa1l9IgVktsYg/geW7KsJU0lXd3oTbnUjLD+enpi3w=="],
+
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
@@ -694,6 +794,12 @@
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.4", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "postcss": "^8.5.6", "tailwindcss": "4.2.4" } }, "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
 
     "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw=="],
@@ -706,9 +812,23 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A=="],
 
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/doctrine": ["@types/doctrine@0.0.9", "", {}, "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -721,6 +841,8 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/resolve": ["@types/resolve@1.20.6", "", {}, "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ=="],
 
     "@types/rss": ["@types/rss@0.0.32", "", {}, "sha512-2oKNqKyUY4RSdvl5eZR1n2Q9yvw3XTe3mQHsFPn9alaNBxfPnbXBtGP8R0SV8pK1PrVnLul0zx7izbm5/gF5Qw=="],
 
@@ -762,15 +884,23 @@
 
     "@voidzero-dev/vite-plus-win32-x64-msvc": ["@voidzero-dev/vite-plus-win32-x64-msvc@0.1.19", "", { "os": "win32", "cpu": "x64" }, "sha512-//xUNHQnd+p4Xd4rlObAvum3DW1ugbWZ+kfaqD7biHQ9HQwHF28WSpJ3+d31vLUHj4o3DXYSA67g1Bq2d4tVgg=="],
 
+    "@webcontainer/env": ["@webcontainer/env@1.1.1", "", {}, "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
     "array-timsort": ["array-timsort@1.0.3", "", {}, "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "astral-regex": ["astral-regex@2.0.0", "", {}, "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="],
 
@@ -788,6 +918,10 @@
 
     "brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001766", "", {}, "sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA=="],
 
     "case": ["case@1.6.3", "", {}, "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ=="],
@@ -799,6 +933,8 @@
     "chalk-template": ["chalk-template@1.1.2", "", { "dependencies": { "chalk": "^5.2.0" } }, "sha512-2bxTP2yUH7AJj/VAXfcA+4IcWGdQ87HwBANLt5XxGTeomo8yG0y95N1um9i5StvhT/Bl0/2cARA5v1PpPXUxUA=="],
 
     "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
@@ -836,13 +972,29 @@
 
     "cspell-trie-lib": ["cspell-trie-lib@10.0.0", "", { "peerDependencies": { "@cspell/cspell-types": "10.0.0" } }, "sha512-R8qrMx10E/bm3Lecslwxn9XYo5NzSRK1rtandEX5n9UmEYHoBXjZELkg5+TOnV8VgrVaJSK57XtcGrbKp/4kSg=="],
 
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
+
+    "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "docs": ["docs@workspace:docs"],
+
+    "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
 
@@ -852,19 +1004,29 @@
 
     "dsql-cli": ["dsql-cli@workspace:tools/dsql-cli"],
 
+    "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
     "env-paths": ["env-paths@4.0.0", "", { "dependencies": { "is-safe-filename": "^0.1.0" } }, "sha512-pxP8eL2SwwaTRi/KHYwLYXinDs7gL3jxFcBYmEdYfZmZXbaVDvdppd0XBU8qVz03rDfKZMXg1omHCbsJjZrMsw=="],
 
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
@@ -888,31 +1050,59 @@
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "gensequence": ["gensequence@8.0.8", "", {}, "sha512-omMVniXEXpdx/vKxGnPRoO2394Otlze28TyxECbFVyoSpZ9H3EO7lemjcB12OpQJzRW4e5tt/dL1rOxry6aMHg=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ=="],
 
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
     "global-directory": ["global-directory@5.0.0", "", { "dependencies": { "ini": "6.0.0" } }, "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w=="],
+
+    "globrex": ["globrex@0.1.2", "", {}, "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "image-size": ["image-size@2.0.2", "", { "bin": { "image-size": "bin/image-size.js" } }, "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w=="],
 
     "import-fresh": ["import-fresh@4.0.0", "", {}, "sha512-Fpi660c7VPDM3fPKYovStd9IP1CPOikf6v/dGxJJMmHPcwYQIMJ4W7kO1avBYEpMqkCh+Dx3Ln6H7VYqgztLjw=="],
 
     "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
 
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
     "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
     "is-safe-filename": ["is-safe-filename@0.1.1", "", {}, "sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g=="],
+
+    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
 
@@ -966,25 +1156,43 @@
 
     "lodash.truncate": ["lodash.truncate@4.4.2", "", {}, "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="],
 
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
+
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "module-alias": ["module-alias@2.3.4", "", {}, "sha512-bOclZt8hkpuGgSSoG07PKmvzTizROilUTvLNyrMqvlC9snhs7y7GzjNWAVbISIOlhCP1T14rH1PDAV9iNyBq/w=="],
+
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "next": ["next@16.2.4", "", { "dependencies": { "@next/env": "16.2.4", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.4", "@next/swc-darwin-x64": "16.2.4", "@next/swc-linux-arm64-gnu": "16.2.4", "@next/swc-linux-arm64-musl": "16.2.4", "@next/swc-linux-x64-gnu": "16.2.4", "@next/swc-linux-x64-musl": "16.2.4", "@next/swc-win32-arm64-msvc": "16.2.4", "@next/swc-win32-x64-msvc": "16.2.4", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q=="],
 
+    "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
+
     "nprogress": ["nprogress@0.2.0", "", {}, "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
     "oxfmt": ["oxfmt@0.45.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.45.0", "@oxfmt/binding-android-arm64": "0.45.0", "@oxfmt/binding-darwin-arm64": "0.45.0", "@oxfmt/binding-darwin-x64": "0.45.0", "@oxfmt/binding-freebsd-x64": "0.45.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.45.0", "@oxfmt/binding-linux-arm-musleabihf": "0.45.0", "@oxfmt/binding-linux-arm64-gnu": "0.45.0", "@oxfmt/binding-linux-arm64-musl": "0.45.0", "@oxfmt/binding-linux-ppc64-gnu": "0.45.0", "@oxfmt/binding-linux-riscv64-gnu": "0.45.0", "@oxfmt/binding-linux-riscv64-musl": "0.45.0", "@oxfmt/binding-linux-s390x-gnu": "0.45.0", "@oxfmt/binding-linux-x64-gnu": "0.45.0", "@oxfmt/binding-linux-x64-musl": "0.45.0", "@oxfmt/binding-openharmony-arm64": "0.45.0", "@oxfmt/binding-win32-arm64-msvc": "0.45.0", "@oxfmt/binding-win32-ia32-msvc": "0.45.0", "@oxfmt/binding-win32-x64-msvc": "0.45.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-0o/COoN9fY50bjVeM7PQsNgbhndKurBIeTIcspW033OumksjJJmIVDKjAk5HMwU/GHTxSOdGDdhJ6BRzGPmsHg=="],
 
@@ -996,7 +1204,13 @@
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
 
     "pg": ["pg@8.20.0", "", { "dependencies": { "pg-connection-string": "^2.12.0", "pg-pool": "^3.13.0", "pg-protocol": "^1.13.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.3.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA=="],
 
@@ -1034,23 +1248,41 @@
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
+    "react-docgen": ["react-docgen@8.0.3", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/traverse": "^7.28.0", "@babel/types": "^7.28.2", "@types/babel__core": "^7.20.5", "@types/babel__traverse": "^7.20.7", "@types/doctrine": "^0.0.9", "@types/resolve": "^1.20.2", "doctrine": "^3.0.0", "resolve": "^1.22.1", "strip-indent": "^4.0.0" } }, "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w=="],
+
+    "react-docgen-typescript": ["react-docgen-typescript@2.4.0", "", { "peerDependencies": { "typescript": ">= 4.3.x" } }, "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg=="],
+
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-tweet": ["react-tweet@3.3.0", "", { "dependencies": { "@swc/helpers": "^0.5.3", "clsx": "^2.0.0", "swr": "^2.2.4" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-gSIG2169ZK7UH6rBzuU+j1xnQbH3IlOTLEkuGrRiJJTMgETik+h+26yHyyVKrLkzwrOaYPk4K3OtEKycqKgNLw=="],
 
+    "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
     "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
+    "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
+
     "rollup": ["rollup@4.56.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.56.0", "@rollup/rollup-android-arm64": "4.56.0", "@rollup/rollup-darwin-arm64": "4.56.0", "@rollup/rollup-darwin-x64": "4.56.0", "@rollup/rollup-freebsd-arm64": "4.56.0", "@rollup/rollup-freebsd-x64": "4.56.0", "@rollup/rollup-linux-arm-gnueabihf": "4.56.0", "@rollup/rollup-linux-arm-musleabihf": "4.56.0", "@rollup/rollup-linux-arm64-gnu": "4.56.0", "@rollup/rollup-linux-arm64-musl": "4.56.0", "@rollup/rollup-linux-loong64-gnu": "4.56.0", "@rollup/rollup-linux-loong64-musl": "4.56.0", "@rollup/rollup-linux-ppc64-gnu": "4.56.0", "@rollup/rollup-linux-ppc64-musl": "4.56.0", "@rollup/rollup-linux-riscv64-gnu": "4.56.0", "@rollup/rollup-linux-riscv64-musl": "4.56.0", "@rollup/rollup-linux-s390x-gnu": "4.56.0", "@rollup/rollup-linux-x64-gnu": "4.56.0", "@rollup/rollup-linux-x64-musl": "4.56.0", "@rollup/rollup-openbsd-x64": "4.56.0", "@rollup/rollup-openharmony-arm64": "4.56.0", "@rollup/rollup-win32-arm64-msvc": "4.56.0", "@rollup/rollup-win32-ia32-msvc": "4.56.0", "@rollup/rollup-win32-x64-gnu": "4.56.0", "@rollup/rollup-win32-x64-msvc": "4.56.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg=="],
 
     "rss": ["rss@1.2.2", "", { "dependencies": { "mime-types": "2.1.13", "xml": "1.0.1" } }, "sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -1070,6 +1302,8 @@
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
@@ -1078,13 +1312,21 @@
 
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
+    "storybook": ["storybook@10.3.5", "", { "dependencies": { "@storybook/global": "^5.0.0", "@storybook/icons": "^2.0.1", "@testing-library/jest-dom": "^6.9.1", "@testing-library/user-event": "^14.6.1", "@vitest/expect": "3.2.4", "@vitest/spy": "3.2.4", "@webcontainer/env": "^1.1.1", "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0", "open": "^10.2.0", "recast": "^0.23.5", "semver": "^7.7.3", "use-sync-external-store": "^1.5.0", "ws": "^8.18.0" }, "peerDependencies": { "prettier": "^2 || ^3" }, "optionalPeers": ["prettier"], "bin": "./dist/bin/dispatcher.js" }, "sha512-uBSZu/GZa9aEIW3QMGvdQPMZWhGxSe4dyRWU8B3/Vd47Gy/XLC7tsBxRr13txmmPOEDHZR94uLuq0H50fvuqBw=="],
+
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
+
+    "strip-indent": ["strip-indent@4.1.1", "", {}, "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA=="],
+
     "strnum": ["strnum@2.2.3", "", {}, "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "swr": ["swr@2.4.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA=="],
 
@@ -1093,6 +1335,8 @@
     "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -1104,9 +1348,17 @@
 
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
     "tocbot": ["tocbot@4.36.4", "", {}, "sha512-ffznkKnZ1NdghwR1y8hN6W7kjn4FwcXq32Z1mn35gA7jd8dt2cTVAwL3d0BXXZGPu0Hd0evverUvcYAb/7vn0g=="],
 
     "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
+
+    "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
+
+    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
+
+    "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -1120,11 +1372,19 @@
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
+    "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
-    "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
+    "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
+
+    "vite-plugin-storybook-nextjs": ["vite-plugin-storybook-nextjs@3.2.4", "", { "dependencies": { "@next/env": "16.0.0", "image-size": "^2.0.0", "magic-string": "^0.30.11", "module-alias": "^2.2.3", "ts-dedent": "^2.2.0", "vite-tsconfig-paths": "^5.1.4" }, "peerDependencies": { "next": "^14.1.0 || ^15.0.0 || ^16.0.0", "storybook": "^0.0.0-0 || ^9.0.0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-shFOJpGQsWDS1FLm8BR8b6FIQC65pFZ5a0IUFGLiBHAX1eRz0N8TOhUJN4p708zfPBLDXqWzj++ocECe8gSoMg=="],
 
     "vite-plus": ["vite-plus@0.1.19", "", { "dependencies": { "@oxc-project/types": "=0.126.0", "@voidzero-dev/vite-plus-core": "0.1.19", "@voidzero-dev/vite-plus-test": "0.1.19", "oxfmt": "=0.45.0", "oxlint": "=1.60.0", "oxlint-tsgolint": "=0.21.1" }, "optionalDependencies": { "@voidzero-dev/vite-plus-darwin-arm64": "0.1.19", "@voidzero-dev/vite-plus-darwin-x64": "0.1.19", "@voidzero-dev/vite-plus-linux-arm64-gnu": "0.1.19", "@voidzero-dev/vite-plus-linux-arm64-musl": "0.1.19", "@voidzero-dev/vite-plus-linux-x64-gnu": "0.1.19", "@voidzero-dev/vite-plus-linux-x64-musl": "0.1.19", "@voidzero-dev/vite-plus-win32-arm64-msvc": "0.1.19", "@voidzero-dev/vite-plus-win32-x64-msvc": "0.1.19" }, "bin": { "oxfmt": "bin/oxfmt", "oxlint": "bin/oxlint", "vp": "bin/vp" } }, "sha512-QWuTqkO/a8Q7I3hHnYdvwlJa7mcc6hgh99/8CHoRb27pgo+z1ux+NGYYCZPJHKVtatAtVRaQQvy4cEQBHyB87A=="],
+
+    "vite-tsconfig-paths": ["vite-tsconfig-paths@5.1.4", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" }, "optionalPeers": ["vite"] }, "sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w=="],
 
     "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
 
@@ -1132,17 +1392,23 @@
 
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
+    "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
+    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
 
     "xml": ["xml@1.0.1", "", {}, "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
@@ -1164,6 +1430,14 @@
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
+    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+
+    "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
@@ -1176,9 +1450,17 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
     "@types/pg/@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
 
     "@voidzero-dev/vite-plus-test/es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.24", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA=="],
+
+    "browserslist/caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
 
     "cspell-config-lib/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
@@ -1186,17 +1468,35 @@
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "path-scurry/lru-cache": ["lru-cache@11.3.5", "", {}, "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw=="],
+
+    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "rolldown/@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
+
     "rss/mime-types": ["mime-types@2.1.13", "", { "dependencies": { "mime-db": "~1.25.0" } }, "sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ=="],
 
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "storybook/@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "storybook/@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
 
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
-    "vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "vite/postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
-    "vite/yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
+    "vite/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "vite-plugin-storybook-nextjs/@next/env": ["@next/env@16.0.0", "", {}, "sha512-s5j2iFGp38QsG1LWRQaE2iUY3h1jc014/melHFfLdrsMJPqxqDQwWNwyQTcNoUSGZlCVZuM7t7JDMmSyRilsnA=="],
+
+    "vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "@aws-crypto/sha256-browser/@aws-sdk/types/@smithy/types": ["@smithy/types@4.12.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw=="],
 
@@ -1212,8 +1512,20 @@
 
     "rss/mime-types/mime-db": ["mime-db@1.25.0", "", {}, "sha512-5k547tI4Cy+Lddr/hdjNbBEWBwSl8EBc5aSdKvedav8DReADgWJzcYiktaRIw3GtGC1jjwldXtTzvqJZmtvC7w=="],
 
+    "storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "storybook/@vitest/expect/chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "storybook/@vitest/expect/tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "vitest/vite/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "vitest/vite/yaml": ["yaml@1.10.2", "", {}, "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="],
+
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from/@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "storybook/@vitest/expect/@vitest/utils/@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
   }
 }

--- a/cspell.json
+++ b/cspell.json
@@ -13,7 +13,8 @@
     ".legacy/**",
     "**/target/**",
     "**/__snapshots__/**",
-    "docs/source/incidents/**"
+    "docs/source/incidents/**",
+    "**/storybook-static/**"
   ],
   "language": "en",
   "words": [
@@ -21,6 +22,7 @@
     "bsky",
     "bunx",
     "apig",
+    "Classmethod",
     "dkerzyk",
     "applicationautoscaling",
     "autobuild",
@@ -49,7 +51,9 @@
     "elasticloadbalancingv",
     "elisp",
     "elbv",
+    "glassmorphism",
     "hashi",
+    "Hiragino",
     "hexdigit",
     "hozi",
     "iconify",
@@ -85,6 +89,7 @@
     "oxlintrc",
     "pgdg",
     "pgpassword",
+    "prioritises",
     "pkey",
     "plpgsql",
     "psql",

--- a/turbo.json
+++ b/turbo.json
@@ -71,6 +71,18 @@
       "inputs": ["src/**"],
       "cache": true
     },
+    "build-storybook": {
+      "dependsOn": [],
+      "inputs": ["src/**", ".storybook/**", "package.json"],
+      "outputs": ["storybook-static/**"],
+      "cache": true,
+      "passThroughEnv": ["STORYBOOK_BASE_PATH"]
+    },
+    "storybook": {
+      "dependsOn": [],
+      "cache": false,
+      "persistent": true
+    },
     "clean": {
       "cache": false
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite-plus';
 export default defineConfig({
   lint: {
     ignorePatterns: [
+      '.claude',
       '.legacy',
       '**/.venv',
       '**/cdk.out',
@@ -14,6 +15,7 @@ export default defineConfig({
       '**/out',
       '**/target',
       '**/next-env.d.ts',
+      '**/storybook-static',
     ],
     options: {
       typeAware: true,
@@ -30,6 +32,7 @@ export default defineConfig({
     ignorePatterns: [
       '**/*.json',
       '**/*.yaml',
+      '.claude',
       '.legacy',
       '**/.venv',
       '**/cdk.out',
@@ -42,6 +45,7 @@ export default defineConfig({
       '**/target',
       '**/next-env.d.ts',
       '**/node_modules/**',
+      '**/storybook-static',
     ],
     singleQuote: true,
   },


### PR DESCRIPTION
## 概要

- `.claude/skills/shuntaka-dev-design/` を全削除し、ブランドルール / Hard rules / voice を `apps/web/DESIGN.md` に復活
- `apps/web/CLAUDE.md` を新設して workspace 入り口に
- Storybook 10 + `@storybook/nextjs-vite` を `apps/web/.storybook/` に導入、本番 TSX コンポーネントの Story を 5 種追加
- `docs.yaml` ワークフローに Storybook ビルドを統合し、GitHub Pages 1 サイトに docs と Storybook を共存させる
- `globals.css` を skill のトークン体系に完全準拠（radius/line-height 統一、レガシートークン整理、ハードコード色撤去）

## 主要な変更

### デザイン仕様の再配置
- 新規: `apps/web/CLAUDE.md`、`apps/web/DESIGN.md`
- 削除: `.claude/skills/shuntaka-dev-design/`（README, SKILL.md, colors_and_type.css, assets/, fonts/, preview/, ui_kits/）
- ルート `CLAUDE.md` に apps/web/CLAUDE.md への一行誘導を追加

### Storybook 導入
- `apps/web/.storybook/{main.ts, preview.tsx, storybook.d.ts}`
- Story: `ToggleSwitch` / `Button` / `ArticleCard` / `Callouts` / `Tokens`（Color / Radius / Type）
- `STORYBOOK_BASE_PATH` 環境変数で base path 切替可能

### globals.css 同期
- token 追加: `--color-accent-alt`, `--lh-{tight,heading,body,list}`, `--fs-*`, `--fw-*`, `--font-mono`, `--color-code-tab-{bg,fg}`, `--ease-out`, `--shadow-{0..3}`, `--color-success-icon`
- radius を 4 段階（4/10/15/9999px）に統一
- line-height を 3 段階（1.4/1.7/1.9）に統一
- ハードコード色 (`#e40067`, `#3fb950`, `#2b303b`, `#9da5b4`) を変数化
- レガシートークン (`--bg-color`, `--tag-a-*`, `--message-*` 等) を semantic 名 (`--color-*`) に整理
- `link-card-footer` の静止 box-shadow 削除（pill 形状に変更）
- `ToggleSwitch.tsx` のインライン色 `#e40067` を CSS 変数化

### CI / インフラ
- `docs.yaml` に Storybook ビルドステップを追加し `docs/build/storybook/` に配置
- turbo.json に `build-storybook` / `storybook` タスク追加
- `.gitignore` / `cspell.json` / `vite.config.ts` で `storybook-static/` と `.claude` を ignore
- README.md を shields.io バッジ表記に変更（Site / dev / Docs / Storybook）

## デプロイ後の URL

| URL | 中身 |
| --- | --- |
| `https://shuntaka.dev/` | 本番ブログ |
| `https://shuntaka.tech/` | dev 環境 |
| `https://shuntaka9576.github.io/shuntaka-dev/` | Sphinx Docs |
| `https://shuntaka9576.github.io/shuntaka-dev/storybook/` | Storybook |
