### PR TITLE
fix: ダークモードでトグルノブが左端に張り付く問題を修正

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -688,6 +688,7 @@ a:hover {
   width: 42px;
   height: 16px;
   position: relative;
+  cursor: pointer;
 }
 
 .toggle-label {
@@ -699,14 +700,24 @@ a:hover {
   border: 1px solid var(--color-toggle-moon);
 }
 
+[data-theme='dark'] .toggle-label {
+  background-color: var(--color-accent-alt);
+  border-color: var(--color-surface-raised);
+}
+
 .dark-icon {
   position: absolute;
   width: 24px;
   height: 24px;
   border-radius: var(--radius-full);
   top: -4px;
+  left: -6px;
   transition: 0.2s;
   box-sizing: border-box;
+}
+
+[data-theme='dark'] .dark-icon {
+  left: 22px;
 }
 
 /* NProgress */

--- a/apps/web/src/components/ToggleSwitch.tsx
+++ b/apps/web/src/components/ToggleSwitch.tsx
@@ -18,26 +18,10 @@ export function ToggleSwitch() {
       onClick={handleClick}
       aria-label={isDark ? 'ライトモードに切り替え' : 'ダークモードに切り替え'}
       aria-pressed={isDark}
-      style={{ cursor: 'pointer' }}
       suppressHydrationWarning
     >
-      <div
-        className="toggle-label"
-        style={
-          isDark
-            ? {
-                backgroundColor: 'var(--color-accent-alt)',
-                borderColor: 'var(--color-surface-raised)',
-              }
-            : {}
-        }
-        suppressHydrationWarning
-      >
-        <span
-          className="dark-icon"
-          style={{ left: isDark ? '22px' : '-6px' }}
-          suppressHydrationWarning
-        >
+      <div className="toggle-label">
+        <span className="dark-icon">
           <svg
             width="24"
             height="24"


### PR DESCRIPTION
## 概要

- ハードリロード時に dark モードでもトグルのノブが左端に張り付いて動かなくなる問題を修正
- ノブ位置・ラベル色を React state ベースのインライン style から CSS の `[data-theme='dark']` セレクタに移管
- `ToggleSwitch` から不要な `suppressHydrationWarning` を撤去（`button` のみ残置）

## 原因

ダークモード FOUC 修正 (#397) で `ToggleSwitch` がインライン style + `suppressHydrationWarning` 構成になっていた。React 19 では `suppressHydrationWarning` を付けた要素の属性差分はハイドレーション時に更新されないため、SSR の light 状態の `style` 属性が残り、ノブが左に固まっていた。

CSS `[data-theme]` 経由に移すことで、`<head>` の boot script が `data-theme` をセットした時点で正しい位置に描画される。

## 変更内容

### `apps/web/src/app/globals.css`

- `.toggle-switch` に `cursor: pointer` を追加（インライン style から移管）
- `.dark-icon` のデフォルト位置として `left: -6px` を追加（light モード時のノブ位置）
- `[data-theme='dark'] .toggle-label` を追加（背景色・ボーダー色のダーク版）
- `[data-theme='dark'] .dark-icon` を追加（`left: 22px` でノブを右側へ）

### `apps/web/src/components/ToggleSwitch.tsx`

- `button` の `style={{ cursor: 'pointer' }}` を撤去
- `.toggle-label` のインライン style（`backgroundColor` / `borderColor`）と `suppressHydrationWarning` を撤去
- `.dark-icon` のインライン style（`left`）と `suppressHydrationWarning` を撤去
- `button` の `suppressHydrationWarning` は `aria-label` / `aria-pressed` の差分対策として残置


