### PR TITLE
docs: sqlx 0.9 対応の upstream issue をサーベイで追跡

### DIFF
--- a/docs/source/survey/2026-05-23-aurora-dsql-sqlx-0.9-support.md
+++ b/docs/source/survey/2026-05-23-aurora-dsql-sqlx-0.9-support.md
@@ -1,0 +1,22 @@
+# aurora-dsql-sqlx-connector の sqlx 0.9 対応トラッキング
+
+- 対象 issue: <https://github.com/awslabs/aurora-dsql-connectors/issues/518>
+- 起票日: 2026-05-23
+- ステータス: open（メンテからのレスポンス待ち）
+
+## ローカルへの影響
+
+- Renovate PR [#410](https://github.com/shuntaka9576/shuntaka-dev/pull/410) (sqlx 0.8.6 → 0.9.0) がブロック中。upstream 対応まで再オープン不可
+- `apps/blog-api/adapter` が `aurora-dsql-sqlx-connector` 経由で sqlx 0.8 系に固定される
+
+## 暫定対応の方針
+
+- PR #410 はクローズして 0.8 系を維持
+- `renovate.json` で sqlx の major-equivalent bump を抑止する packageRule を追加（未対応）
+
+## 次のアクション
+
+- [ ] メンテのレスポンスを待つ
+- [ ] レスポンスなしが 2〜3 週間続いたら fork から draft PR を出す
+- [ ] upstream 対応リリース後、sqlx を 0.9 に上げる PR を投げ直す
+- [ ] Renovate の suppress ルール解除

--- a/docs/source/survey/index.md
+++ b/docs/source/survey/index.md
@@ -3,6 +3,7 @@
 ```{toctree}
 :maxdepth: 1
 
+2026-05-23-aurora-dsql-sqlx-0.9-support
 2026-05-21-apps-web-modern-web-improvements
 2026-05-11-vercel-labs-skills-vs-apm
 2026-05-09-aws-agent-toolkit-skills-survey


### PR DESCRIPTION
## 概要

- `aurora-dsql-sqlx-connector` の sqlx 0.9 対応を待つ間、upstream issue ([awslabs/aurora-dsql-connectors#518](https://github.com/awslabs/aurora-dsql-connectors/issues/518)) の進捗とローカル影響を追跡するサーベイメモを追加
- 技術的な詳細は upstream issue 側に集約し、本リポジトリ側は「何が止まっていて、解決後に何をやるべきか」の追跡情報のみを保持

## 変更内容

- `docs/source/survey/2026-05-23-aurora-dsql-sqlx-0.9-support.md`: 新規追加
  - 対象 issue / ステータス
  - ローカルへの影響 (Renovate PR #410 のブロック、`apps/blog-api/adapter` の sqlx 0.8 系固定)
  - 暫定対応の方針 (PR #410 クローズ + Renovate suppress rule 追加予定)
  - 次のアクション (チェックボックス4項目)
- `docs/source/survey/index.md`: toctree に新エントリを追加

## 背景

PR #410 (Renovate の sqlx 0.8.6 → 0.9.0 bump) が CI 失敗。原因は `aurora-dsql-sqlx-connector` v0.2.0 が `sqlx ^0.8` に pin されていて、ワークスペースで sqlx 0.9 にバンプすると sqlx-core が 0.8 と 0.9 で同居して型不整合になるため。

upstream に sqlx 0.9 対応の issue を起票済み (#518)。レスポンスがない場合は draft PR を出す方針。

## Test plan

- [x] `docs/source/survey/` 配下のファイルが追加されている
- [x] `index.md` の toctree から新エントリが参照されている
- [ ] Sphinx ビルドが通る (CI で確認)
