### PR TITLE
fix: apm の新スキルパス対応と Renovate workflow の lockfile 強制再生成

### DIFF
--- a/.github/workflows/renovate-apm-update.yaml
+++ b/.github/workflows/renovate-apm-update.yaml
@@ -49,8 +49,15 @@ jobs:
           rm apm.tar.gz
           echo "${HOME}/.apm" >> "${GITHUB_PATH}"
 
-      - name: apm install
-        run: apm install -t claude
+      # Renovate が apm.yml の ref を bump しても apm install は lockfile の
+      # resolved_commit を優先して fetch するため、ref と commit が乖離した状態
+      # で lockfile が更新されることがある。lockfile を消してから install する
+      # ことで、新 ref で必ず resolve し直し、新 ref に存在しないパスは fail
+      # させる
+      - name: apm install (force re-resolve)
+        run: |
+          rm -f apm.lock.yaml
+          apm install -t claude
 
       - name: apm audit (lockfile + drift + content scan)
         run: apm audit --ci

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,10 +1,10 @@
 lockfile_version: '1'
-generated_at: '2026-05-22T21:36:03.053730+00:00'
-apm_version: 0.13.0
+generated_at: '2026-05-26T02:05:15.329567+00:00'
+apm_version: 0.12.4
 dependencies:
 - repo_url: GoogleChrome/modern-web-guidance
   host: github.com
-  resolved_commit: 1dee00c2ae94d2e0c26d4a0c9fecb87c52bd82f9
+  resolved_commit: 65d7f20ac85517a362107ce89b7be7f905105fd3
   resolved_ref: 65d7f20ac85517a362107ce89b7be7f905105fd3
   virtual_path: skills/modern-web-guidance
   is_virtual: true
@@ -14,59 +14,49 @@ dependencies:
   content_hash: sha256:322b3f5620be102387bbdddae4ed5aa80d67427c6e38dd6a76ba09b12b48717e
 - repo_url: aws/agent-toolkit-for-aws
   host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
   resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/compute-skills/connecting-lambda-to-api-gateway
-  is_virtual: true
-  package_type: claude_skill
-  deployed_files:
-  - .claude/skills/connecting-lambda-to-api-gateway
-  content_hash: sha256:8a5264f97d13fe4954d4368548100702da08ab43c7b25b4df38558120b266299
-- repo_url: aws/agent-toolkit-for-aws
-  host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
-  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/compute-skills/creating-api-gateway-stage
-  is_virtual: true
-  package_type: claude_skill
-  deployed_files:
-  - .claude/skills/creating-api-gateway-stage
-  content_hash: sha256:9b55be54c03cdbc6e9059cadd22c859c20570f76014e28f920112d33c788fe48
-- repo_url: aws/agent-toolkit-for-aws
-  host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
-  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/compute-skills/debugging-lambda-timeouts
-  is_virtual: true
-  package_type: claude_skill
-  deployed_files:
-  - .claude/skills/debugging-lambda-timeouts
-  content_hash: sha256:6cbbec857526e2983fec3f13d46016893bd99225b0ec411e47864fd09f559559
-- repo_url: aws/agent-toolkit-for-aws
-  host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
-  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/compute-skills/routing-traffic-with-route53-and-cloudfront
-  is_virtual: true
-  package_type: claude_skill
-  deployed_files:
-  - .claude/skills/routing-traffic-with-route53-and-cloudfront
-  content_hash: sha256:030bd804c68cc4570c4e698a6e947d699b4775143e3410bc9b5d387ea942637c
-- repo_url: aws/agent-toolkit-for-aws
-  host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
-  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/developer-tools-skills/aws-cdk
+  virtual_path: skills/core-skills/aws-cdk
   is_virtual: true
   package_type: claude_skill
   deployed_files:
   - .claude/skills/aws-cdk
-  content_hash: sha256:3240c05ab5f879ab004af7f9e2eebf42e61954ded8aeee257448f39d46de1d39
+  content_hash: sha256:ae241625fa69ae0f36b14b251de4a773027996e972e0844b9410dea2b850c86f
 - repo_url: aws/agent-toolkit-for-aws
   host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
   resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/developer-tools-skills/aws-sdk-js-v3-usage
+  virtual_path: skills/core-skills/aws-cloudformation
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .claude/skills/aws-cloudformation
+  content_hash: sha256:3572ccb82ce2b2b941f0347031c64d32ff39de02eac75c9ae2b56cf225f8ec7b
+- repo_url: aws/agent-toolkit-for-aws
+  host: github.com
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  virtual_path: skills/core-skills/aws-iam
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .claude/skills/aws-iam
+  content_hash: sha256:e6b01570731dc3a67e26ecaaa5ce0d1d7b54f39f5e041a057f23f3b22c57cd9c
+- repo_url: aws/agent-toolkit-for-aws
+  host: github.com
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  virtual_path: skills/core-skills/aws-observability
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .claude/skills/aws-observability
+  content_hash: sha256:016bd8dae36b0862684adb9fdb550a645ecd69dc1a059724f04a183d1addd84d
+- repo_url: aws/agent-toolkit-for-aws
+  host: github.com
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  virtual_path: skills/core-skills/aws-sdk-js-v3-usage
   is_virtual: true
   package_type: claude_skill
   deployed_files:
@@ -74,67 +64,77 @@ dependencies:
   content_hash: sha256:4fda5595deafac7384c16b9cf86a6c90a894e54949d149e9f8c68a29f189ea9e
 - repo_url: aws/agent-toolkit-for-aws
   host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
   resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/management-tools-skills/aws-cloudformation
+  virtual_path: skills/specialized-skills/networking-and-content-delivery-skills/routing-traffic-with-route53-and-cloudfront
   is_virtual: true
   package_type: claude_skill
   deployed_files:
-  - .claude/skills/aws-cloudformation
-  content_hash: sha256:8961ad5785b117ea44a9f4cc013b32990c6fa363dd6d86cbbfc2ad12c07e2845
+  - .claude/skills/routing-traffic-with-route53-and-cloudfront
+  content_hash: sha256:1a216fa8fff21132aa262d645d97f44fff73802ab96664bd4a9a0942640fcd1c
 - repo_url: aws/agent-toolkit-for-aws
   host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
   resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/operations-skills/aws-observability
-  is_virtual: true
-  package_type: claude_skill
-  deployed_files:
-  - .claude/skills/aws-observability
-  content_hash: sha256:0e228cc1cc543b5b420768e6ceb88015d93958e0eee78768193381ddeaa3b2e8
-- repo_url: aws/agent-toolkit-for-aws
-  host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
-  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/operations-skills/setting-up-cloudwatch-alarm-notifications
+  virtual_path: skills/specialized-skills/operations-skills/setting-up-cloudwatch-alarm-notifications
   is_virtual: true
   package_type: claude_skill
   deployed_files:
   - .claude/skills/setting-up-cloudwatch-alarm-notifications
-  content_hash: sha256:e6de6e254091b5e12840d9098edd8b131894d94d4bdd6531b07d4a0887c0e570
+  content_hash: sha256:d06fc6d09b5e0da1e9b89fb3ac507cfa800115adff8d16ce8b329362fab42ec7
 - repo_url: aws/agent-toolkit-for-aws
   host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
   resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/operations-skills/troubleshooting-application-failures
+  virtual_path: skills/specialized-skills/operations-skills/troubleshooting-application-failures
   is_virtual: true
   package_type: claude_skill
   deployed_files:
   - .claude/skills/troubleshooting-application-failures
-  content_hash: sha256:a473523223098b52b94c7638d30654d4cf1b558ed49555d919ef04fc3cbb1ca4
+  content_hash: sha256:f3cbf837b1c53d58f3118e6a3ef5ff50ff82b1186f7b2eb8aa640626601a0269
 - repo_url: aws/agent-toolkit-for-aws
   host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
   resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/security-and-identity-skills/aws-iam
-  is_virtual: true
-  package_type: claude_skill
-  deployed_files:
-  - .claude/skills/aws-iam
-  content_hash: sha256:ee2040ac65acb7bc94e2e1cb36092b962ba76010a34bb315c4ca10a56c9f9847
-- repo_url: aws/agent-toolkit-for-aws
-  host: github.com
-  resolved_commit: 750230758fbf23acd60d075dedd7ead4092127ce
-  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-  virtual_path: skills/security-and-identity-skills/creating-secrets-using-best-practices
+  virtual_path: skills/specialized-skills/security-and-identity-skills/creating-secrets-using-best-practices
   is_virtual: true
   package_type: claude_skill
   deployed_files:
   - .claude/skills/creating-secrets-using-best-practices
-  content_hash: sha256:7fe5c304e58b8fe965b3e92ec885a6edaa281b8c228b23f270f5bd30b9a8a664
+  content_hash: sha256:4420d479a9e1efec486d5b0425bfd2e919ad9ccc1fd2795c83d210a55c91c870
+- repo_url: aws/agent-toolkit-for-aws
+  host: github.com
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  virtual_path: skills/specialized-skills/serverless-skills/connecting-lambda-to-api-gateway
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .claude/skills/connecting-lambda-to-api-gateway
+  content_hash: sha256:889cefb3b4e939aab214739a8cd7abd472553c8604577dd37638aed5692b5666
+- repo_url: aws/agent-toolkit-for-aws
+  host: github.com
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  virtual_path: skills/specialized-skills/serverless-skills/creating-api-gateway-stage
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .claude/skills/creating-api-gateway-stage
+  content_hash: sha256:b38d67fb759c9d6ec6bd54b8786e1c8217eb13e349f44af97381d53bcf5c8531
+- repo_url: aws/agent-toolkit-for-aws
+  host: github.com
+  resolved_commit: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  resolved_ref: ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+  virtual_path: skills/specialized-skills/serverless-skills/debugging-lambda-timeouts
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .claude/skills/debugging-lambda-timeouts
+  content_hash: sha256:da3148ccff16e63b1680501e30f2ab9511d371d9a8dd5cbff5f5c0d9b15d3c37
 - repo_url: vercel-labs/agent-skills
   host: github.com
-  resolved_commit: b9c8ee0643d87d3c5a953d1e22382ff2ead39229
+  resolved_commit: 18a24346600009dc3fcb99e4b2cd83b301601775
   resolved_ref: 18a24346600009dc3fcb99e4b2cd83b301601775
   virtual_path: skills/composition-patterns
   is_virtual: true
@@ -144,7 +144,7 @@ dependencies:
   content_hash: sha256:5b3564ca435f4714d5e65023351e1999e4744818603a9cfb6a6f6a61b7d84918
 - repo_url: vercel-labs/agent-skills
   host: github.com
-  resolved_commit: b9c8ee0643d87d3c5a953d1e22382ff2ead39229
+  resolved_commit: 18a24346600009dc3fcb99e4b2cd83b301601775
   resolved_ref: 18a24346600009dc3fcb99e4b2cd83b301601775
   virtual_path: skills/react-best-practices
   is_virtual: true
@@ -154,7 +154,7 @@ dependencies:
   content_hash: sha256:74f142d28d360d78e8bac4f239a84c87f0ced9015729bc72b5458d82ff45b015
 - repo_url: vercel-labs/agent-skills
   host: github.com
-  resolved_commit: b9c8ee0643d87d3c5a953d1e22382ff2ead39229
+  resolved_commit: 18a24346600009dc3fcb99e4b2cd83b301601775
   resolved_ref: 18a24346600009dc3fcb99e4b2cd83b301601775
   virtual_path: skills/web-design-guidelines
   is_virtual: true

--- a/apm.yml
+++ b/apm.yml
@@ -7,18 +7,18 @@ targets:
 dependencies:
   apm:
     # AWS Agent Toolkit (12)
-    - aws/agent-toolkit-for-aws/skills/developer-tools-skills/aws-cdk#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-    - aws/agent-toolkit-for-aws/skills/management-tools-skills/aws-cloudformation#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-    - aws/agent-toolkit-for-aws/skills/security-and-identity-skills/aws-iam#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-    - aws/agent-toolkit-for-aws/skills/operations-skills/aws-observability#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-    - aws/agent-toolkit-for-aws/skills/developer-tools-skills/aws-sdk-js-v3-usage#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-    - aws/agent-toolkit-for-aws/skills/compute-skills/connecting-lambda-to-api-gateway#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-    - aws/agent-toolkit-for-aws/skills/compute-skills/creating-api-gateway-stage#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-    - aws/agent-toolkit-for-aws/skills/security-and-identity-skills/creating-secrets-using-best-practices#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-    - aws/agent-toolkit-for-aws/skills/compute-skills/debugging-lambda-timeouts#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-    - aws/agent-toolkit-for-aws/skills/compute-skills/routing-traffic-with-route53-and-cloudfront#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-    - aws/agent-toolkit-for-aws/skills/operations-skills/setting-up-cloudwatch-alarm-notifications#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
-    - aws/agent-toolkit-for-aws/skills/operations-skills/troubleshooting-application-failures#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/core-skills/aws-cdk#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/core-skills/aws-cloudformation#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/core-skills/aws-iam#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/core-skills/aws-observability#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/core-skills/aws-sdk-js-v3-usage#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/specialized-skills/serverless-skills/connecting-lambda-to-api-gateway#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/specialized-skills/serverless-skills/creating-api-gateway-stage#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/specialized-skills/security-and-identity-skills/creating-secrets-using-best-practices#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/specialized-skills/serverless-skills/debugging-lambda-timeouts#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/specialized-skills/networking-and-content-delivery-skills/routing-traffic-with-route53-and-cloudfront#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/specialized-skills/operations-skills/setting-up-cloudwatch-alarm-notifications#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
+    - aws/agent-toolkit-for-aws/skills/specialized-skills/operations-skills/troubleshooting-application-failures#ba1cc8ca4f063d88ca40c6acf3f670e6321b7a7f
     # vercel-labs (3)
     - vercel-labs/agent-skills/skills/composition-patterns#18a24346600009dc3fcb99e4b2cd83b301601775
     - vercel-labs/agent-skills/skills/react-best-practices#18a24346600009dc3fcb99e4b2cd83b301601775

--- a/docs/source/01_development.md
+++ b/docs/source/01_development.md
@@ -301,6 +301,19 @@ apm install --update -t claude
 apm uninstall <package> -t claude
 ```
 
+完全リセット（apm.yml のパス書き換えが反映されないときに使う。apm は `apm_modules/` をローカル展開先として保持し、ここに旧構造のスナップショットが残っていると新パスを書いても `(cached)` 表示でそのまま再利用されるため、apm_modules と lockfile を消してから入れ直す）
+
+```bash
+rm -rf apm_modules apm.lock.yaml
+apm install -t claude
+```
+
+新しい `apm.lock.yaml` の `virtual_path` が apm.yml と同じパスになっていることを確認する。
+
+```bash
+grep virtual_path apm.lock.yaml
+```
+
 ### GitHub設定変更作業
 
 [babarot/gh-infra](https://github.com/babarot/gh-infra)でリポジトリ設定（visibility, labels, features, merge_strategy, security, rulesets, actions）を [`.github/infra.yaml`](.github/infra.yaml) で宣言的に管理。CI連携はせず手動運用。


### PR DESCRIPTION
## 概要

- apm.yml の AWS Agent Toolkit を upstream の新パス構造に追随
- Renovate workflow が ref bump 時に必ず新 ref で resolve し直すよう修正
- APM の完全リセット手順を docs に追記

## 背景

PR #386 で Renovate が `aws/agent-toolkit-for-aws` の SHA を `14780bf` → `ba1cc8c` に bump したが、`ba1cc8c` 時点では旧パス (`developer-tools-skills/`, `compute-skills/` 等) は既に削除され、新パス (`core-skills/`, `specialized-skills/`) に再編されていた。本来 `apm install` が 404 で fail するはずだったが、apm の挙動として「ref bump 時に lockfile の `resolved_commit` (古い `7502307`) を流用して fetch」していたため、見せかけの成功で lockfile が `resolved_ref: ba1cc8c` と `resolved_commit: 7502307` が乖離した状態で commit されていた。

## 変更内容

### `apm.yml`

AWS Agent Toolkit 12 件のパスを新構造に更新。

| 旧 | 新 |
|---|---|
| `developer-tools-skills/aws-cdk` 等 | `core-skills/aws-cdk` 等 |
| `compute-skills/connecting-lambda-to-api-gateway` 等 | `specialized-skills/serverless-skills/connecting-lambda-to-api-gateway` 等 |
| `security-and-identity-skills/creating-secrets-using-best-practices` | `specialized-skills/security-and-identity-skills/creating-secrets-using-best-practices` |
| `operations-skills/setting-up-cloudwatch-alarm-notifications` 等 | `specialized-skills/operations-skills/setting-up-cloudwatch-alarm-notifications` 等 |
| `compute-skills/routing-traffic-with-route53-and-cloudfront` | `specialized-skills/networking-and-content-delivery-skills/routing-traffic-with-route53-and-cloudfront` |

### `.github/workflows/renovate-apm-update.yaml`

`apm install` 前に `rm -f apm.lock.yaml` を追加。これで Renovate が ref bump した PR では新 ref で必ず resolve し直され、新 ref にパスが存在しなければ workflow が fail して人が気付けるようになる。

### `apm.lock.yaml`

新パス構造で再生成。`resolved_ref` と `resolved_commit` が一致した正常な状態に。

### `docs/source/01_development.md`

APM の完全リセット手順を追記。A/B 検証で以下が確認できたため最小化：

- 必須: `apm_modules` + `apm.lock.yaml` 削除
- 不要: `apm cache clean` / `~/.cache/apm/git` / `~/Library/Caches/apm` (削除しても結果は同じで install 時間が約 6 秒伸びるだけ)

```bash
rm -rf apm_modules apm.lock.yaml
apm install -t claude
```

