### PR TITLE
ci: CI ワークフローを pull_request トリガー基盤に変更

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: [preview]
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- CI ワークフローのトリガーを `on: [push]` から `pull_request` + `push: branches:[preview]` 構成に変更
- 背景: `renovate-apm-update` / `renovate-cargo-update` が App トークンで lockfile 同期コミットを push する際、同一ブランチへ連続 push が走るため CI の concurrency (`cancel-in-progress: true`) と競合し、最新コミットの CI run が race で CANCELLED される事象が #386 で再現していた
- 解決: PR ベース 1 系統に集約。任意ブランチへの単体 push では CI が走らず、`pull_request: opened` / `synchronize` が発火したときだけ CI が起動するため、App トークン経由の同期 push でも単一 run に集約され race が起きない

## Changes

- `.github/workflows/ci.yaml`
  - `on: [push]` を以下に変更
    ```yaml
    on:
      push:
        branches: [preview]
      pull_request:
    ```
  - これにより:
    - 任意ブランチへの push 単体 (PR なし) では CI は走らない
    - PR 作成時 / PR ブランチへの push (synchronize) で CI が走る
    - `preview` への直接 push (マージコミット / hotfix 用) でも CI が走る

## Test plan

- [ ] このPR自体で `pull_request: opened` トリガーから CI が起動することを確認
- [ ] マージ後、Renovate (`apm.yml` / `Cargo.toml`) PR で lockfile 同期 push 後の synchronize から CI / zizmor が一発で揃ってマージ可能になる (#386 の再現が解消)
- [ ] `preview` への直接 push でも CI が走る
