### PR TITLE
chore: gh-infra のラベル管理を authoritative 化して既定ラベルを整理

### DIFF
--- a/.github/infra.yaml
+++ b/.github/infra.yaml
@@ -3,6 +3,8 @@ kind: Repository
 metadata:
   name: shuntaka-dev
   owner: shuntaka9576
+reconcile:
+  labels: authoritative
 spec:
   description: https://shuntaka.dev blog source
   homepage: https://shuntaka.dev
@@ -12,27 +14,6 @@ spec:
     - name: bug
       description: Something isn't working
       color: d73a4a
-    - name: duplicate
-      description: This issue or pull request already exists
-      color: cfd3d7
-    - name: enhancement
-      description: New feature or request
-      color: a2eeef
-    - name: good first issue
-      description: Good for newcomers
-      color: 7057ff
-    - name: help wanted
-      description: Extra attention is needed
-      color: 008672
-    - name: invalid
-      description: This doesn't seem right
-      color: e4e669
-    - name: question
-      description: Further information is requested
-      color: d876e3
-    - name: wontfix
-      description: This will not be worked on
-      color: ffffff
   features:
     issues: true
     projects: true


### PR DESCRIPTION
## 概要

- `reconcile.labels: authoritative` を宣言し、YAML に書かれていないラベルを削除対象として扱う
- 未使用の GitHub 既定ラベル 7 件をマニフェストから消し込み、`bug` のみ管理対象として残す

## 変更詳細

- `.github/infra.yaml`
  - `metadata` 直下に `reconcile.labels: authoritative` を追加
  - `spec.labels` から `duplicate` / `enhancement` / `good first issue` / `help wanted` / `invalid` / `question` / `wontfix` を削除

## 適用後の挙動

`gh infra plan` で上記 7 ラベルが destroy 対象として表示される。`gh infra apply` 実行により GitHub 側からも削除される（該当ラベルが付いた既存 issue/PR からは付与が外れる）。


