### PR TITLE
docs: cluster 統合の残整合

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,12 +72,12 @@ apps/web の作業時は `apps/web/CLAUDE.md` を参照（workspace 専用ガイ
 
 ### ルール: 必ず再現可能な手順を作ること
 
-クラスタに対してコマンドを実行した場合は `docs/source/cluster/` 配下の手順書に同期する。トラブルシュートをした場合は、解決時に内省し必要最小限のコマンドを同期すること。
+クラスタに対してコマンドを実行した場合は `docs/source/tasks/` 配下の手順書に同期する。トラブルシュートをした場合は、解決時に内省し必要最小限のコマンドを同期すること。
 
 ### 参照先
 
-- 概要・物理機材・ソフトウェア構成: `docs/source/cluster/01_overview.md`
-- ユーティリティ手順（全消し→再構築等）: `docs/source/cluster/98_utils/`
+- 物理機材・ソフトウェア構成: `docs/source/01_development.md` の「構成 > 必要機材」
+- 全消し→再構築手順: `docs/source/tasks/2026-06-27-tidb-full-rebuild.md`
 - 構築時の作業記録: `docs/source/tasks/`（2026-06-25〜2026-06-28 のクラスタ関連エントリ）
 - 実体: `cluster/manifests/`, `cluster/scripts/`
 

--- a/cluster/README.md
+++ b/cluster/README.md
@@ -5,4 +5,4 @@
 - `manifests/` — Kubernetes マニフェスト (tidb-cluster / monitoring / tailscale)
 - `scripts/` — ベンチマーク等の運用スクリプト
 
-構築・運用手順書は `docs/source/cluster/` を参照。
+機材構成は `docs/source/01_development.md` の「構成 > 必要機材」、構築・運用の作業記録は `docs/source/tasks/` を参照。

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -14,6 +14,5 @@ incidents/index
 refactors/index
 survey/index
 tasks/index
-cluster/index
 99_memo
 ```

--- a/docs/source/tasks/index.md
+++ b/docs/source/tasks/index.md
@@ -10,6 +10,7 @@
 2026-06-28-tidb-dashboard-search-logs
 2026-06-27-ng-monitoring-standalone
 2026-06-27-perf-bench
+2026-06-27-tidb-full-rebuild
 2026-06-27-tidbmonitor-decommission
 2026-06-26-dsql-to-tidb-migration
 2026-06-25-construction-plan


### PR DESCRIPTION
## 概要

#509 のマージに含まれなかった、`docs/source/cluster/` 解体後の整合コミットを反映する。

## 変更内容

- `docs/source/index.md` — 存在しない `cluster/index` への toctree 参照を削除 (現状 Sphinx ビルドで WARNING が出る状態)
- `docs/source/tasks/index.md` — `2026-06-27-tidb-full-rebuild` を toctree に追加 (現状 orphan で目次から辿れない)
- `CLAUDE.md` / `cluster/README.md` — 参照先を解体後のパス (`01_development.md` の必要機材、`tasks/`) に更新