### PR TITLE
ci: install gitleaks in renovate-cargo-update workflow

### DIFF
--- a/.github/workflows/renovate-cargo-update.yaml
+++ b/.github/workflows/renovate-cargo-update.yaml
@@ -49,6 +49,14 @@ jobs:
       - name: Run CI
         uses: ./.github/actions/ci
 
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
       - name: Commit Cargo.lock
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- `renovate-cargo-update.yaml` の `Update Cargo.lock` ジョブで `git commit` 時に lefthook の pre-commit hook が動き、ubuntu-latest runner に gitleaks バイナリが無く `sh: 1: gitleaks: not found` で CI 失敗していた
- `Commit Cargo.lock` ステップ直前に gitleaks 8.30.1 (linux_x64) を `/usr/local/bin` に展開するステップを追加して解消

## Background

PR #410 の `Update Cargo.lock` ジョブが失敗中。lefthook の pre-commit (`gitleaks git --pre-commit --staged --no-banner --redact`) が呼ばれるが、ubuntu-latest にバイナリが無い。bun install では入らないので、release tarball から直接配置する。

ローカル開発環境 (macOS) の gitleaks とバージョンを揃え 8.30.1 に固定。


