### PR TITLE
perf: 記事一覧の viewport prefetch を廃止し hover 時の単発 prefetch に変更

### DIFF
--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 export function Footer() {
   return (
     <div className="w-full p-4">
-      <Link href="/">
+      <Link href="/" prefetch={false}>
         <div className="block text-center text-xs">shuntaka.dev</div>
       </Link>
       <p className="text-center text-xs">This site uses Google Analytics.</p>

--- a/apps/web/src/components/ProgressLink.tsx
+++ b/apps/web/src/components/ProgressLink.tsx
@@ -1,14 +1,53 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
+import { useCallback, useRef } from 'react';
 import { useNavigationProgress } from './NavigationProgressProvider';
 
 type ProgressLinkProps = React.ComponentProps<typeof Link>;
 
-export function ProgressLink({ children, href, onClick, ...props }: ProgressLinkProps) {
+export function ProgressLink({
+  children,
+  href,
+  onClick,
+  onMouseEnter,
+  onTouchStart,
+  prefetch = false,
+  ...props
+}: ProgressLinkProps) {
   const { startProgress } = useNavigationProgress();
   const pathname = usePathname();
+  const router = useRouter();
+  const prefetchCalledRef = useRef(false);
+
+  // router.prefetch は string のみ受け付けるため UrlObject を正規化する
+  const hrefString = typeof href === 'string' ? href : (href.pathname ?? '/');
+
+  // viewport prefetch の一斉発火を避け、hover / touch の意図があった時だけ単発で prefetch する。
+  // App Router では prefetch={false} だと hover でも自動 prefetch されないため手動で呼ぶ
+  const triggerPrefetch = useCallback(() => {
+    if (prefetch !== false) return;
+    if (prefetchCalledRef.current) return;
+    prefetchCalledRef.current = true;
+    router.prefetch(hrefString);
+  }, [router, hrefString, prefetch]);
+
+  const handleMouseEnter = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      triggerPrefetch();
+      onMouseEnter?.(e);
+    },
+    [triggerPrefetch, onMouseEnter],
+  );
+
+  const handleTouchStart = useCallback(
+    (e: React.TouchEvent<HTMLAnchorElement>) => {
+      triggerPrefetch();
+      onTouchStart?.(e);
+    },
+    [triggerPrefetch, onTouchStart],
+  );
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     const targetPath = typeof href === 'string' ? href : href.pathname;
@@ -19,7 +58,14 @@ export function ProgressLink({ children, href, onClick, ...props }: ProgressLink
   };
 
   return (
-    <Link href={href} onClick={handleClick} {...props}>
+    <Link
+      href={href}
+      onClick={handleClick}
+      onMouseEnter={handleMouseEnter}
+      onTouchStart={handleTouchStart}
+      prefetch={prefetch}
+      {...props}
+    >
       {children}
     </Link>
   );

--- a/docs/source/survey/2026-07-02-next-viewport-prefetch-burst.md
+++ b/docs/source/survey/2026-07-02-next-viewport-prefetch-burst.md
@@ -1,0 +1,79 @@
+<!-- cspell:ignore dedup -->
+
+# 記事一覧の viewport prefetch 一斉発火による体感遅延
+
+- 対象: apps/web (Next.js 16.2.9 / App Router, Vercel dev 環境)
+- 調査日: 2026-07-02
+- 関連: [TiDB 記事詳細クエリの実行プラン](./2026-06-30-tidb-article-detail-explain-plan.md)
+
+dev 環境で記事一覧ページが 10 記事程度でも遅く感じる事象。原因は viewport prefetch の一斉発火と、prefetch 1 本あたりのバックエンドコストの掛け算だった。フロント側の対処として ProgressLink を intent-based prefetch（hover / touch 時のみ単発発火）に変更した。
+
+## 事象と構造
+
+- 記事カード・ページネーション・nav タブは `ProgressLink` 経由の `next/link` で、`prefetch` prop は未指定 = デフォルトの viewport prefetch が有効だった
+- 一覧ページを開くと viewport 内の 12〜14 URL（記事 10 + ページネーション + タブ）が prefetch キューに積まれる
+- 記事詳細は `revalidate = 30` の ISR + `generateStaticParams` 空 = キャッシュ miss 時に blog-api Lambda がフルレンダリング
+- blog-api の詳細エンドポイントはリクエスト毎に Markdown→HTML 変換を実行する（DB に content_html を持たない）ため 1 本が重い
+- dev 環境はデプロイ頻度が高くトラフィックが少ないので ISR キャッシュがほぼ常に空 = 最悪パスを毎回踏む
+
+## next 16.2.9 の prefetch 内部実装
+
+prefetch は完全並列でも完全直列でもなく、優先度付きキューで同時実行数が絞られている。segment cache の scheduler 実装（`next/dist/client/components/segment-cache/scheduler.js`）より:
+
+```js
+if (task.priority === _types.PrefetchPriority.Intent) {
+  // The most recently hovered link is allowed to exceed the default limit.
+  return inProgressRequests < 12;
+}
+// The default limit is lower than the limit for a hovered link.
+return inProgressRequests < 4;
+```
+
+- viewport 由来の prefetch: **同時 4 本まで**
+- hover（Intent）由来: 優先扱いで同時 12 本まで
+
+つまり 12〜14 URL は 4 並列 × 順番待ちで流れる。1 レスポンスが数秒かかる dev 環境ではキューが数十秒単位で流れ続け、その間の実ナビゲーションが prefetch と Lambda・帯域を奪い合う。
+
+また App Router の `prefetch={false}` は **hover でも自動 prefetch しない**（Pages Router と挙動が異なる。`link.d.ts` の型コメントに明記）。hover prefetch が欲しい場合は `useRouter().prefetch()` の手動呼び出しが必要。
+
+## 対処（実施済み）
+
+### `src/components/ProgressLink.tsx` — intent-based prefetch 化
+
+- `prefetch = false` をデフォルトで destructure し `<Link prefetch={prefetch}>` に明示的に渡す。呼び出し側が `prefetch="auto"` 等を渡せば従来挙動に戻る
+- `onMouseEnter` / `onTouchStart` で `router.prefetch(href)` を単発発火。`useRef` でインスタンス単位の dedup
+- `onFocus` は付けない（next 16 の `InternalLinkProps` に存在せず型エラーになる）
+- `unstable_dynamicOnHover` prop は不採用（unstable かつ FULL prefetch になり過剰）
+
+### `src/components/Footer.tsx`
+
+`next/link` を直接 import しているのは ProgressLink と Footer の 2 ファイルのみ。Footer の `/` リンクに `prefetch={false}` を追加。
+
+## 検証結果（ローカル production ビルド + dev API 実測）
+
+`NEXT_PUBLIC_API_URL=https://api.shuntaka.tech bun run build && bun run start` で起動し、Chrome の Network（`?_rsc=` フィルタ）で確認。
+
+| 操作                  | 結果                                                               |
+| --------------------- | ------------------------------------------------------------------ |
+| 一覧ページ表示後 5 秒 | `_rsc` prefetch 0 件（修正前は 12〜14 URL が一斉発火）             |
+| 記事カード hover      | 該当記事のみ prefetch 発火                                         |
+| 同じカードに再 hover  | 追加リクエストなし（dedup）                                        |
+| 別カードに hover      | 該当記事のみ。共有レイアウトのセグメントはキャッシュ再利用で本数減 |
+| カードをクリック      | prefetch 済みキャッシュで即遷移、プログレスバー表示も従来どおり    |
+
+補足: next 16 は segment cache 方式のため、hover 1 回で `?_rsc=` リクエストがセグメント単位（route tree / layout / page / metadata）で数本飛ぶ。これは 1 記事分の分割取得であり正常。
+
+検証時の注意: `.env.local` の `NEXT_PUBLIC_USER_NAME` が dev API に存在しないユーザーだと一覧が空になる。`NEXT_PUBLIC_*` はビルド時にインライン化されるため、上書きはランタイムではなく **ビルド時** に環境変数で行う必要がある。
+
+## 見送った対応と根拠
+
+- **`revalidate = 30` の延長**: Vercel の ISR は stale-while-revalidate で動くため、期限切れでも CDN が stale を即返して裏で再生成する。遅いのはキャッシュが完全に空の初回のみで、延長しても解消せず記事更新の反映が遅れるだけ。現状維持
+- **`/page/[page]` の probe fetch**: `ArticleListView` 内の fetch と URL・オプションが同一のため Request Memoization で 1 回に dedup 済み。実害なし
+- **`generateStaticParams`（空配列）**: 意図的なオンデマンド生成方針のため維持。デプロイ直後の初回 miss まで潰したくなったらビルド時生成か on-demand revalidation を検討
+
+## 残課題（別タスク推奨）
+
+prefetch を止めても詳細ページ 1 リクエスト自体の重さは残っている。
+
+- `apps/blog-api/markdown/src/lib.rs` の `highlight_code` が **コードブロック毎に** `SyntaxSet::load_defaults_newlines()` / `ThemeSet::load_defaults()` をロードしている。`LazyLock` 化で変換コストを大きく削れる
+- OGP リンクカード / GitHub embed が変換中に同期外部 HTTP fetch（タイムアウト 5 秒 × URL 数、squid プロキシ経由）を行う。キャッシュか保存時変換（content_html の永続化）を検討

--- a/docs/source/survey/index.md
+++ b/docs/source/survey/index.md
@@ -3,6 +3,7 @@
 ```{toctree}
 :maxdepth: 1
 
+2026-07-02-next-viewport-prefetch-burst
 2026-07-01-tidb-articles-offset-plan-verify-5m
 2026-07-01-tidb-load-data-large-file
 2026-07-01-tidb-articles-list-plan-split


### PR DESCRIPTION
## 概要

- dev 環境で記事一覧ページが 10 記事でも遅い問題の対処。原因は viewport prefetch の一斉発火（12〜14 URL が同時 4 本制限のキューで流れ続け、ISR キャッシュ miss 時に重い blog-api レンダリングへ殺到）
- viewport prefetch を止め、hover / touch の意図があったリンクだけ単発 prefetch する intent-based prefetch に変更
- 調査の詳細は同梱の survey ドキュメントを参照

## 変更内容

### `apps/web/src/components/ProgressLink.tsx`

- `prefetch = false` をデフォルト化し `<Link prefetch={prefetch}>` に明示的に渡す（呼び出し側が `prefetch="auto"` 等を指定すれば従来挙動に戻る）
- `onMouseEnter` / `onTouchStart` で `useRouter().prefetch()` を単発発火。`useRef` でインスタンス単位の重複防止
- App Router の `prefetch={false}` は hover でも自動 prefetch しないため手動呼び出しが必要（Pages Router と挙動が異なる）
- 記事カード・ページネーション・nav タブは本コンポーネント経由のため自動的に恩恵を受ける

### `apps/web/src/components/Footer.tsx`

- 唯一 `next/link` を直接使用していた `/` リンクに `prefetch={false}` を追加

### `docs/source/survey/`

- `2026-07-02-next-viewport-prefetch-burst.md` を追加（next 16.2.9 の prefetch scheduler 実装の調査、検証結果、見送った対応の根拠、残課題）
- `index.md` の toctree に追加

## 検証

ローカル production ビルド（`bun run build && bun run start` + dev API）で確認済み。

- [x] 一覧ページ表示後 5 秒で `_rsc` prefetch 0 件（修正前は 12〜14 URL が一斉発火）
- [x] 記事カード hover で該当記事のみ prefetch 発火
- [x] 同一カード再 hover で追加リクエストなし（dedup）
- [x] カードクリックで即遷移、プログレスバー表示も従来どおり
- [x] `bun run type-check` / `bun run lint`（pre-push フックで全パッケージ実行済み）

## 残課題（別タスク）

- blog-api の `highlight_code` がコードブロック毎に syntect の `SyntaxSet` / `ThemeSet` をロードしている問題（`LazyLock` 化）
- OGP / GitHub embed の同期外部 fetch のキャッシュまたは保存時変換
