### PR TITLE
ci: Renovate 同期コミットを GitHub App トークンで push する

### DIFF
--- a/.github/workflows/renovate-apm-update.yaml
+++ b/.github/workflows/renovate-apm-update.yaml
@@ -17,12 +17,23 @@ jobs:
     if: github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    permissions:
-      contents: write # apm.lock.yaml の同期コミットを PR ブランチへ push するため
+    permissions: {}
     env:
       APM_VERSION: 0.13.0
       APM_SHA256: ed02b1103ef4bc49559a81f7e109b424a49d95cf978515ad224e5eeb701b1f8a
     steps:
+      # GITHUB_TOKEN で push すると後続ワークフローがトリガーされない仕様を回避するため、
+      # GitHub App トークンを発行してそれで push する
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+          repositories: |
+            shuntaka-dev
+          permission-contents: write
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
@@ -46,7 +57,7 @@ jobs:
 
       - name: Commit apm.lock.yaml
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/renovate-apm-update.yaml
+++ b/.github/workflows/renovate-apm-update.yaml
@@ -28,8 +28,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
-          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+          app-id: ${{ vars.SHUNTAKA_DEV_UTILS_APP_ID }}
+          private-key: ${{ secrets.SHUNTAKA_DEV_UTILS_PRIVATE_KEY }}
           repositories: |
             shuntaka-dev
           permission-contents: write

--- a/.github/workflows/renovate-cargo-update.yaml
+++ b/.github/workflows/renovate-cargo-update.yaml
@@ -26,8 +26,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
-          app-id: ${{ secrets.RENOVATE_APP_ID }}
-          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+          app-id: ${{ vars.SHUNTAKA_DEV_UTILS_APP_ID }}
+          private-key: ${{ secrets.SHUNTAKA_DEV_UTILS_PRIVATE_KEY }}
           repositories: |
             shuntaka-dev
           permission-contents: write

--- a/.github/workflows/renovate-cargo-update.yaml
+++ b/.github/workflows/renovate-cargo-update.yaml
@@ -18,9 +18,20 @@ jobs:
     if: github.event.pull_request.user.login == 'renovate[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    permissions:
-      contents: write # Cargo.lock の更新コミットを PR ブランチへ push するため
+    permissions: {}
     steps:
+      # GITHUB_TOKEN で push すると後続ワークフローがトリガーされない仕様を回避するため、
+      # GitHub App トークンを発行してそれで push する
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_PRIVATE_KEY }}
+          repositories: |
+            shuntaka-dev
+          permission-contents: write
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.head_ref }}
@@ -40,7 +51,7 @@ jobs:
 
       - name: Commit Cargo.lock
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/docs/source/01_development.md
+++ b/docs/source/01_development.md
@@ -210,6 +210,26 @@ bun run convert --input ../../.legacy/dynamo/backup_prd-Article_20251229-083009.
 bun run migrate --endpoint $DSQL_CLUSTER_ENDPOINT
 ```
 
+### GitHub App (Utils)
+
+Renovate のワークフロー（`renovate-apm-update.yaml` / `renovate-cargo-update.yaml`）が lockfile 同期コミットを push した際、後続のチェック（CI / zizmor）が再トリガーされるよう、`GITHUB_TOKEN` ではなく App トークンで push するための GitHub App。
+
+1. GitHub Settings → Developer settings → GitHub Apps → New GitHub App
+2. 設定値:
+   - GitHub App name: `shuntaka-dev-utils`（任意）
+   - Webhook: Active のチェックを外す
+   - Repository permissions → Contents: Read and write
+3. 作成後、App ID を控える
+4. Private key を生成してダウンロード
+5. `shuntaka9576/shuntaka-dev` にインストール
+
+リポジトリの Variables / Secrets に登録。
+
+```bash
+gh variable set SHUNTAKA_DEV_UTILS_APP_ID --body "<App ID>"
+gh secret set SHUNTAKA_DEV_UTILS_PRIVATE_KEY < path/to/private-key.pem
+```
+
 ### ライブラリ更新
 
 依存関係の自動アップデートPRを作成するためのRenovateを利用。以下の設定で導入が可能。


### PR DESCRIPTION
## Summary

- Renovate の lockfile 同期コミット (`apm.lock.yaml` / `Cargo.lock`) を `GITHUB_TOKEN` ではなく **GitHub App トークン** で push するように変更
- 背景: `GITHUB_TOKEN` による push は GitHub 仕様で後続ワークフローをトリガーしないため、同期コミット後の最新 HEAD に対して必須チェック (CI / zizmor) が走らず、PR が BLOCKED になっていた（例: #386）
- App トークンは `actions/create-github-app-token` で発行し、`permission-contents: write` のみに絞る（zizmor の `github-app` 監査もクリア）

## Changes

- `.github/workflows/renovate-apm-update.yaml`
  - `permissions: contents: write` を job レベルから除去し、`permissions: {}` に
  - `actions/create-github-app-token@d72941d` を追加 (`secrets.RENOVATE_APP_ID`, `secrets.RENOVATE_PRIVATE_KEY`, `repositories: shuntaka-dev`, `permission-contents: write`)
  - `Commit apm.lock.yaml` ステップの `GH_TOKEN` を `steps.app-token.outputs.token` に切り替え
- `.github/workflows/renovate-cargo-update.yaml`
  - 同じ手当てを `Cargo.lock` 同期側にも適用

## Prerequisites

- リポジトリ secrets に登録済み
  - `RENOVATE_APP_ID`
  - `RENOVATE_PRIVATE_KEY`
- GitHub App はこのリポジトリにインストール済みで、`Contents: Write` 権限を保持していること


