### PR TITLE
fix: X カード描画と動画再生を修正

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,7 @@
     "nprogress": "^0.2.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-tweet": "^3.3.0",
+    "react-tweet": "^3.3.1",
     "rss": "^1.2.2",
     "tocbot": "^4.36.8"
   },

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1136,10 +1136,11 @@ a:hover {
   max-width: 550px;
 }
 
-/* Prevent .prose styles from interfering with react-tweet internals */
-.prose .tweet-container img {
-  margin: 0;
-  display: initial;
+/* 動画埋め込み右上の「Watch on X」ピル。背景 rgba(15,20,25,0.75) がダーク背景上で
+   輪郭を失い視覚的にうるさい。X への導線はヘッダの X アイコン、作成日時、Read more on X
+   ボタン、本文 x.com リンクで足りているので非表示にする */
+.tweet-container [class*='__watchOnTwitter'] {
+  display: none;
 }
 
 [data-theme='dark'] .tweet-container {

--- a/apps/web/src/components/ArticleContent.tsx
+++ b/apps/web/src/components/ArticleContent.tsx
@@ -154,10 +154,14 @@ export function ArticleContent({ html }: ArticleContentProps) {
   }, [html]);
 
   return (
-    <div ref={contentRef} className="prose max-w-none">
+    <div ref={contentRef}>
       {parts.map((part, i) =>
         part.type === 'html' ? (
-          <div key={i} dangerouslySetInnerHTML={{ __html: part.content }} />
+          <div
+            key={i}
+            className="prose max-w-none"
+            dangerouslySetInnerHTML={{ __html: part.content }}
+          />
         ) : (
           <div key={i} className="tweet-container">
             <SafeTweet id={part.id} components={{ AvatarImg }} />

--- a/apps/web/src/components/SafeTweet.tsx
+++ b/apps/web/src/components/SafeTweet.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Component, type ComponentProps, type ReactNode } from 'react';
+import { Component, type ComponentProps, type ReactNode, useEffect, useRef } from 'react';
 import { Tweet } from 'react-tweet';
 
 interface SafeTweetProps {
@@ -45,10 +45,61 @@ class TweetErrorBoundary extends Component<TweetErrorBoundaryProps, TweetErrorBo
   }
 }
 
+// video.twimg.com は Referer ホワイトリスト（x.com 系のみ）で、localhost / 自ドメインからの
+// <video> リクエストを 403 で弾く。HTML 仕様上 <video> に referrerpolicy 属性が無いため
+// 後付けでは効かない。代わりに <source> の URL を fetch({referrerPolicy:'no-referrer'}) で
+// 取得して blob URL に差し替え、ブラウザに Referer 無しでバイト列を渡してから再生させる。
+function useTweetVideoBlobRewrite(rootRef: React.RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    let blobUrl: string | null = null;
+
+    const rewrite = async (source: HTMLSourceElement) => {
+      if (!source.src.startsWith('https://video.twimg.com/')) return;
+      if (source.dataset.blobRewrite) return;
+      source.dataset.blobRewrite = '1';
+      try {
+        const res = await fetch(source.src, { referrerPolicy: 'no-referrer' });
+        if (!res.ok) return;
+        blobUrl = URL.createObjectURL(await res.blob());
+        source.src = blobUrl;
+        source.closest('video')?.load();
+      } catch {
+        // 失敗時は元の src のまま放置。ブラウザ側で再生失敗を表示する
+      }
+    };
+
+    const scan = (node: ParentNode) =>
+      node.querySelectorAll<HTMLSourceElement>('video > source').forEach((s) => void rewrite(s));
+
+    scan(root);
+
+    const observer = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        for (const node of m.addedNodes) {
+          if (node instanceof Element) scan(node);
+        }
+      }
+    });
+    observer.observe(root, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+      if (blobUrl) URL.revokeObjectURL(blobUrl);
+    };
+  }, [rootRef]);
+}
+
 export function SafeTweet({ id, components }: SafeTweetProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  useTweetVideoBlobRewrite(ref);
+
   return (
-    <TweetErrorBoundary id={id}>
-      <Tweet id={id} components={components} />
-    </TweetErrorBoundary>
+    <div ref={ref}>
+      <TweetErrorBoundary id={id}>
+        <Tweet id={id} components={components} />
+      </TweetErrorBoundary>
+    </div>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
         "nprogress": "^0.2.0",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
-        "react-tweet": "^3.3.0",
+        "react-tweet": "^3.3.1",
         "rss": "^1.2.2",
         "tocbot": "^4.36.8",
       },
@@ -1282,7 +1282,7 @@
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
-    "react-tweet": ["react-tweet@3.3.0", "", { "dependencies": { "@swc/helpers": "^0.5.3", "clsx": "^2.0.0", "swr": "^2.2.4" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-gSIG2169ZK7UH6rBzuU+j1xnQbH3IlOTLEkuGrRiJJTMgETik+h+26yHyyVKrLkzwrOaYPk4K3OtEKycqKgNLw=="],
+    "react-tweet": ["react-tweet@3.3.1", "", { "dependencies": { "@swc/helpers": "^0.5.3", "clsx": "^2.0.0", "swr": "^2.2.4" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-0Gj1YgBTe1K85NBMoWBlUc17Rdc67gIJLlacrVgj+3jWIoXpFfxPdZ1U5OnWkkF9zxhphqs2pY1i//JBfP3Qog=="],
 
     "read-pkg": ["read-pkg@10.1.0", "", { "dependencies": { "@types/normalize-package-data": "^2.4.4", "normalize-package-data": "^8.0.0", "parse-json": "^8.3.0", "type-fest": "^5.4.4", "unicorn-magic": "^0.4.0" } }, "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg=="],
 

--- a/cspell.json
+++ b/cspell.json
@@ -119,6 +119,7 @@
     "tagpr",
     "tbls",
     "tfvars",
+    "twimg",
     "twttr",
     "thiserror",
     "toctree",


### PR DESCRIPTION
## Summary

- `react-tweet` 3.3.0 → 3.3.1 で `TypeError: entities is not iterable` を解消し X カード描画自体を復活
- 動画ツイートは `video.twimg.com` の Referer ホワイトリスト (`localhost` / 自ドメイン 403) を、`SafeTweet` 内で `<source>` URL を `fetch({referrerPolicy:'no-referrer'})` → blob URL に差し替えて回避
- `.prose` の cascade 漏れによる Watch on X バッジ視認性破綻を、`.prose max-w-none` を html-part 単位に絞ることで根本対応 (CSS の `:not(:where(...))` バンドエイドが不要に)

## 変更詳細

### apps/web/package.json, bun.lock
- `react-tweet` ^3.3.0 → ^3.3.1 (#222 entities 欠落耐性)

### apps/web/src/components/SafeTweet.tsx
- `useTweetVideoBlobRewrite(rootRef)` カスタムフックを追加
- `MutationObserver` を tweet root にだけ張り、`video > source` を `fetch({referrerPolicy:'no-referrer'})` で取得 → `URL.createObjectURL` で blob URL 化 → `<source>.src` を差し替えて `video.load()` を呼ぶ
- アンマウント時に `URL.revokeObjectURL`

### apps/web/src/components/ArticleContent.tsx
- `className="prose max-w-none"` を外側 `<div ref={contentRef}>` から、html-part の `<div>` へ移動
- 結果、ツイートは `.prose` の子孫ではなくなり、`.prose a` / `.prose img` 等の cascade が tweet 内部に漏れなくなる

### apps/web/src/app/globals.css
- `.prose .tweet-container img { margin: 0; display: initial }` リセットを削除 (`.prose` スコープ縮小により不要)
- 視認性の悪い react-tweet の Watch on X ピル (`[class*='__watchOnTwitter']`) を非表示

### cspell.json
- `twimg` (video.twimg.com 由来) を辞書に追加

