### PR TITLE
feat: cdk-nag (AwsSolutions) を iac/aws に導入

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "^2.253.1",
+        "cdk-nag": "^2.38.2",
         "change-case": "^5.4.4",
         "constructs": "^10.6.0",
         "zod": "^4.4.3",
@@ -876,6 +877,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001792", "", {}, "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw=="],
 
     "case": ["case@1.6.3", "", {}, "sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ=="],
+
+    "cdk-nag": ["cdk-nag@2.38.2", "", { "peerDependencies": { "aws-cdk-lib": "^2.176.0", "constructs": "^10.5.1" } }, "sha512-Ddim1r8IwAPQn95KB2owbHoU4YHveHg4PfM+k7TdcANqfVmoHem6cTFMpcIuoDM16BkQQ+xshxYxZgcAoeVKGw=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 

--- a/iac/aws/bin/cdk.ts
+++ b/iac/aws/bin/cdk.ts
@@ -6,6 +6,11 @@ import { DeployRoleStack } from '../lib/deployment/deploy-role-stack.js';
 import { OidcProviderStack } from '../lib/deployment/oidc-provider-stack.js';
 import { GlobalDnsStack } from '../lib/dns/global-dns-stack.js';
 import { TokyoCertificateStack } from '../lib/dns/tokyo-certificate-stack.js';
+import { applyNag } from '../lib/nag.js';
+import {
+  applyDeployRoleSuppressions,
+  applyMainStackSuppressions,
+} from '../lib/nag-suppressions.js';
 
 const REGIONS = {
   TOKYO: 'ap-northeast-1',
@@ -85,3 +90,7 @@ const deployRoleStack = new DeployRoleStack(
 );
 
 deployRoleStack.addDependency(oidcProviderStack);
+
+applyNag(app);
+applyMainStackSuppressions(mainStack);
+applyDeployRoleSuppressions(deployRoleStack);

--- a/iac/aws/lib/nag-suppressions.ts
+++ b/iac/aws/lib/nag-suppressions.ts
@@ -1,0 +1,73 @@
+import type * as cdk from 'aws-cdk-lib';
+import { NagSuppressions } from 'cdk-nag';
+
+export const applyDeployRoleSuppressions = (stack: cdk.Stack): void => {
+  NagSuppressions.addStackSuppressions(stack, [
+    {
+      id: 'AwsSolutions-IAM4',
+      reason:
+        'TODO(別PR): デプロイロールの AWS 管理ポリシー (CloudFormationFullAccess / IAMFullAccess / S3FullAccess) を Permissions Boundary + カスタマー管理ポリシーへ置き換える。',
+      appliesTo: [
+        'Policy::arn:<AWS::Partition>:iam::aws:policy/AWSCloudFormationFullAccess',
+        'Policy::arn:<AWS::Partition>:iam::aws:policy/IAMFullAccess',
+        'Policy::arn:<AWS::Partition>:iam::aws:policy/AmazonS3FullAccess',
+      ],
+    },
+    {
+      id: 'AwsSolutions-IAM5',
+      reason:
+        'TODO(別PR): デプロイロールのインライン IAM ステートメントの wildcard アクション / リソースをスコープ縮小する。',
+      appliesTo: [
+        'Action::lambda:*',
+        'Action::apigateway:*',
+        'Action::route53:*',
+        'Action::acm:*',
+        'Action::logs:*',
+        'Resource::*',
+      ],
+    },
+  ]);
+};
+
+export const applyMainStackSuppressions = (stack: cdk.Stack): void => {
+  NagSuppressions.addStackSuppressions(stack, [
+    {
+      id: 'AwsSolutions-IAM4',
+      reason:
+        'TODO(別PR): Lambda 実行ロールと API Gateway CloudWatchRole が CDK 既定で利用する AWS 管理ポリシーをカスタマー管理ポリシーに置き換える。',
+      appliesTo: [
+        'Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole',
+        'Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs',
+      ],
+    },
+    {
+      id: 'AwsSolutions-APIG1',
+      reason:
+        'TODO(別PR): API Gateway ステージのアクセスログを CloudWatch Logs に出力する設定を追加する。',
+    },
+    {
+      id: 'AwsSolutions-APIG2',
+      reason:
+        'TODO(別PR): API Gateway のリクエスト検証 (RequestValidator + Model) を OpenAPI 整備とセットで追加する。',
+    },
+    {
+      id: 'AwsSolutions-APIG4',
+      reason:
+        'API Gateway は {proxy+} ANY で全リクエストを Lambda にパススルーする構成のため Method 単位のオーソライザーは設定しない。書き込み系 (POST /webhooks/github) は Lambda 側で X-Hub-Signature-256 の HMAC 検証を実装済み。読み取り系 (GET /users/.../articles 等) は意図的に未認証の public エンドポイント。',
+    },
+    {
+      id: 'AwsSolutions-APIG3',
+      reason: 'TODO(別PR): API Gateway ステージに WAFv2 WebACL を associate する。',
+    },
+    {
+      id: 'AwsSolutions-APIG6',
+      reason:
+        'TODO(別PR): API Gateway 全 Method の CloudWatch Logs 出力 (deployOptions.loggingLevel) を追加する。',
+    },
+    {
+      id: 'AwsSolutions-COG4',
+      reason:
+        'Cognito User Pool による認証基盤を持たないプロジェクトのため不適合。認証が必要な書き込み系は GitHub Webhook (HMAC 検証) のみで、それ以外は public read。',
+    },
+  ]);
+};

--- a/iac/aws/lib/nag.ts
+++ b/iac/aws/lib/nag.ts
@@ -1,0 +1,7 @@
+import { Aspects } from 'aws-cdk-lib';
+import { AwsSolutionsChecks } from 'cdk-nag';
+import type { IConstruct } from 'constructs';
+
+export const applyNag = (scope: IConstruct): void => {
+  Aspects.of(scope).add(new AwsSolutionsChecks({ verbose: true, reports: true }));
+};

--- a/iac/aws/package.json
+++ b/iac/aws/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.253.1",
+    "cdk-nag": "^2.38.2",
     "change-case": "^5.4.4",
     "constructs": "^10.6.0",
     "zod": "^4.4.3"

--- a/iac/aws/test/__snapshots__/api.test.ts.snap
+++ b/iac/aws/test/__snapshots__/api.test.ts.snap
@@ -2,6 +2,51 @@
 
 exports[`MainStack > snapshot 1`] = `
 {
+  "Metadata": {
+    "cdk_nag": {
+      "rules_to_suppress": [
+        {
+          "applies_to": [
+            "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+            "Policy::arn:<AWS::Partition>:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+          ],
+          "id": "AwsSolutions-IAM4",
+          "is_reason_encoded": true,
+          "reason": "VE9ETyjliKVQUik6IExhbWJkYSDlrp/ooYzjg63jg7zjg6vjgaggQVBJIEdhdGV3YXkgQ2xvdWRXYXRjaFJvbGUg44GMIENESyDml6LlrprjgafliKnnlKjjgZnjgosgQVdTIOeuoeeQhuODneODquOCt+ODvOOCkuOCq+OCueOCv+ODnuODvOeuoeeQhuODneODquOCt+ODvOOBq+e9ruOBjeaPm+OBiOOCi+OAgg==",
+        },
+        {
+          "id": "AwsSolutions-APIG1",
+          "is_reason_encoded": true,
+          "reason": "VE9ETyjliKVQUik6IEFQSSBHYXRld2F5IOOCueODhuODvOOCuOOBruOCouOCr+OCu+OCueODreOCsOOCkiBDbG91ZFdhdGNoIExvZ3Mg44Gr5Ye65Yqb44GZ44KL6Kit5a6a44KS6L+95Yqg44GZ44KL44CC",
+        },
+        {
+          "id": "AwsSolutions-APIG2",
+          "is_reason_encoded": true,
+          "reason": "VE9ETyjliKVQUik6IEFQSSBHYXRld2F5IOOBruODquOCr+OCqOOCueODiOaknOiovCAoUmVxdWVzdFZhbGlkYXRvciArIE1vZGVsKSDjgpIgT3BlbkFQSSDmlbTlgpnjgajjgrvjg4Pjg4jjgafov73liqDjgZnjgovjgII=",
+        },
+        {
+          "id": "AwsSolutions-APIG4",
+          "is_reason_encoded": true,
+          "reason": "QVBJIEdhdGV3YXkg44GvIHtwcm94eSt9IEFOWSDjgaflhajjg6rjgq/jgqjjgrnjg4jjgpIgTGFtYmRhIOOBq+ODkeOCueOCueODq+ODvOOBmeOCi+ani+aIkOOBruOBn+OCgSBNZXRob2Qg5Y2Y5L2N44Gu44Kq44O844K944Op44Kk44K244O844Gv6Kit5a6a44GX44Gq44GE44CC5pu444GN6L6844G/57O7IChQT1NUIC93ZWJob29rcy9naXRodWIpIOOBryBMYW1iZGEg5YG044GnIFgtSHViLVNpZ25hdHVyZS0yNTYg44GuIEhNQUMg5qSc6Ki844KS5a6f6KOF5riI44G/44CC6Kqt44G/5Y+W44KK57O7IChHRVQgL3VzZXJzLy4uLi9hcnRpY2xlcyDnrYkpIOOBr+aEj+Wbs+eahOOBq+acquiqjeiovOOBriBwdWJsaWMg44Ko44Oz44OJ44Od44Kk44Oz44OI44CC",
+        },
+        {
+          "id": "AwsSolutions-APIG3",
+          "is_reason_encoded": true,
+          "reason": "VE9ETyjliKVQUik6IEFQSSBHYXRld2F5IOOCueODhuODvOOCuOOBqyBXQUZ2MiBXZWJBQ0wg44KSIGFzc29jaWF0ZSDjgZnjgovjgII=",
+        },
+        {
+          "id": "AwsSolutions-APIG6",
+          "is_reason_encoded": true,
+          "reason": "VE9ETyjliKVQUik6IEFQSSBHYXRld2F5IOWFqCBNZXRob2Qg44GuIENsb3VkV2F0Y2ggTG9ncyDlh7rlipsgKGRlcGxveU9wdGlvbnMubG9nZ2luZ0xldmVsKSDjgpLov73liqDjgZnjgovjgII=",
+        },
+        {
+          "id": "AwsSolutions-COG4",
+          "is_reason_encoded": true,
+          "reason": "Q29nbml0byBVc2VyIFBvb2wg44Gr44KI44KL6KqN6Ki85Z+655uk44KS5oyB44Gf44Gq44GE44OX44Ot44K444Kn44Kv44OI44Gu44Gf44KB5LiN6YGp5ZCI44CC6KqN6Ki844GM5b+F6KaB44Gq5pu444GN6L6844G/57O744GvIEdpdEh1YiBXZWJob29rIChITUFDIOaknOiovCkg44Gu44G/44Gn44CB44Gd44KM5Lul5aSW44GvIHB1YmxpYyByZWFk44CC",
+        },
+      ],
+    },
+  },
   "Outputs": {
     "BlogAPIRestApiEndpoint9DCAF3F6": {
       "Value": {
@@ -414,6 +459,17 @@ exports[`MainStack > snapshot 1`] = `
         "BlogAPIWebApiLambdaServiceRoleDefaultPolicyB2A8DC71",
         "BlogAPIWebApiLambdaServiceRole5C77D6FD",
       ],
+      "Metadata": {
+        "cdk_nag": {
+          "rules_to_suppress": [
+            {
+              "id": "AwsSolutions-L1",
+              "is_reason_encoded": true,
+              "reason": "44OG44K544OI55So44GrIERvY2tlckltYWdlRnVuY3Rpb24g44KS44Oi44OD44Kv44GX44GmIE5vZGUuanMg44Op44Oz44K/44Kk44Og6Zai5pWw44Gr5beu44GX5pu/44GI44Gm44GE44KL44CC5pys55Wq44GvIERvY2tlciDjgqTjg6Hjg7zjgrjjga7jgZ/jgoHpnZ7oqbLlvZPjgII=",
+            },
+          ],
+        },
+      },
       "Properties": {
         "Architectures": [
           "arm64",

--- a/iac/aws/test/__snapshots__/deployment.test.ts.snap
+++ b/iac/aws/test/__snapshots__/deployment.test.ts.snap
@@ -2,6 +2,35 @@
 
 exports[`DeployRoleStack > snapshot 1`] = `
 {
+  "Metadata": {
+    "cdk_nag": {
+      "rules_to_suppress": [
+        {
+          "applies_to": [
+            "Policy::arn:<AWS::Partition>:iam::aws:policy/AWSCloudFormationFullAccess",
+            "Policy::arn:<AWS::Partition>:iam::aws:policy/IAMFullAccess",
+            "Policy::arn:<AWS::Partition>:iam::aws:policy/AmazonS3FullAccess",
+          ],
+          "id": "AwsSolutions-IAM4",
+          "is_reason_encoded": true,
+          "reason": "VE9ETyjliKVQUik6IOODh+ODl+ODreOCpOODreODvOODq+OBriBBV1Mg566h55CG44Od44Oq44K344O8IChDbG91ZEZvcm1hdGlvbkZ1bGxBY2Nlc3MgLyBJQU1GdWxsQWNjZXNzIC8gUzNGdWxsQWNjZXNzKSDjgpIgUGVybWlzc2lvbnMgQm91bmRhcnkgKyDjgqvjgrnjgr/jg57jg7znrqHnkIbjg53jg6rjgrfjg7zjgbjnva7jgY3mj5vjgYjjgovjgII=",
+        },
+        {
+          "applies_to": [
+            "Action::lambda:*",
+            "Action::apigateway:*",
+            "Action::route53:*",
+            "Action::acm:*",
+            "Action::logs:*",
+            "Resource::*",
+          ],
+          "id": "AwsSolutions-IAM5",
+          "is_reason_encoded": true,
+          "reason": "VE9ETyjliKVQUik6IOODh+ODl+ODreOCpOODreODvOODq+OBruOCpOODs+ODqeOCpOODsyBJQU0g44K544OG44O844OI44Oh44Oz44OI44GuIHdpbGRjYXJkIOOCouOCr+OCt+ODp+ODsyAvIOODquOCveODvOOCueOCkuOCueOCs+ODvOODl+e4ruWwj+OBmeOCi+OAgg==",
+        },
+      ],
+    },
+  },
   "Parameters": {
     "BootstrapVersion": {
       "Default": "/cdk-bootstrap/hnb659fds/version",

--- a/iac/aws/test/api.test.ts
+++ b/iac/aws/test/api.test.ts
@@ -1,8 +1,11 @@
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import type * as lambda from 'aws-cdk-lib/aws-lambda';
+import { NagSuppressions } from 'cdk-nag';
 import type { Construct } from 'constructs';
 import { MainStack } from '../lib/api/main-stack.js';
+import { applyNag } from '../lib/nag.js';
+import { applyMainStackSuppressions } from '../lib/nag-suppressions.js';
 
 // DockerImageFunctionをモックしてDockerビルドをスキップ
 vi.mock('aws-cdk-lib/aws-lambda', async (importOriginal) => {
@@ -65,6 +68,28 @@ describe('MainStack', () => {
         region: 'ap-northeast-1',
       },
     });
+
+    applyNag(stack);
+    applyMainStackSuppressions(stack);
+    // テスト用に DockerImageFunction を NODEJS_20_X の Function に差し替えているため
+    // L1 (latest runtime) ルールが発火する。本番は Docker イメージなので該当しない。
+    NagSuppressions.addResourceSuppressionsByPath(
+      stack,
+      '/TestMainStack/BlogAPI/WebApiLambda/Resource',
+      [
+        {
+          id: 'AwsSolutions-L1',
+          reason:
+            'テスト用に DockerImageFunction をモックして Node.js ランタイム関数に差し替えている。本番は Docker イメージのため非該当。',
+        },
+      ],
+    );
+
+    const nagErrors = Annotations.fromStack(stack).findError(
+      '*',
+      Match.stringLikeRegexp('AwsSolutions-.*'),
+    );
+    expect(nagErrors).toEqual([]);
 
     const template = Template.fromStack(stack);
     expect(template.toJSON()).toMatchSnapshot();

--- a/iac/aws/test/deployment.test.ts
+++ b/iac/aws/test/deployment.test.ts
@@ -1,7 +1,17 @@
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import { DeployRoleStack } from '../lib/deployment/deploy-role-stack.js';
 import { OidcProviderStack } from '../lib/deployment/oidc-provider-stack.js';
+import { applyNag } from '../lib/nag.js';
+import { applyDeployRoleSuppressions } from '../lib/nag-suppressions.js';
+
+const expectNoNagErrors = (stack: cdk.Stack): void => {
+  const errors = Annotations.fromStack(stack).findError(
+    '*',
+    Match.stringLikeRegexp('AwsSolutions-.*'),
+  );
+  expect(errors).toEqual([]);
+};
 
 describe('OidcProviderStack', () => {
   it('snapshot', () => {
@@ -13,6 +23,9 @@ describe('OidcProviderStack', () => {
         region: 'ap-northeast-1',
       },
     });
+
+    applyNag(stack);
+    expectNoNagErrors(stack);
 
     const template = Template.fromStack(stack);
     expect(template.toJSON()).toMatchSnapshot();
@@ -33,6 +46,10 @@ describe('DeployRoleStack', () => {
         region: 'ap-northeast-1',
       },
     });
+
+    applyNag(stack);
+    applyDeployRoleSuppressions(stack);
+    expectNoNagErrors(stack);
 
     const template = Template.fromStack(stack);
     expect(template.toJSON()).toMatchSnapshot();

--- a/iac/aws/test/dns.test.ts
+++ b/iac/aws/test/dns.test.ts
@@ -1,7 +1,16 @@
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import { GlobalDnsStack } from '../lib/dns/global-dns-stack.js';
 import { TokyoCertificateStack } from '../lib/dns/tokyo-certificate-stack.js';
+import { applyNag } from '../lib/nag.js';
+
+const expectNoNagErrors = (stack: cdk.Stack): void => {
+  const errors = Annotations.fromStack(stack).findError(
+    '*',
+    Match.stringLikeRegexp('AwsSolutions-.*'),
+  );
+  expect(errors).toEqual([]);
+};
 
 describe('GlobalDnsStack', () => {
   it('snapshot', () => {
@@ -14,6 +23,9 @@ describe('GlobalDnsStack', () => {
         region: 'ap-northeast-1',
       },
     });
+
+    applyNag(stack);
+    expectNoNagErrors(stack);
 
     const template = Template.fromStack(stack);
     expect(template.toJSON()).toMatchSnapshot();
@@ -32,6 +44,9 @@ describe('TokyoCertificateStack', () => {
         region: 'ap-northeast-1',
       },
     });
+
+    applyNag(stack);
+    expectNoNagErrors(stack);
 
     const template = Template.fromStack(stack);
     expect(template.toJSON()).toMatchSnapshot();


### PR DESCRIPTION
## Summary

- `iac/aws` に cdk-nag (`AwsSolutionsChecks`) を導入し、CDK のセキュリティ・運用上の典型的な指摘を機械的に検出できるようにした
- 既知の指摘（DeployRole の wildcard 権限、API Gateway のログ・WAF 未設定 等）は実際の発火を確認したうえで `lib/nag-suppressions.ts` に集約し、reason に「別 PR 対応」TODO を明記
- 実装修正は本 PR では行わない。検出基盤のみを整備し、リグレッションが起きた際に既存の vitest スナップショットテストの中で CI が落ちる体制にする

## 変更内容

### 新規ファイル

- `iac/aws/lib/nag.ts`
  - `applyNag(scope)` を export。`Aspects.of(scope).add(new AwsSolutionsChecks({ verbose: true, reports: true }))` を呼ぶだけの薄いヘルパー
  - `bin/cdk.ts` と各テストの両方から同じものを呼ぶことで synth 時とテスト時で Aspects を一致させる
- `iac/aws/lib/nag-suppressions.ts`
  - `applyDeployRoleSuppressions` / `applyMainStackSuppressions` を export
  - 抑止理由（reason）には「別 PR で対応する TODO」または「恒久的に suppress する根拠」を日本語で記載

### 既存ファイルの変更

- `iac/aws/bin/cdk.ts`
  - スタック生成後に `applyNag(app)` と各 suppression を呼ぶ
- `iac/aws/test/{api,dns,deployment}.test.ts`
  - `applyNag(stack)` 後に `Annotations.fromStack(stack).findError('*', /AwsSolutions-.*/)` が空であることを assert
  - `api.test.ts` のみ、`DockerImageFunction` のテストモック起因で発火する `AwsSolutions-L1` をリソースパス指定で suppress
- `iac/aws/test/__snapshots__/{api,deployment}.test.ts.snap`
  - suppression が CFN テンプレに `Metadata.cdk_nag.rules_to_suppress` として埋め込まれる分、スナップショットを再生成
- `iac/aws/package.json` / `bun.lock`
  - `cdk-nag@^2.38.2` を追加

## 実発火を確認した上で suppress した rule

### MainStack

| Rule | 種別 | 抑止理由 |
|---|---|---|
| `AwsSolutions-IAM4` (`AWSLambdaBasicExecutionRole` / `AmazonAPIGatewayPushToCloudWatchLogs`) | TODO | CDK 既定の AWS 管理ポリシー利用。カスタマー管理ポリシーへ置換予定 |
| `AwsSolutions-APIG1` | TODO | アクセスログ未設定 |
| `AwsSolutions-APIG2` | TODO | リクエスト検証未設定 |
| `AwsSolutions-APIG3` | TODO | WAFv2 未関連付け |
| `AwsSolutions-APIG4` | 恒久 | `{proxy+}` ANY で Lambda パススルー、書き込み系は HMAC 検証、読み取り系は public read |
| `AwsSolutions-APIG6` | TODO | Method 単位の CloudWatch Logs 出力未設定 |
| `AwsSolutions-COG4` | 恒久 | Cognito User Pool を持たないプロジェクト |

### DeployRoleStack

| Rule | 種別 | 抑止理由 |
|---|---|---|
| `AwsSolutions-IAM4` (`AWSCloudFormationFullAccess` / `IAMFullAccess` / `AmazonS3FullAccess`) | TODO | Permissions Boundary + カスタマー管理ポリシーへ置換予定 |
| `AwsSolutions-IAM5` (`Action::lambda:*` / `apigateway:*` / `route53:*` / `acm:*` / `logs:*` / `Resource::*`) | TODO | wildcard アクション/リソースをスコープ縮小予定 |

### test 固有

- `AwsSolutions-L1` — `api.test.ts` のみ。テストの `DockerImageFunction` モックが NODEJS_20_X 関数になるため発火するが本番は Docker 関数なので非該当


## やらないこと（Out of Scope）

- DeployRole / API Gateway / DSQL / Lambda の **実装修正**（別 PR）
- NIST / HIPAA / PCI パックの導入
- CI への `cdk synth --strict` 専用ステップ追加
