### PR TITLE
feat: apps/web のフォントを Gen Interface JP に置き換え

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -29,8 +29,7 @@ shuntaka.dev は、日本人ソフトウェアエンジニアの個人テック�
 
 ### Typography
 
-- **英語:** Roboto (400/700) — `next/font/google` で読み込み、`--font-roboto` で公開。
-- **日本語:** Noto Sans JP — `--font-noto-sans-jp` で公開。（Figma 下書きは Hiragino Sans を使うが、本番は macOS 限定を避けて Noto Sans JP）
+- **本文 / 見出し:** [Gen Interface JP](https://gen.typesetting.jp/)（400 / 700）。Inter（欧文）と Noto Sans JP（和文）を合成した OFL ライセンスの UI 書体で、欧文と和文を 1 ファミリーで賄う。jsDelivr CDN（`https://cdn.jsdelivr.net/npm/gen-interface-jp@<version>/{400,700}.css`）から読み込み、Google Fonts と同じ unicode-range サブセット化により必要な woff2 だけが動的にロードされる。CSS 上は `font-family: 'Gen Interface JP', …` として参照。
 - **Mono:** システムスタック（`ui-monospace, SFMono-Regular, …`）。
 - **スケール.** 9 段階の `--fs-display` / `--fs-h1` / `--fs-h2` / `--fs-h3` / `--fs-h4` / `--fs-body-lg` / `--fs-body` / `--fs-caption` / `--fs-code`。実値は `globals.css` と Storybook `Design System/Tokens` を参照。
 - **行高.** 本文 `--lh-body`（読書体験のため大きめ）。見出し `--lh-heading`。リスト `--lh-list`。
@@ -147,8 +146,8 @@ shuntaka.dev は、日本人ソフトウェアエンジニアの個人テック�
 
 ## 留意点
 
-- **フォント.** 本番は `next/font` で Roboto + Noto Sans JP を読み込み、`--font-roboto` / `--font-noto-sans-jp` として公開する。CDN 依存はなく、`next/font` がビルド時にサブセットをセルフホスト。
-- **Hiragino Sans (Figma) → Noto Sans JP（本番）.** Figma が macOS デフォルトの Hiragino Sans を表示しているのは見た目確認用。本番は環境を問わず動く Noto Sans JP を使う。視覚的にはほぼ等価とみなす。
+- **フォント.** 本番は `apps/web/src/app/layout.tsx` の `<head>` に jsDelivr の `<link rel="stylesheet">` を 2 本（400 / 700）読み込ませている。書体名は `Gen Interface JP` で、`globals.css` の `body { font-family: 'Gen Interface JP', … }` から参照する。和文グリフの中身は Noto Sans JP（合成元）なので、CDN 障害時もシステムフォントスタックへフォールバックすれば見た目の劣化は最小限。
+- **Hiragino Sans (Figma) → Gen Interface JP（本番）.** Figma が macOS デフォルトの Hiragino Sans で表示するのは下書き確認用。本番は環境を問わず動く Gen Interface JP（和文は Noto Sans JP 合成）に統一する。
 - **Dark mode.** トークンは `<html>` の `[data-theme='dark']` で切り替わり、`ToggleSwitch` がそれを操作する。明示的な theme が保存されていないとき `prefers-color-scheme: dark` も尊重する。
 
 ---

--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -29,9 +29,21 @@ shuntaka.dev は、日本人ソフトウェアエンジニアの個人テック�
 
 ### Typography
 
-- **本文 / 見出し:** [Gen Interface JP](https://gen.typesetting.jp/)（400 / 700）。Inter（欧文）と Noto Sans JP（和文）を合成した OFL ライセンスの UI 書体で、欧文と和文を 1 ファミリーで賄う。jsDelivr CDN（`https://cdn.jsdelivr.net/npm/gen-interface-jp@<version>/{400,700}.css`）から読み込み、Google Fonts と同じ unicode-range サブセット化により必要な woff2 だけが動的にロードされる。CSS 上は `font-family: 'Gen Interface JP', …` として参照。
+- **本文 / 見出し:** [Gen Interface JP](https://gen.typesetting.jp/)（300 / 400 / 500 / 600 / 700 の 5 weight）。Inter（欧文）と Noto Sans JP（和文）を合成した OFL ライセンスの UI 書体で、欧文と和文を 1 ファミリーで賄う。jsDelivr CDN（`https://cdn.jsdelivr.net/npm/gen-interface-jp@<version>/{300,400,500,600,700}.css`）から読み込み、Google Fonts と同じ unicode-range サブセット化により必要な woff2 だけが動的にロードされる。CSS 上は `font-family: 'Gen Interface JP', …` として参照。
 - **Mono:** システムスタック（`ui-monospace, SFMono-Regular, …`）。
 - **スケール.** 9 段階の `--fs-display` / `--fs-h1` / `--fs-h2` / `--fs-h3` / `--fs-h4` / `--fs-body-lg` / `--fs-body` / `--fs-caption` / `--fs-code`。実値は `globals.css` と Storybook `Design System/Tokens` を参照。
+- **Weight ladder.** 5 段階のトークン `--fw-light` (300) / `--fw-regular` (400) / `--fw-medium` (500) / `--fw-semibold` (600) / `--fw-bold` (700)。要素ごとの割り当ては以下:
+
+  | 要素                                                                                          | Weight                |
+  | --------------------------------------------------------------------------------------------- | --------------------- |
+  | body / `.prose p` / `.prose li` / `.prose blockquote` / `.prose code` / nav タブ / 一覧の日付 | 300 (`--fw-light`)    |
+  | `.prose h3`〜`.prose h6` / 一覧の記事タイトル                                                 | 400 (`--fw-regular`)  |
+  | `.prose h1`, `.prose h2` / Button                                                             | 500 (`--fw-medium`)   |
+  | `.link-card-title` / ロゴ「shuntaka.dev」                                                     | 600 (`--fw-semibold`) |
+  | `.article-title` / `strong`                                                                   | 700 (`--fw-bold`)     |
+
+  body は Light で読み物寄り、見出しは 400–500 の細やかな段階で立ち上げる。最強調（700）は記事冒頭タイトルと `<strong>` のみで、見出しを含む他の要素は控えめに保つ。font-weight は数値リテラルではなく必ず `var(--fw-*)` または対応する Tailwind の `font-*` クラスで参照する。
+
 - **行高.** 本文 `--lh-body`（読書体験のため大きめ）。見出し `--lh-heading`。リスト `--lh-list`。
 - **`em` と `px` を混ぜない.** タイポは `rem`、レイアウトは `px` またはレイアウトトークン。
 - **強調は `<strong>` のみ.** 着色強調・全大文字・letter-spacing いじりはしない。

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -228,6 +228,7 @@ body {
     'Droid Sans',
     'Helvetica Neue',
     sans-serif;
+  font-weight: 300;
   word-wrap: break-word;
   background: var(--color-bg);
   color: var(--color-text);

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -216,8 +216,7 @@ html {
 body {
   height: 100%;
   font-family:
-    var(--font-roboto),
-    var(--font-noto-sans-jp),
+    'Gen Interface JP',
     -apple-system,
     BlinkMacSystemFont,
     'Segoe UI',

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -80,8 +80,10 @@
   --lh-body: 1.9;
 
   /* Font weight */
+  --fw-light: 300;
   --fw-regular: 400;
   --fw-medium: 500;
+  --fw-semibold: 600;
   --fw-bold: 700;
 
   /* Mono font stack (sans is supplied by next/font: --font-roboto, --font-noto-sans-jp) */
@@ -228,7 +230,7 @@ body {
     'Droid Sans',
     'Helvetica Neue',
     sans-serif;
-  font-weight: 300;
+  font-weight: var(--fw-light);
   word-wrap: break-word;
   background: var(--color-bg);
   color: var(--color-text);
@@ -256,6 +258,7 @@ a:hover {
 
 .prose h1 {
   font-size: 1.7em;
+  font-weight: var(--fw-medium);
   margin-bottom: 1.1rem;
   padding-bottom: 0.2em;
   position: relative;
@@ -268,6 +271,7 @@ a:hover {
 
 .prose h2 {
   font-size: 1.5em;
+  font-weight: var(--fw-medium);
   margin-top: 1.5em;
   margin-bottom: 0.5em;
   padding-bottom: 0.4em;
@@ -286,20 +290,24 @@ a:hover {
 
 .prose h3 {
   font-size: 1.4em;
+  font-weight: var(--fw-regular);
   margin-top: 1em;
   margin-bottom: 0.5em;
 }
 
 .prose h4 {
   font-size: 1.1em;
+  font-weight: var(--fw-regular);
 }
 
 .prose h5 {
   font-size: 1em;
+  font-weight: var(--fw-regular);
 }
 
 .prose h6 {
   font-size: 0.85em;
+  font-weight: var(--fw-regular);
 }
 
 /* Responsive heading sizes */
@@ -431,7 +439,7 @@ a:hover {
 }
 
 .prose strong {
-  font-weight: bold;
+  font-weight: var(--fw-bold);
 }
 
 .prose em {
@@ -509,6 +517,7 @@ a:hover {
 
 .article-title {
   font-size: 32px;
+  font-weight: var(--fw-bold);
   text-align: center;
 }
 
@@ -516,7 +525,7 @@ a:hover {
   .article-title {
     text-align: left;
     font-size: 1.4em;
-    font-weight: 700;
+    font-weight: var(--fw-bold);
   }
 }
 
@@ -987,7 +996,7 @@ a:hover {
 
 .link-card-title {
   font-size: 0.95rem;
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
   line-height: var(--lh-heading);
   word-break: break-word;
   overflow-wrap: break-word;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -60,6 +60,9 @@ export default function RootLayout({
       <GoogleTagManager />
       <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="anonymous" />
       <link rel="stylesheet" href={`${GEN_INTERFACE_JP_BASE}/300.css`} precedence="default" />
+      <link rel="stylesheet" href={`${GEN_INTERFACE_JP_BASE}/400.css`} precedence="default" />
+      <link rel="stylesheet" href={`${GEN_INTERFACE_JP_BASE}/500.css`} precedence="default" />
+      <link rel="stylesheet" href={`${GEN_INTERFACE_JP_BASE}/600.css`} precedence="default" />
       <link rel="stylesheet" href={`${GEN_INTERFACE_JP_BASE}/700.css`} precedence="default" />
       <body>
         <GoogleTagManagerNoscript />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { Noto_Sans_JP, Roboto } from 'next/font/google';
 import './globals.css';
 import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -9,18 +8,8 @@ import { NavigationProgressProvider } from '@/components/NavigationProgressProvi
 import { ThemeProvider } from '@/components/ThemeProvider';
 import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '@/lib/constants';
 
-const roboto = Roboto({
-  subsets: ['latin'],
-  weight: ['400', '700'],
-  display: 'swap',
-  variable: '--font-roboto',
-});
-
-const notoSansJP = Noto_Sans_JP({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-noto-sans-jp',
-});
+const GEN_INTERFACE_JP_VERSION = '0.1.1';
+const GEN_INTERFACE_JP_BASE = `https://cdn.jsdelivr.net/npm/gen-interface-jp@${GEN_INTERFACE_JP_VERSION}`;
 
 const OG_IMAGE_URL =
   'https://res.cloudinary.com/dkerzyk09/image/upload/v1767101809/blog/og/shuntaka.png';
@@ -67,12 +56,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html
-      lang="ja"
-      className={`${roboto.variable} ${notoSansJP.variable}`}
-      suppressHydrationWarning
-    >
+    <html lang="ja" suppressHydrationWarning>
       <GoogleTagManager />
+      <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="anonymous" />
+      <link rel="stylesheet" href={`${GEN_INTERFACE_JP_BASE}/400.css`} precedence="default" />
+      <link rel="stylesheet" href={`${GEN_INTERFACE_JP_BASE}/700.css`} precedence="default" />
       <body>
         <GoogleTagManagerNoscript />
         <ThemeProvider>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -59,7 +59,7 @@ export default function RootLayout({
     <html lang="ja" suppressHydrationWarning>
       <GoogleTagManager />
       <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="anonymous" />
-      <link rel="stylesheet" href={`${GEN_INTERFACE_JP_BASE}/400.css`} precedence="default" />
+      <link rel="stylesheet" href={`${GEN_INTERFACE_JP_BASE}/300.css`} precedence="default" />
       <link rel="stylesheet" href={`${GEN_INTERFACE_JP_BASE}/700.css`} precedence="default" />
       <body>
         <GoogleTagManagerNoscript />

--- a/apps/web/src/components/ArticleCard.tsx
+++ b/apps/web/src/components/ArticleCard.tsx
@@ -24,8 +24,8 @@ export const ArticleCard = memo(function ArticleCard({ article, userName }: Arti
       <article className="mb-4 block w-full border-b border-[var(--color-border-subtle)]">
         <div className="mb-2 flex justify-between">
           <div>
-            <div className="pt-2 pr-2 pb-4 text-base">{article.title}</div>
-            <div className="text-xs">{formatDate(article.publishedAt)}</div>
+            <div className="pt-2 pr-2 pb-4 text-base font-medium">{article.title}</div>
+            <div className="text-xs font-normal">{formatDate(article.publishedAt)}</div>
           </div>
           {article.thumbnail && (
             <div>

--- a/apps/web/src/components/ArticleCard.tsx
+++ b/apps/web/src/components/ArticleCard.tsx
@@ -24,8 +24,8 @@ export const ArticleCard = memo(function ArticleCard({ article, userName }: Arti
       <article className="mb-4 block w-full border-b border-[var(--color-border-subtle)]">
         <div className="mb-2 flex justify-between">
           <div>
-            <div className="pt-2 pr-2 pb-4 text-base font-medium">{article.title}</div>
-            <div className="text-xs font-normal">{formatDate(article.publishedAt)}</div>
+            <div className="pt-2 pr-2 pb-4 text-base font-normal">{article.title}</div>
+            <div className="text-xs font-light">{formatDate(article.publishedAt)}</div>
           </div>
           {article.thumbnail && (
             <div>

--- a/apps/web/src/components/BaseLayout.tsx
+++ b/apps/web/src/components/BaseLayout.tsx
@@ -31,7 +31,7 @@ export function BaseLayout({ children, showTypeHeader = false, currentTab }: Bas
       <div className="h-12 w-full bg-[var(--color-surface-raised)]">
         <div className="mx-auto flex max-w-[var(--layout-max)] items-center justify-between px-8 pt-3 pb-1 max-sm:px-4">
           <ProgressLink href="/">
-            <div className="text-2xl font-bold">shuntaka.dev</div>
+            <div className="text-2xl font-semibold">shuntaka.dev</div>
           </ProgressLink>
           <ToggleSwitch />
         </div>


### PR DESCRIPTION
## 概要

- apps/web の和文フォントを [Gen Interface JP](https://gen.typesetting.jp/) に置き換え（OFL ライセンス、Inter + Noto Sans JP を合成した UI 向け書体）
- jsDelivr CDN（`gen-interface-jp@0.1.1`）から **5 weight（300/400/500/600/700）**を `<head>` にロード。unicode-range サブセット化により、必要な woff2 だけが動的取得される
- サイト全体のタイポグラフィ階層を整理し、`--fw-*` トークンと weight ladder を確定

## Weight ladder（最終形）

| 要素 | Weight |
| --- | --- |
| body / `.prose p` / `.prose li` / `.prose blockquote` / `.prose code` / nav タブ / 一覧の日付 | **300** (`--fw-light`) |
| `.prose h3`〜`.prose h6` / 一覧の記事タイトル | **400** (`--fw-regular`) |
| `.prose h1`, `.prose h2` / Button | **500** (`--fw-medium`) |
| `.link-card-title` / ロゴ「shuntaka.dev」 | **600** (`--fw-semibold`) |
| `.article-title` / `strong` | **700** (`--fw-bold`) |

body は Light で読み物寄り、最強調（700）は記事冒頭タイトルと `<strong>` のみ。Tailwind v4 preflight が h1-h6 の browser default bold を解除する仕様にも、明示 weight を当てて対応。

## 変更ファイル

| ファイル | 変更 |
| --- | --- |
| `apps/web/src/app/layout.tsx` | `next/font/google`（Roboto / Noto Sans JP）の定義と `<html className>` を削除。`<head>` に preconnect + `<link rel="stylesheet">`（300/400/500/600/700）を追加（React 19 の `precedence="default"` で hoist 制御） |
| `apps/web/src/app/globals.css` | `:root` に `--fw-light` (300) と `--fw-semibold` (600) を追加し、`--fw-*` を 5 段階に。body の `font-family` を `'Gen Interface JP', …` に変更し `font-weight: var(--fw-light)`。`.prose h1`〜`.prose h6` / `.article-title` / `.prose strong` / `.link-card-title` の weight を `var(--fw-*)` で明示 |
| `apps/web/src/components/ArticleCard.tsx` | 一覧の記事タイトル `font-normal`、日付 `font-light` |
| `apps/web/src/components/BaseLayout.tsx` | ロゴ「shuntaka.dev」を `font-bold` → `font-semibold` |
| `apps/web/DESIGN.md` | Typography セクションを Gen Interface JP（OFL / jsDelivr CDN / 5 weight）に書き換え、Weight ladder 表を追記 |

## 設計判断

- Gen Interface JP は **Inter（欧文）+ Noto Sans JP（和文）** の合成書体なので、既存の Roboto と Noto Sans JP は両方撤去して 1 ファミリーに集約
- 公式推奨の jsDelivr CDN 直リンクを採用。サブセット化済みなので必要な woff2 だけが動的にロード（実機計測で `document.fonts.size: 260` を確認）
- body weight は 300（Light）。読み物寄りに薄く、見出しは 400-500 の細かい段階で立ち上げる
- Tailwind v4 preflight で h1-h6 が `font-weight: inherit` になっていたため、`.prose h1-h6` に明示 weight を付与
- font-weight は数値リテラルではなく必ず `var(--fw-*)` または対応する Tailwind の `font-*` クラス経由で参照

## コミット履歴

- `174d393` フォントを Gen Interface JP に置き換え（次/font/google 撤去 + jsDelivr CDN 化）
- `9eaa0d0` 本文 weight を 300 (Light) に下げる
- `d454929` 5 weight 化と ArticleCard 一覧の調整
- `d5d3dc1` タイポグラフィ階層を整え weight ladder を確定（h1-h6 / 一覧 / ロゴの最終調整）

## テストプラン

- [x] `bun run dev` で `http://localhost:3000/` と `/shuntaka/articles/<slug>` を表示し、各要素の computed `font-weight` を DevTools で確認（plan 通り 300/400/500/600/700 に解決）
- [x] DevTools Network で `gen-interface-jp@0.1.1/{300,400,500,600,700}.css` および unicode-range サブセット woff2 が 200 OK で取得されることを確認
- [x] コンソールエラー無し
- [x] `bun run lint`（vp lint + fmt + prettier + cspell）pass
- [x] `bun run type-check` pass
- [ ] Vercel Preview デプロイで本番相当の挙動を再確認（PC / スマホ）
