### PR TITLE
feat: 記事一覧にページネーションを追加

### DIFF
--- a/apps/blog-api/adapter/src/repository/users_articles.rs
+++ b/apps/blog-api/adapter/src/repository/users_articles.rs
@@ -5,7 +5,7 @@ use kernel::model::article::{
     Article, ArticleId, ArticleSummary, ArticleType, Content, Description, Slug, Status, Thumbnail,
     Title, UserId,
 };
-use kernel::repository::users_articles::UsersArticlesRepository;
+use kernel::repository::users_articles::{ArticleSummaryPage, UsersArticlesRepository};
 use sqlx::FromRow;
 use uuid::Uuid;
 
@@ -124,7 +124,9 @@ impl UsersArticlesRepository for UsersArticlesRepositoryImpl {
         &self,
         user_name: &str,
         article_type: &ArticleType,
-    ) -> Result<Vec<ArticleSummary>, anyhow::Error> {
+        offset: u64,
+        limit: u64,
+    ) -> Result<ArticleSummaryPage, anyhow::Error> {
         let rows: Vec<ArticleSummaryRow> = sqlx::query_as(
             r#"
             SELECT
@@ -143,14 +145,38 @@ impl UsersArticlesRepository for UsersArticlesRepositoryImpl {
             JOIN users u ON a.user_id = u.user_id
             WHERE a.status = 'published' AND a.`type` = ? AND u.name = ?
             ORDER BY a.published_at DESC
+            LIMIT ? OFFSET ?
             "#,
         )
         .bind(article_type.as_str())
         .bind(user_name)
+        .bind(limit)
+        .bind(offset)
         .fetch_all(&self.db.pool())
         .await?;
 
-        rows.into_iter().map(ArticleSummary::try_from).collect()
+        let total_count: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*)
+            FROM articles a
+            JOIN users u ON a.user_id = u.user_id
+            WHERE a.status = 'published' AND a.`type` = ? AND u.name = ?
+            "#,
+        )
+        .bind(article_type.as_str())
+        .bind(user_name)
+        .fetch_one(&self.db.pool())
+        .await?;
+
+        let articles: Vec<ArticleSummary> = rows
+            .into_iter()
+            .map(ArticleSummary::try_from)
+            .collect::<Result<_, _>>()?;
+
+        Ok(ArticleSummaryPage {
+            articles,
+            total_count: total_count.0 as u64,
+        })
     }
 
     async fn find_published_by_user_name_and_slug(

--- a/apps/blog-api/api/src/handler/users_articles.rs
+++ b/apps/blog-api/api/src/handler/users_articles.rs
@@ -11,10 +11,16 @@ use utoipa::{IntoParams, ToSchema};
 
 use crate::error::AppError;
 
+const DEFAULT_PER_PAGE: u32 = 10;
+const MAX_PER_PAGE: u32 = 500;
+
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct UsersArticlesQuery {
     #[serde(rename = "type")]
     pub article_type: String,
+    pub page: Option<u32>,
+    #[serde(rename = "perPage")]
+    pub per_page: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -60,8 +66,14 @@ pub struct ArticleSummaryResponse {
 }
 
 #[derive(Debug, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+#[schema(rename_all = "camelCase")]
 pub struct UsersArticlesResponse {
     pub articles: Vec<ArticleSummaryResponse>,
+    pub total_count: u64,
+    pub page: u32,
+    pub per_page: u32,
+    pub total_pages: u32,
 }
 
 #[utoipa::path(
@@ -86,9 +98,15 @@ pub async fn get_users_articles(
     let article_type = ArticleType::new(query.article_type)
         .map_err(|_| AppError::bad_request("Invalid article type"))?;
 
-    let articles = registry
+    let page = query.page.unwrap_or(1).max(1);
+    let per_page = parse_per_page(query.per_page.as_deref())?;
+
+    let offset = (u64::from(page) - 1) * u64::from(per_page);
+    let limit = u64::from(per_page);
+
+    let result = registry
         .users_articles_repository()
-        .find_published_by_user_name_and_type(&name, &article_type)
+        .find_published_by_user_name_and_type(&name, &article_type, offset, limit)
         .await
         .map_err(|e| AppError::internal("Failed to find articles", e))?;
 
@@ -98,8 +116,15 @@ pub async fn get_users_articles(
         config.cloudinary_api_secret.clone(),
     );
 
+    let total_pages = if result.total_count == 0 {
+        0
+    } else {
+        result.total_count.div_ceil(u64::from(per_page)) as u32
+    };
+
     let response = UsersArticlesResponse {
-        articles: articles
+        articles: result
+            .articles
             .into_iter()
             .map(|article| {
                 let slug = article.slug.into_inner();
@@ -121,9 +146,32 @@ pub async fn get_users_articles(
                 }
             })
             .collect(),
+        total_count: result.total_count,
+        page,
+        per_page,
+        total_pages,
     };
 
     Ok(Json(response))
+}
+
+fn parse_per_page(raw: Option<&str>) -> Result<u32, AppError> {
+    let Some(value) = raw else {
+        return Ok(DEFAULT_PER_PAGE);
+    };
+    if value.eq_ignore_ascii_case("all") {
+        return Ok(MAX_PER_PAGE);
+    }
+    let parsed: u32 = value
+        .parse()
+        .map_err(|_| AppError::bad_request("Invalid perPage value"))?;
+    if parsed == 0 {
+        return Err(AppError::bad_request("perPage must be >= 1"));
+    }
+    if parsed > MAX_PER_PAGE {
+        return Err(AppError::bad_request("perPage exceeds maximum"));
+    }
+    Ok(parsed)
 }
 
 #[utoipa::path(

--- a/apps/blog-api/kernel/src/repository/users_articles.rs
+++ b/apps/blog-api/kernel/src/repository/users_articles.rs
@@ -2,13 +2,20 @@ use async_trait::async_trait;
 
 use crate::model::article::{Article, ArticleSummary, ArticleType};
 
+pub struct ArticleSummaryPage {
+    pub articles: Vec<ArticleSummary>,
+    pub total_count: u64,
+}
+
 #[async_trait]
 pub trait UsersArticlesRepository: Send + Sync {
     async fn find_published_by_user_name_and_type(
         &self,
         user_name: &str,
         article_type: &ArticleType,
-    ) -> Result<Vec<ArticleSummary>, anyhow::Error>;
+        offset: u64,
+        limit: u64,
+    ) -> Result<ArticleSummaryPage, anyhow::Error>;
 
     async fn find_published_by_user_name_and_slug(
         &self,

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -20,6 +20,16 @@ const nextConfig: NextConfig = {
         destination: '/about',
         permanent: true,
       },
+      {
+        source: '/page/1',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source: '/type/note/page/1',
+        destination: '/type/note',
+        permanent: true,
+      },
     ];
   },
   async headers() {

--- a/apps/web/src/app/feed/route.ts
+++ b/apps/web/src/app/feed/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
     language: 'ja',
   });
 
-  const articles = await getArticlesByType(USER_NAME, 'tech');
+  const { articles } = await getArticlesByType(USER_NAME, 'tech', { perPage: 20 });
 
   articles.forEach((article) => {
     feed.item({

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,48 +1,13 @@
-import { ArticleCard } from '@/components/ArticleCard';
-import { BaseLayout } from '@/components/BaseLayout';
-import { PageReady } from '@/components/PageReady';
-import { getArticlesByType } from '@/lib/api';
+import type { Metadata } from 'next';
+import { ArticleListView } from '@/components/ArticleListView';
+import { SITE_URL } from '@/lib/constants';
 
-const USER_NAME = process.env.NEXT_PUBLIC_USER_NAME || 'shuntaka';
+export const metadata: Metadata = {
+  alternates: {
+    canonical: `${SITE_URL}/`,
+  },
+};
 
 export default async function Home() {
-  let articles: Awaited<ReturnType<typeof getArticlesByType>> = [];
-  let error: string | null = null;
-
-  try {
-    articles = await getArticlesByType(USER_NAME, 'tech');
-  } catch (e) {
-    error = e instanceof Error ? e.message : 'Failed to fetch articles';
-  }
-
-  const priorityArticleIds = new Set(
-    articles
-      .filter((a) => a.thumbnail)
-      .slice(0, 2)
-      .map((a) => a.articleId),
-  );
-
-  return (
-    <BaseLayout showTypeHeader currentTab="tech">
-      <main className="w-full">
-        <div className="max-w-[var(--layout-list-max)]">
-          {error ? (
-            <p className="text-[var(--color-danger-border)]">{error}</p>
-          ) : articles.length === 0 ? (
-            <p>No articles found.</p>
-          ) : (
-            articles.map((article) => (
-              <ArticleCard
-                key={article.articleId}
-                article={article}
-                userName={USER_NAME}
-                priority={priorityArticleIds.has(article.articleId)}
-              />
-            ))
-          )}
-        </div>
-        <PageReady />
-      </main>
-    </BaseLayout>
-  );
+  return <ArticleListView type="tech" currentTab="tech" page={1} baseHref="/" />;
 }

--- a/apps/web/src/app/page/[page]/page.tsx
+++ b/apps/web/src/app/page/[page]/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ArticleListView } from '@/components/ArticleListView';
+import { getArticlesByType } from '@/lib/api';
+import { SITE_URL, USER_NAME } from '@/lib/constants';
+
+interface PageProps {
+  params: Promise<{ page: string }>;
+}
+
+function parsePage(raw: string): number | null {
+  if (!/^[1-9]\d*$/.test(raw)) return null;
+  const n = Number(raw);
+  return n >= 2 ? n : null;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { page: rawPage } = await params;
+  const page = parsePage(rawPage);
+  if (page === null) return {};
+  return {
+    alternates: {
+      canonical: `${SITE_URL}/page/${page}`,
+    },
+  };
+}
+
+export default async function TechPaginationPage({ params }: PageProps) {
+  const { page: rawPage } = await params;
+  const page = parsePage(rawPage);
+  if (page === null) notFound();
+
+  const probe = await getArticlesByType(USER_NAME, 'tech', { page, perPage: 10 });
+  if (probe.articles.length === 0) notFound();
+
+  return <ArticleListView type="tech" currentTab="tech" page={page} baseHref="/" />;
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -9,12 +9,12 @@ function formatDate(date: Date): string {
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const [techArticles, noteArticles] = await Promise.all([
-    getArticlesByType(USER_NAME, 'tech'),
-    getArticlesByType(USER_NAME, 'note'),
+  const [techPage, notePage] = await Promise.all([
+    getArticlesByType(USER_NAME, 'tech', { perPage: 'all' }),
+    getArticlesByType(USER_NAME, 'note', { perPage: 'all' }),
   ]);
 
-  const articles = [...techArticles, ...noteArticles];
+  const articles = [...techPage.articles, ...notePage.articles];
 
   const articleUrls: MetadataRoute.Sitemap = articles.map((article) => ({
     url: `${SITE_URL}/${USER_NAME}/articles/${article.slug}`,

--- a/apps/web/src/app/type/note/page.tsx
+++ b/apps/web/src/app/type/note/page.tsx
@@ -1,48 +1,13 @@
-import { ArticleCard } from '@/components/ArticleCard';
-import { BaseLayout } from '@/components/BaseLayout';
-import { PageReady } from '@/components/PageReady';
-import { getArticlesByType } from '@/lib/api';
+import type { Metadata } from 'next';
+import { ArticleListView } from '@/components/ArticleListView';
+import { SITE_URL } from '@/lib/constants';
 
-const USER_NAME = process.env.NEXT_PUBLIC_USER_NAME || 'shuntaka';
+export const metadata: Metadata = {
+  alternates: {
+    canonical: `${SITE_URL}/type/note`,
+  },
+};
 
 export default async function NotePage() {
-  let articles: Awaited<ReturnType<typeof getArticlesByType>> = [];
-  let error: string | null = null;
-
-  try {
-    articles = await getArticlesByType(USER_NAME, 'note');
-  } catch (e) {
-    error = e instanceof Error ? e.message : 'Failed to fetch articles';
-  }
-
-  const priorityArticleIds = new Set(
-    articles
-      .filter((a) => a.thumbnail)
-      .slice(0, 2)
-      .map((a) => a.articleId),
-  );
-
-  return (
-    <BaseLayout showTypeHeader currentTab="note">
-      <main className="w-full">
-        <div className="max-w-[var(--layout-list-max)]">
-          {error ? (
-            <p className="text-[var(--color-danger-border)]">{error}</p>
-          ) : articles.length === 0 ? (
-            <p>No articles found.</p>
-          ) : (
-            articles.map((article) => (
-              <ArticleCard
-                key={article.articleId}
-                article={article}
-                userName={USER_NAME}
-                priority={priorityArticleIds.has(article.articleId)}
-              />
-            ))
-          )}
-        </div>
-        <PageReady />
-      </main>
-    </BaseLayout>
-  );
+  return <ArticleListView type="note" currentTab="note" page={1} baseHref="/type/note" />;
 }

--- a/apps/web/src/app/type/note/page/[page]/page.tsx
+++ b/apps/web/src/app/type/note/page/[page]/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ArticleListView } from '@/components/ArticleListView';
+import { getArticlesByType } from '@/lib/api';
+import { SITE_URL, USER_NAME } from '@/lib/constants';
+
+interface PageProps {
+  params: Promise<{ page: string }>;
+}
+
+function parsePage(raw: string): number | null {
+  if (!/^[1-9]\d*$/.test(raw)) return null;
+  const n = Number(raw);
+  return n >= 2 ? n : null;
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { page: rawPage } = await params;
+  const page = parsePage(rawPage);
+  if (page === null) return {};
+  return {
+    alternates: {
+      canonical: `${SITE_URL}/type/note/page/${page}`,
+    },
+  };
+}
+
+export default async function NotePaginationPage({ params }: PageProps) {
+  const { page: rawPage } = await params;
+  const page = parsePage(rawPage);
+  if (page === null) notFound();
+
+  const probe = await getArticlesByType(USER_NAME, 'note', { page, perPage: 10 });
+  if (probe.articles.length === 0) notFound();
+
+  return <ArticleListView type="note" currentTab="note" page={page} baseHref="/type/note" />;
+}

--- a/apps/web/src/components/ArticleCard.stories.tsx
+++ b/apps/web/src/components/ArticleCard.stories.tsx
@@ -1,12 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import type { Article } from '@/lib/api';
+import type { ArticleSummary } from '@/lib/api';
 import { ArticleCard } from './ArticleCard';
 
-const baseArticle: Article = {
+const baseArticle: ArticleSummary = {
   articleId: '01HX2YE5PG9N3CK1S3FZ6T2WJK',
   title: 'shuntaka.dev のデザインシステムを skill 化した',
   slug: 'design-system-as-skill',
-  content: '',
   description: '',
   type: 'tech',
   thumbnail: 'https://res.cloudinary.com/dkerzyk09/image/upload/v1767101809/blog/og/shuntaka.png',

--- a/apps/web/src/components/ArticleCard.tsx
+++ b/apps/web/src/components/ArticleCard.tsx
@@ -1,10 +1,10 @@
 import Image from 'next/image';
 import { memo } from 'react';
-import type { Article } from '@/lib/api';
+import type { ArticleSummary } from '@/lib/api';
 import { ProgressLink } from './ProgressLink';
 
 interface ArticleCardProps {
-  article: Article;
+  article: ArticleSummary;
   userName: string;
   priority?: boolean;
 }

--- a/apps/web/src/components/ArticleListView.tsx
+++ b/apps/web/src/components/ArticleListView.tsx
@@ -1,0 +1,63 @@
+import { ArticleCard } from '@/components/ArticleCard';
+import { BaseLayout } from '@/components/BaseLayout';
+import { PageReady } from '@/components/PageReady';
+import { Pagination } from '@/components/Pagination';
+import { getArticlesByType } from '@/lib/api';
+import { USER_NAME } from '@/lib/constants';
+
+interface ArticleListViewProps {
+  type: 'tech' | 'note';
+  currentTab: 'tech' | 'note';
+  page: number;
+  baseHref: string;
+}
+
+const PER_PAGE = 10;
+
+export async function ArticleListView({ type, currentTab, page, baseHref }: ArticleListViewProps) {
+  let articles: Awaited<ReturnType<typeof getArticlesByType>>['articles'] = [];
+  let totalPages = 1;
+  let error: string | null = null;
+
+  try {
+    const result = await getArticlesByType(USER_NAME, type, { page, perPage: PER_PAGE });
+    articles = result.articles;
+    totalPages = result.totalPages;
+  } catch (e) {
+    error = e instanceof Error ? e.message : 'Failed to fetch articles';
+  }
+
+  const priorityArticleIds = new Set(
+    articles
+      .filter((a) => a.thumbnail)
+      .slice(0, 2)
+      .map((a) => a.articleId),
+  );
+
+  return (
+    <BaseLayout showTypeHeader currentTab={currentTab}>
+      <main className="w-full">
+        <div className="max-w-[var(--layout-list-max)]">
+          {error ? (
+            <p className="text-[var(--color-danger-border)]">{error}</p>
+          ) : articles.length === 0 ? (
+            <p>No articles found.</p>
+          ) : (
+            <>
+              {articles.map((article) => (
+                <ArticleCard
+                  key={article.articleId}
+                  article={article}
+                  userName={USER_NAME}
+                  priority={priorityArticleIds.has(article.articleId)}
+                />
+              ))}
+              <Pagination currentPage={page} totalPages={totalPages} baseHref={baseHref} />
+            </>
+          )}
+        </div>
+        <PageReady />
+      </main>
+    </BaseLayout>
+  );
+}

--- a/apps/web/src/components/BaseLayout.tsx
+++ b/apps/web/src/components/BaseLayout.tsx
@@ -40,7 +40,7 @@ export function BaseLayout({ children, showTypeHeader = false, currentTab }: Bas
       {/* Type Header (tech/note/about) */}
       {showTypeHeader && (
         <nav
-          className="w-full bg-[var(--color-surface-raised)]"
+          className="sticky top-0 z-10 w-full border-b border-[var(--color-border-subtle)] bg-[var(--color-surface-raised)]"
           aria-label="カテゴリーナビゲーション"
         >
           <div className="mx-auto max-w-[var(--layout-max)] px-8 max-sm:px-4 max-sm:pt-3">

--- a/apps/web/src/components/Pagination.stories.tsx
+++ b/apps/web/src/components/Pagination.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Pagination } from './Pagination';
+
+const meta = {
+  title: 'Components/Pagination',
+  component: Pagination,
+  args: {
+    baseHref: '/',
+    currentPage: 1,
+    totalPages: 1,
+  },
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const SinglePage: Story = {
+  args: {
+    currentPage: 1,
+    totalPages: 1,
+  },
+};
+
+export const FewPages: Story = {
+  args: {
+    currentPage: 2,
+    totalPages: 4,
+  },
+};
+
+export const FirstPageOfMany: Story = {
+  args: {
+    currentPage: 1,
+    totalPages: 10,
+  },
+};
+
+export const MiddlePageOfMany: Story = {
+  args: {
+    currentPage: 5,
+    totalPages: 10,
+  },
+};
+
+export const LastPageOfMany: Story = {
+  args: {
+    currentPage: 10,
+    totalPages: 10,
+  },
+};
+
+export const NoteBase: Story = {
+  args: {
+    baseHref: '/type/note',
+    currentPage: 3,
+    totalPages: 8,
+  },
+};

--- a/apps/web/src/components/Pagination.tsx
+++ b/apps/web/src/components/Pagination.tsx
@@ -1,0 +1,82 @@
+import { ProgressLink } from './ProgressLink';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  baseHref: string;
+}
+
+type PageItem = number | 'ellipsis';
+
+function buildPageItems(currentPage: number, totalPages: number): PageItem[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+
+  const items: PageItem[] = [];
+  const window = 2;
+  const start = Math.max(2, currentPage - window);
+  const end = Math.min(totalPages - 1, currentPage + window);
+
+  items.push(1);
+  if (start > 2) {
+    items.push('ellipsis');
+  }
+  for (let p = start; p <= end; p += 1) {
+    items.push(p);
+  }
+  if (end < totalPages - 1) {
+    items.push('ellipsis');
+  }
+  items.push(totalPages);
+  return items;
+}
+
+function hrefFor(baseHref: string, page: number): string {
+  if (page === 1) return baseHref;
+  const sep = baseHref.endsWith('/') ? '' : '/';
+  return `${baseHref}${sep}page/${page}`;
+}
+
+export function Pagination({ currentPage, totalPages, baseHref }: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  const items = buildPageItems(currentPage, totalPages);
+
+  return (
+    <nav className="mt-6 flex items-center justify-center text-sm sm:mt-8" aria-label="pagination">
+      <ul className="flex items-center gap-1 sm:gap-2">
+        {items.map((item, idx) =>
+          item === 'ellipsis' ? (
+            <li
+              key={`ellipsis-${idx}`}
+              className="px-1 text-[var(--color-text-muted)] sm:px-2"
+              aria-hidden="true"
+            >
+              …
+            </li>
+          ) : item === currentPage ? (
+            <li key={item}>
+              <span
+                aria-current="page"
+                className="inline-flex min-h-10 min-w-10 items-center justify-center border-b-2 border-[var(--color-text)] px-2 font-medium text-[var(--color-text)] sm:px-3"
+              >
+                {item}
+              </span>
+            </li>
+          ) : (
+            <li key={item}>
+              <ProgressLink
+                href={hrefFor(baseHref, item)}
+                className="inline-flex min-h-10 min-w-10 items-center justify-center px-2 text-[var(--color-link)] hover:text-[var(--color-link-hover)] sm:px-3"
+                aria-label={`page ${item}`}
+              >
+                {item}
+              </ProgressLink>
+            </li>
+          ),
+        )}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -13,8 +13,30 @@ export interface Article {
   updatedAt: string | null;
 }
 
-export interface ArticlesResponse {
-  articles: Article[];
+export interface ArticleSummary {
+  articleId: string;
+  title: string;
+  slug: string;
+  description: string;
+  type: string | null;
+  thumbnail: string | null;
+  ogpUrl: string;
+  publishedAt: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface ArticlesPage {
+  articles: ArticleSummary[];
+  totalCount: number;
+  page: number;
+  perPage: number;
+  totalPages: number;
+}
+
+export interface ArticlesQueryOptions {
+  page?: number;
+  perPage?: number | 'all';
 }
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
@@ -22,8 +44,17 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
 export async function getArticlesByType(
   userName: string,
   type: 'tech' | 'note',
-): Promise<Article[]> {
-  const res = await fetch(`${API_BASE_URL}/users/${userName}/articles?type=${type}`, {
+  opts: ArticlesQueryOptions = {},
+): Promise<ArticlesPage> {
+  const params = new URLSearchParams({ type });
+  if (opts.page !== undefined) {
+    params.set('page', String(opts.page));
+  }
+  if (opts.perPage !== undefined) {
+    params.set('perPage', String(opts.perPage));
+  }
+
+  const res = await fetch(`${API_BASE_URL}/users/${userName}/articles?${params.toString()}`, {
     next: { revalidate: 30 },
   });
 
@@ -31,8 +62,7 @@ export async function getArticlesByType(
     throw new Error(`Failed to fetch articles: ${res.status}`);
   }
 
-  const data: ArticlesResponse = await res.json();
-  return data.articles;
+  return res.json();
 }
 
 export async function getArticleBySlug(userName: string, slug: string): Promise<Article | null> {

--- a/cspell.json
+++ b/cspell.json
@@ -55,6 +55,7 @@
     "dualstack",
     "ecspresso",
     "envrc",
+    "fanout",
     "ffprobe",
     "fira",
     "fopen",

--- a/docs/source/tasks/2026-06-30-articles-list-drop-content.md
+++ b/docs/source/tasks/2026-06-30-articles-list-drop-content.md
@@ -328,6 +328,191 @@ Sort_10                         0.04     37       root                          
 
 ---
 
+## Phase 3: 一覧 API のページネーション + フロント prefetch fanout 削減
+
+### 動機
+
+Phase 1 / Phase 2 で Q1 自体は十分軽くなった (7.33ms → 2.63ms)。**残るボトルネックは Q1 ではなく、フロントの `next/link` viewport prefetch によって裏で叩かれる Q2 (詳細) 群** である。
+
+具体的には:
+
+- `apps/web/src/components/ArticleCard.tsx` の `<ProgressLink>` は `next/link` ラッパーで、`prefetch` 指定無し → production では viewport in 時に自動 prefetch
+- 一覧ページが 40 件の `ArticleCard` をレンダする以上、トップを開くと **40 個の `/[userName]/articles/[slug]` ルートが RSC prefetch され、各々で `getArticleBySlug` (Q2) が走る**
+- `revalidate: 30` なので Next.js キャッシュが切れるたびにまた走る
+
+Q2 自体は `uq_articles_slug` の Point_Get なので 1 回は軽いが、40 倍に増幅されると一覧 API の Q1 1 回より圧倒的に重い。`tidb_statement_summary` で Q1 だけ追うと全体像を見誤る。
+
+ページネーションして 1 ページ 10 件にすれば、**viewport に並ぶ `<Link>` は 10 個 + ページネーション数個** に減り、prefetch fanout は約 4 分の 1。`prefetch={false}` で全切りせず体感速度を維持したまま fanout を絞れる。
+
+Phase 2 の新インデックス `(user_id, status, type, published_at)` のおかげで `LIMIT/OFFSET` も `COUNT(*)` も追加コストほぼ無しで載るので、API 側の DDL は不要。
+
+### 設計判断（確定済み）
+
+| 項目                | 採用案                                                                                                         |
+| ------------------- | -------------------------------------------------------------------------------------------------------------- |
+| URL 形式            | `/page/[page]` 動的ルート（searchParams ではない）                                                             |
+| 1 ページ件数        | **10 件**                                                                                                      |
+| 1 ページ目の扱い    | `/` と `/type/note` をそのまま 1 ページ目として動作させる。`/page/1` / `/type/note/page/1` は 308 リダイレクト |
+| ページネーション UI | `1 2 3 … 9 [10]` 形式。現ページ ±2 + 最初/最後 + 省略                                                          |
+| RSS                 | 最新 20 件で十分 (`perPage=20`)                                                                                |
+| sitemap             | 全件必要 (`perPage=all` または十分大きい上限)                                                                  |
+
+### Q1 SQL（変更後）
+
+```sql
+-- ページ取得
+SELECT a.article_id, a.title, a.slug, a.user_id, a.thumbnail, a.description,
+       a.status, a.`type`, a.published_at, a.created_at, a.updated_at
+FROM articles a
+JOIN users u ON a.user_id = u.user_id
+WHERE a.status = 'published' AND a.`type` = ? AND u.name = ?
+ORDER BY a.published_at DESC
+LIMIT ? OFFSET ?;
+
+-- 総件数（ページネーション UI 用）
+SELECT COUNT(*)
+FROM articles a
+JOIN users u ON a.user_id = u.user_id
+WHERE a.status = 'published' AND a.`type` = ? AND u.name = ?;
+```
+
+期待プラン:
+
+- ページ取得: Phase 2 の新インデックスのみで完結。`IndexRangeScan` でレンジを引いた後 `Limit` で 10 行に絞ってから `TableRowIDScan`。**TableRowIDScan の actRows = 10** で済む
+- COUNT: `IndexRangeScan` のみで完結し `TableRowIDScan` は走らない（インデックスのキーだけで件数が分かる）
+
+### API 変更
+
+#### Repository (`apps/blog-api/adapter/src/repository/users_articles.rs`)
+
+- `find_published_by_user_name_and_type` のシグネチャを以下に変更:
+  ```rust
+  pub async fn find_published_by_user_name_and_type(
+      &self,
+      name: &str,
+      article_type: &ArticleType,
+      page: u32,
+      per_page: u32,
+  ) -> Result<(Vec<ArticleSummary>, u64)>  // (articles, totalCount)
+  ```
+- `per_page` の上限は API ハンドラ側でバリデート（例: 1〜100、または `all` 相当の 500）
+- COUNT は同じ JOIN 条件で別クエリとして発行
+
+#### Handler (`apps/blog-api/api/src/handler/users_articles.rs`)
+
+- `UsersArticlesQuery` に `page` / `per_page` を追加（`Option<u32>` で default 1 / 10）
+- `UsersArticlesResponse` を以下に拡張:
+  ```rust
+  pub struct UsersArticlesResponse {
+      pub articles: Vec<ArticleSummaryResponse>,
+      pub total_count: u64,
+      pub page: u32,
+      pub per_page: u32,
+      pub total_pages: u32,
+  }
+  ```
+- `per_page` に `all` 相当（数値上限による表現で良い、例 500）を許容するか、別途 `perPage` クエリで `all` 文字列を許容するかは実装時に決める（後者の方が明示的で sitemap から使いやすい）
+- `utoipa` スキーマ更新
+
+### フロント変更 (`apps/web`)
+
+#### `src/lib/api.ts`
+
+- 戻り値型を `ArticlesPage` に変更:
+  ```ts
+  export interface ArticlesPage {
+    articles: ArticleSummary[];
+    totalCount: number;
+    page: number;
+    perPage: number;
+    totalPages: number;
+  }
+  export async function getArticlesByType(
+    userName: string,
+    type: 'tech' | 'note',
+    opts?: { page?: number; perPage?: number | 'all' },
+  ): Promise<ArticlesPage>;
+  ```
+
+#### ルート構成
+
+| URL                                | 新規/既存    | 内容                                                             |
+| ---------------------------------- | ------------ | ---------------------------------------------------------------- |
+| `/`                                | 既存         | tech 1 ページ目（`getArticlesByType(..., 'tech', { page: 1 })`） |
+| `/page/[page]`                     | **新規**     | tech 2 ページ目以降                                              |
+| `/type/note`                       | 既存         | note 1 ページ目                                                  |
+| `/type/note/page/[page]`           | **新規**     | note 2 ページ目以降                                              |
+| `/page/1` → `/`                    | リダイレクト | URL 正規化（308）                                                |
+| `/type/note/page/1` → `/type/note` | リダイレクト | URL 正規化（308）                                                |
+
+各ページに canonical (`<link rel="canonical">`) を入れて自分自身を指す。
+
+#### Pagination コンポーネント
+
+- 新規 `src/components/Pagination.tsx`:
+  ```ts
+  interface PaginationProps {
+    currentPage: number;
+    totalPages: number;
+    baseHref: string; // '/' or '/type/note'
+  }
+  ```
+- 出力: `‹ Prev   1  2 ... 8  9 [10]   Next ›`
+- リンクは `<Link>` で繋ぐ → デフォルト prefetch で隣接ページの RSC が prefetch される（ページ遷移の体感は維持）
+- Story を追加（少件数/多件数/最初ページ/最終ページ）
+
+#### RSS (`src/app/feed/route.ts`)
+
+- 全件 `getArticlesByType(USER_NAME, 'tech')` を `getArticlesByType(USER_NAME, 'tech', { perPage: 20 })` に変更
+- 一般的な RSS リーダーは最新 N 件で十分
+
+#### sitemap (`src/app/sitemap.ts`)
+
+- 全件必要なので `getArticlesByType(USER_NAME, 'tech', { perPage: 'all' })` を使う
+- `revalidate = 60` なので COUNT + 全件取得が 60 秒に 1 回。Phase 1 で content 抜きなので転送量は十分軽い
+
+### prefetch fanout の比較
+
+| 観点                         | 現状                     | Phase 3 後                                              |
+| ---------------------------- | ------------------------ | ------------------------------------------------------- |
+| トップ表示時に走る Q2 (詳細) | 最大 40                  | **10**                                                  |
+| トップ表示時に走る Q1 (一覧) | 1                        | 1 + ページネーションリンクの prefetch（隣接 ~3 ページ） |
+| Q1 自体の重さ                | Phase 1/2 適用済みで軽い | 同左（LIMIT 10 + COUNT で更に軽い）                     |
+
+Q2 の fanout が **4 分の 1**。Q1 はページネーションリンクの prefetch で数回増えるが、Phase 1/2 + LIMIT のおかげで 1 回あたり極めて軽いので無視できる。
+
+### Phase 3 チェックリスト
+
+- [ ] Repository: `find_published_by_user_name_and_type` に `page` / `per_page` を追加し、戻り値を `(Vec<ArticleSummary>, u64)` に拡張
+- [ ] Repository: COUNT 用クエリを追加（同 JOIN 条件）
+- [ ] Handler: `UsersArticlesQuery` に `page` / `perPage` を追加
+- [ ] Handler: `UsersArticlesResponse` に `totalCount` / `page` / `perPage` / `totalPages` を追加
+- [ ] Handler: `perPage=all` (または上限 500) のハンドリング決定 + 実装
+- [ ] `utoipa` スキーマ更新
+- [ ] dev TiDB で `EXPLAIN ANALYZE` を取り、`LIMIT/OFFSET` クエリが新インデックスのみで完結（`TableRowIDScan` の actRows = 10、Sort が無い）していることを確認
+- [ ] dev TiDB で COUNT クエリが `IndexRangeScan` のみで完結している（`TableRowIDScan` 不要）ことを確認
+- [ ] フロント: `lib/api.ts` の `getArticlesByType` シグネチャ更新、戻り値型を `ArticlesPage` に
+- [ ] フロント: `/page/[page]/page.tsx` 新設（tech）
+- [ ] フロント: `/type/note/page/[page]/page.tsx` 新設（note）
+- [ ] フロント: `/page/1` / `/type/note/page/1` の 308 リダイレクト（`next.config.ts` の `redirects()` に追記）
+- [ ] フロント: `<Pagination>` コンポーネント新設、Story 追加
+- [ ] フロント: 各一覧ページに `<Pagination>` 配置、canonical 設定
+- [ ] フロント: `feed/route.ts` を `perPage: 20` に変更
+- [ ] フロント: `sitemap.ts` を `perPage: 'all'` に変更
+- [ ] `bun run check` 通過
+- [ ] dev 環境で動作確認: 1 ページ目 / 中間 / 最終ページの表示、`/page/1` リダイレクト、Prev/Next、最初/最後の数字リンク
+- [ ] **prefetch 観測**: Production ビルドで Network タブを開き、Filter `_rsc` でトップ表示時の prefetch が **10 件 + 隣接ページ分** に収まっていることを確認（変更前は最大 40 件）
+- [ ] API 側のアクセスログで、トップ初回ロード時の Q2 リクエスト数が変更前後でどう変わったかを記録
+
+### Phase 3 で踏み込まないこと
+
+- **URL クエリパラメータ方式 (`?page=2`) への切り替え** — 動的ルートで確定
+- **無限スクロール / Load More UI** — ページ番号方式で確定
+- **カーソル方式 (keyset pagination) への移行** — 記事数が数千件規模になるまで OFFSET 方式で十分。Phase 2 の新インデックスのおかげで OFFSET も B+Tree を順走するだけ
+- **`<Link prefetch={false}>` への切り替え / hover-only prefetch** — ページネーションで fanout が許容範囲に収まれば不要。Phase 3 適用後に Q2 観測値を見て、それでもまだ多ければ別途検討
+
+---
+
 ## キャッシュ仮説の整理
 
 「トップを叩いたら前記事のキャッシュが作られていて初回が重い」という仮説に対しての回答:
@@ -354,4 +539,3 @@ Sort_10                         0.04     37       root                          
 
 - `content` 列の別テーブル切り出し（垂直分割）
 - 6/28 と 6/30 で実行経路が割れた件の再現確認（統計のタイミング揃え）
-- 一覧 API への pagination（現状 全件返し、件数が増えたら別途検討）


### PR DESCRIPTION
## 概要

`next/link` の viewport prefetch によって、一覧ページを開いた時に表示中の記事カード全件 (最大 40 件) 分の詳細ページが裏で prefetch され、各々で `getArticleBySlug` (Q2) が走る問題への対策。

ページネーションを導入して 1 ページ 10 件にし、prefetch fanout を約 4 分の 1 に削減する。

詳細な設計判断と背景は [`docs/source/tasks/2026-06-30-articles-list-drop-content.md`](./docs/source/tasks/2026-06-30-articles-list-drop-content.md) の Phase 3 を参照。

## 主な変更

### API (Rust)

- `find_published_by_user_name_and_type` に `offset` / `limit` 引数を追加、戻り値を `ArticleSummaryPage { articles, total_count }` に変更
- `COUNT(*)` 取得用クエリを追加 (新インデックスのみで完結、`TableRowIDScan` 不要)
- ハンドラのクエリパラメータに `page` / `perPage` 追加、レスポンスに `totalCount` / `page` / `perPage` / `totalPages` を追加
- `perPage='all'` 文字列を許容 (sitemap 用、上限 500)
- `utoipa` スキーマも更新

### Frontend (Next.js)

- `lib/api.ts`: `ArticleSummary` / `ArticlesPage` 型を追加、`getArticlesByType` シグネチャを `{ articles, totalCount, page, perPage, totalPages }` を返すように変更
- `components/Pagination.tsx` + Story 新設: 数字のみのページネーション (Prev/Next なし、現ページは下線で表現)、モバイルでタップ領域 40x40px 確保
- `components/ArticleListView.tsx`: 一覧表示の共通ビューを抽出 (4 ルートで共有)
- `components/BaseLayout.tsx`: tech/note/about ナビを `sticky top-0` に変更、スクロール時にも追従
- `components/ArticleCard.tsx`: props 型を `ArticleSummary` に
- `app/page/[page]/page.tsx` 新設 (tech 2 ページ目以降)
- `app/type/note/page/[page]/page.tsx` 新設 (note 2 ページ目以降)
- `app/page.tsx` / `app/type/note/page.tsx`: 新ビュー経由に置き換え、canonical 設定
- `next.config.ts`: `/page/1` → `/`、`/type/note/page/1` → `/type/note` の 308 リダイレクト
- `app/feed/route.ts`: `perPage: 20` に変更
- `app/sitemap.ts`: `perPage: 'all'` に変更

### Docs / 設定

- `docs/source/tasks/2026-06-30-articles-list-drop-content.md` に Phase 3 を追記
- `cspell.json` に `fanout` を追加

## チェックリスト

- [x] `bun run type-check` 通過
- [x] `bun run lint` 通過 (Rust clippy / oxlint / prettier / cspell)
- [x] `cargo check` 通過
- [ ] dev 環境で動作確認
  - [ ] トップ (`/`) → 2 ページ目 (`/page/2`) → 最終ページの遷移
  - [ ] `/type/note` → `/type/note/page/2` の遷移
  - [ ] `/page/1` → `/` への 308 リダイレクト確認
  - [ ] tech/note/about ナビがスクロール時に固定されること
  - [ ] モバイル幅 (375px) でページネーションのタップしやすさ
- [ ] **prefetch 観測**: Production ビルドで Network タブ `_rsc` filter → トップ表示時の prefetch が 10 件 + 隣接ページ分に収まっていることを確認
- [ ] dev TiDB で `EXPLAIN ANALYZE` を取り、`LIMIT/OFFSET` クエリが新インデックスのみで完結 (TableRowIDScan の actRows = 10) していることを確認
- [ ] dev TiDB で COUNT クエリが `IndexRangeScan` のみで完結している (TableRowIDScan 不要) ことを確認
