### PR TITLE
fix: react-tweet の描画エラーで記事ページが落ちる問題を ErrorBoundary でガード

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1146,3 +1146,18 @@ a:hover {
   --tweet-bg-color: var(--card-bg);
   --tweet-border: 1px solid var(--github-embed-border);
 }
+
+.tweet-fallback {
+  display: inline-block;
+  padding: 8px 14px;
+  border: 1px solid var(--color-border);
+  border-radius: 9999px;
+  color: var(--color-link);
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+
+.tweet-fallback:hover {
+  color: var(--color-link-hover);
+  border-color: var(--color-link-hover);
+}

--- a/apps/web/src/components/ArticleContent.tsx
+++ b/apps/web/src/components/ArticleContent.tsx
@@ -2,8 +2,8 @@
 
 import type { ComponentProps } from 'react';
 import { useEffect, useMemo, useRef } from 'react';
-import { Tweet } from 'react-tweet';
 import { useNavigationProgress } from '@/components/NavigationProgressProvider';
+import { SafeTweet } from '@/components/SafeTweet';
 
 function AvatarImg({ src, ...props }: ComponentProps<'img'>) {
   const hiResSrc = typeof src === 'string' ? src.replace('_normal.', '_bigger.') : src;
@@ -160,7 +160,7 @@ export function ArticleContent({ html }: ArticleContentProps) {
           <div key={i} dangerouslySetInnerHTML={{ __html: part.content }} />
         ) : (
           <div key={i} className="tweet-container">
-            <Tweet id={part.id} components={{ AvatarImg }} />
+            <SafeTweet id={part.id} components={{ AvatarImg }} />
           </div>
         ),
       )}

--- a/apps/web/src/components/SafeTweet.tsx
+++ b/apps/web/src/components/SafeTweet.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Component, type ComponentProps, type ReactNode } from 'react';
+import { Tweet } from 'react-tweet';
+
+interface SafeTweetProps {
+  id: string;
+  components?: ComponentProps<typeof Tweet>['components'];
+}
+
+interface TweetErrorBoundaryProps {
+  id: string;
+  children: ReactNode;
+}
+
+interface TweetErrorBoundaryState {
+  hasError: boolean;
+}
+
+class TweetErrorBoundary extends Component<TweetErrorBoundaryProps, TweetErrorBoundaryState> {
+  state: TweetErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): TweetErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error(`Tweet render failed (id=${this.props.id}):`, error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <a
+          className="tweet-fallback"
+          href={`https://x.com/i/status/${this.props.id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View this post on X
+        </a>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export function SafeTweet({ id, components }: SafeTweetProps) {
+  return (
+    <TweetErrorBoundary id={id}>
+      <Tweet id={id} components={components} />
+    </TweetErrorBoundary>
+  );
+}


### PR DESCRIPTION
## 概要

- 本番の記事ページ（例: `/shuntaka/articles/20260118-transfer-from-cloudflare`）で `TypeError: r is not iterable` が発生し、ページ全体がクラッシュしていた問題を修正する
- 原因は `react-tweet@3.3.0` の `addEntities` がツイートの `entities` を配列前提でイテレートする実装になっており、Twitter syndication API が entities を一切持たないツイートで返す `entities: {}` を処理できないこと
- `SafeTweet` で `<Tweet>` を class component の ErrorBoundary でラップし、描画失敗時は当該ツイート枠のみ X への外部リンクをフォールバック表示する。記事本体や他のツイートには影響しない

## 変更内容

- `apps/web/src/components/SafeTweet.tsx`（新規）
  - `TweetErrorBoundary` クラスコンポーネントを実装。`getDerivedStateFromError` でエラーをキャッチし、`componentDidCatch` でログを残しつつ「View this post on X」リンクへフォールバック
  - `SafeTweet` で `<Tweet>` をラップして公開
- `apps/web/src/components/ArticleContent.tsx`
  - `Tweet` の直接利用を `SafeTweet` に差し替え
- `apps/web/src/app/globals.css`
  - `.tweet-fallback` スタイルを Tweet セクション末尾に追加（既存トークン `--color-border` / `--color-link` を利用）

## 影響範囲

- 既存の正常なツイート描画は変化なし
- 異常なツイートが含まれる記事でも、該当枠のみフォールバック表示に切り替わり、ページ全体は表示される

## テストプラン

- [ ] `bun run type-check` が通る（ローカル確認済み）
- [ ] `bun run lint` が通る（ローカル確認済み）
- [ ] 本番デプロイ後、`/shuntaka/articles/20260118-transfer-from-cloudflare` でページ全体が表示されること
- [ ] 同記事中の Tweet 枠が「View this post on X」リンクにフォールバックすること
- [ ] 別記事の正常な Tweet 埋め込みが従来どおり表示されること

## 補足

- 根本対応として `react-tweet` をパッチする案（`bun patch` で `addEntities` に undefined ガードを追加）もあるが、本 PR はクラッシュ防止の最小修正のみとする
- upstream の修正リリースが入った時点で本ラッパーは不要にできる
