### PR TITLE
feat: /who を /about にリネームしリダイレクトを追加

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -13,6 +13,15 @@ const nextConfig: NextConfig = {
   experimental: {
     optimizePackageImports: ['tocbot'],
   },
+  async redirects() {
+    return [
+      {
+        source: '/who',
+        destination: '/about',
+        permanent: true,
+      },
+    ];
+  },
   async headers() {
     return [
       {

--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -41,9 +41,9 @@ const links = [
   },
 ];
 
-export default function WhoPage() {
+export default function AboutPage() {
   return (
-    <BaseLayout showTypeHeader currentTab="who">
+    <BaseLayout showTypeHeader currentTab="about">
       <main className="w-full">
         <div className="flex items-center gap-2 pb-2">
           <span>髙橋俊一 a.k.a shuntaka</span>

--- a/apps/web/src/components/BaseLayout.tsx
+++ b/apps/web/src/components/BaseLayout.tsx
@@ -8,7 +8,7 @@ import { ToggleSwitch } from './ToggleSwitch';
 interface BaseLayoutProps {
   children: React.ReactNode;
   showTypeHeader?: boolean;
-  currentTab?: 'tech' | 'note' | 'who';
+  currentTab?: 'tech' | 'note' | 'about';
 }
 
 export function BaseLayout({ children, showTypeHeader = false, currentTab }: BaseLayoutProps) {
@@ -18,7 +18,7 @@ export function BaseLayout({ children, showTypeHeader = false, currentTab }: Bas
   const isTechActive =
     currentTab === 'tech' || (!currentTab && (pathname === '/' || pathname === undefined));
   const isNoteActive = currentTab === 'note' || (!currentTab && pathname === '/type/note');
-  const isWhoActive = currentTab === 'who' || (!currentTab && pathname === '/who');
+  const isAboutActive = currentTab === 'about' || (!currentTab && pathname === '/about');
   // NOTE: doneProgress()はここで呼ばない
   // loading.tsxもBaseLayoutを使用するため、スケルトン表示時に完了してしまう
   // 各ページの末端コンポーネント（PageReady, ArticleContent等）で呼ぶ
@@ -37,7 +37,7 @@ export function BaseLayout({ children, showTypeHeader = false, currentTab }: Bas
         </div>
       </div>
 
-      {/* Type Header (tech/note/who?) */}
+      {/* Type Header (tech/note/about) */}
       {showTypeHeader && (
         <nav
           className="w-full bg-[var(--color-surface-raised)]"
@@ -55,8 +55,8 @@ export function BaseLayout({ children, showTypeHeader = false, currentTab }: Bas
               </ProgressLink>
             </div>
             <div className="inline-block mr-2">
-              <ProgressLink href="/who" className={isWhoActive ? tabActiveClass : ''}>
-                who?
+              <ProgressLink href="/about" className={isAboutActive ? tabActiveClass : ''}>
+                about
               </ProgressLink>
             </div>
           </div>


### PR DESCRIPTION
## 概要

- プロフィールページのルートを `/who` から `/about` にリネーム
- ナビゲーションタブのラベルを `who?` から `about` に変更
- 既存リンクが切れないよう `next.config.ts` に `/who → /about` の恒久(308)リダイレクトを追加

## 変更内容

### ルート / ページ

- `apps/web/src/app/who/page.tsx` → `apps/web/src/app/about/page.tsx` にリネーム
- コンポーネント名 `WhoPage` → `AboutPage`、`<BaseLayout currentTab="about">`

### ナビゲーション (`apps/web/src/components/BaseLayout.tsx`)

- `currentTab` 型: `'tech' | 'note' | 'who'` → `'tech' | 'note' | 'about'`
- `isWhoActive` → `isAboutActive`（pathname 比較も `/about` に）
- Type Header の `ProgressLink`: `href="/who"` `who?` → `href="/about"` `about`

### リダイレクト (`apps/web/next.config.ts`)

- `async redirects()` を追加し `/who → /about` を `permanent: true` (308) で転送

