### PR TITLE
perf: blog-api の syntect/Regex static 化・一覧 COUNT 並列化・gzip 圧縮・Cache-Control 付与

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "sha2 0.11.0",
  "shared",
  "sqlx",
+ "tokio",
  "tracing",
  "uuid",
 ]
@@ -93,6 +94,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -821,6 +834,23 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "comrak"
@@ -4146,12 +4176,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "http 1.4.2",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ uuid = { version = "1.23.3", features = ["serde", "v4"] }
 chrono = { version = "0.4.45", features = ["serde"] }
 aws-config = "1.8.18"
 aws-sdk-ssm = "1.113.0"
-tower-http = { version = "0.7.0", features = ["cors", "trace"] }
+tower-http = { version = "0.7.0", features = ["cors", "trace", "compression-gzip"] }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
 reqwest = { version = "0.13.4", features = ["json", "rustls"] }

--- a/apps/blog-api/adapter/Cargo.toml
+++ b/apps/blog-api/adapter/Cargo.toml
@@ -10,6 +10,7 @@ async-trait.workspace = true
 derive-new.workspace = true
 anyhow.workspace = true
 sqlx.workspace = true
+tokio.workspace = true
 chrono.workspace = true
 uuid.workspace = true
 tracing.workspace = true

--- a/apps/blog-api/adapter/src/repository/users_articles.rs
+++ b/apps/blog-api/adapter/src/repository/users_articles.rs
@@ -128,6 +128,8 @@ impl UsersArticlesRepository for UsersArticlesRepositoryImpl {
         offset: u64,
         limit: u64,
     ) -> Result<ArticleSummaryPage, anyhow::Error> {
+        let pool = self.db.pool();
+
         let list_sql = r#"
             SELECT /*+ USE_INDEX(a, idx_articles_user_status_type_published_at_id) */
                 a.article_id,
@@ -148,18 +150,17 @@ impl UsersArticlesRepository for UsersArticlesRepositoryImpl {
             ORDER BY a.published_at DESC, a.article_id DESC
             LIMIT ? OFFSET ?
             "#;
-        let rows: Vec<ArticleSummaryRow> = observe_query(
+        let rows_future = observe_query(
             "article_list",
             list_sql,
-            sqlx::query_as(list_sql)
+            sqlx::query_as::<_, ArticleSummaryRow>(list_sql)
                 .bind(user_name)
                 .bind(article_type.as_str())
                 .bind(limit)
                 .bind(offset)
-                .fetch_all(&self.db.pool()),
+                .fetch_all(&pool),
             |rows| Some(rows.len() as i64),
-        )
-        .await?;
+        );
 
         let count_sql = r#"
             SELECT COUNT(*)
@@ -168,16 +169,18 @@ impl UsersArticlesRepository for UsersArticlesRepositoryImpl {
               AND a.status = 'published'
               AND a.`type` = ?
             "#;
-        let total_count: (i64,) = observe_query(
+        let count_future = observe_query(
             "article_list_count",
             count_sql,
-            sqlx::query_as(count_sql)
+            sqlx::query_as::<_, (i64,)>(count_sql)
                 .bind(user_name)
                 .bind(article_type.as_str())
-                .fetch_one(&self.db.pool()),
+                .fetch_one(&pool),
             |_| Some(1),
-        )
-        .await?;
+        );
+
+        // DB が Tailscale 越しで RTT が大きいため、一覧と件数を並列に投げる
+        let (rows, total_count) = tokio::try_join!(rows_future, count_future)?;
 
         let articles: Vec<ArticleSummary> = rows
             .into_iter()

--- a/apps/blog-api/api/src/handler/users_articles.rs
+++ b/apps/blog-api/api/src/handler/users_articles.rs
@@ -1,5 +1,6 @@
 use axum::{
     extract::{Path, Query, State},
+    http::{header, HeaderName, HeaderValue},
     Json,
 };
 use infrastructure::cloudinary::client::{CloudinaryClient, CloudinaryClientImpl};
@@ -13,6 +14,12 @@ use crate::error::AppError;
 
 const DEFAULT_PER_PAGE: u32 = 10;
 const MAX_PER_PAGE: u32 = 500;
+
+// 公開済み記事しか返さない API のため、CDN / ブラウザ双方でキャッシュを許可する
+const CACHE_CONTROL_PUBLIC: (HeaderName, HeaderValue) = (
+    header::CACHE_CONTROL,
+    HeaderValue::from_static("public, max-age=60, stale-while-revalidate=300"),
+);
 
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct UsersArticlesQuery {
@@ -94,7 +101,7 @@ pub async fn get_users_articles(
     State(registry): State<AppRegistry>,
     Path(name): Path<String>,
     Query(query): Query<UsersArticlesQuery>,
-) -> Result<Json<UsersArticlesResponse>, AppError> {
+) -> Result<([(HeaderName, HeaderValue); 1], Json<UsersArticlesResponse>), AppError> {
     let article_type = ArticleType::new(query.article_type)
         .map_err(|_| AppError::bad_request("Invalid article type"))?;
 
@@ -152,7 +159,7 @@ pub async fn get_users_articles(
         total_pages,
     };
 
-    Ok(Json(response))
+    Ok(([CACHE_CONTROL_PUBLIC], Json(response)))
 }
 
 fn parse_per_page(raw: Option<&str>) -> Result<u32, AppError> {
@@ -191,7 +198,7 @@ fn parse_per_page(raw: Option<&str>) -> Result<u32, AppError> {
 pub async fn get_users_article(
     State(registry): State<AppRegistry>,
     Path(path): Path<ArticlePath>,
-) -> Result<Json<ArticleResponse>, AppError> {
+) -> Result<([(HeaderName, HeaderValue); 1], Json<ArticleResponse>), AppError> {
     let article = registry
         .users_articles_repository()
         .find_published_by_user_name_and_slug(&path.name, &path.slug)
@@ -225,5 +232,5 @@ pub async fn get_users_article(
         updated_at: article.updated_at.map(|d| d.to_rfc3339()),
     };
 
-    Ok(Json(response))
+    Ok(([CACHE_CONTROL_PUBLIC], Json(response)))
 }

--- a/apps/blog-api/api/src/handler/webhooks.rs
+++ b/apps/blog-api/api/src/handler/webhooks.rs
@@ -12,6 +12,7 @@ use kernel::model::frontmatter::ArticleFrontmatter;
 use kernel::repository::articles::UpsertArticleInput;
 use registry::AppRegistry;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 use tracing::{error, info, warn};
 use utoipa::ToSchema;
 
@@ -37,8 +38,10 @@ struct ArticleProcessError {
 }
 
 fn extract_branch_name(git_ref: &str) -> Option<String> {
-    let re = regex::Regex::new(r"^refs/heads/(.+)$").ok()?;
-    re.captures(git_ref)
+    static BRANCH_NAME_RE: LazyLock<regex::Regex> =
+        LazyLock::new(|| regex::Regex::new(r"^refs/heads/(.+)$").unwrap());
+    BRANCH_NAME_RE
+        .captures(git_ref)
         .and_then(|caps| caps.get(1))
         .map(|m| m.as_str().to_string())
 }

--- a/apps/blog-api/markdown/src/lib.rs
+++ b/apps/blog-api/markdown/src/lib.rs
@@ -2,8 +2,17 @@ use comrak::Options;
 use comrak::plugins::syntect::SyntectAdapter;
 use regex::Regex;
 use scraper::{Html, Selector};
+use std::sync::LazyLock;
 use std::time::Duration;
+use syntect::highlighting::ThemeSet;
+use syntect::parsing::SyntaxSet;
 use url::Url;
+
+// syntect のデフォルト定義ロードは1回数十msかかるため、プロセス内で1度だけ行い使い回す
+static SYNTAX_SET: LazyLock<SyntaxSet> = LazyLock::new(SyntaxSet::load_defaults_newlines);
+static THEME_SET: LazyLock<ThemeSet> = LazyLock::new(ThemeSet::load_defaults);
+static SYNTECT_ADAPTER: LazyLock<SyntectAdapter> =
+    LazyLock::new(|| SyntectAdapter::new(Some("base16-ocean.dark")));
 
 /// GitHub link information extracted from URL
 #[derive(Debug, Clone)]
@@ -353,11 +362,13 @@ fn process_link_cards(markdown: &str) -> String {
 /// Parse a GitHub blob URL into its components
 fn parse_github_link(url: &str) -> Option<GitHubLink> {
     // Pattern: https://github.com/{owner}/{repo}/blob/{branch}/{path}[?plain=1][#L{start}[-L{end}]]
-    let re = Regex::new(
-        r"^https://github\.com/([^/]+)/([^/]+)/blob/([^/?#]+)/([^?#]+)(?:\?[^#]*)?(?:#L(\d+)(?:-L(\d+))?)?$"
-    ).ok()?;
+    static GITHUB_LINK_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r"^https://github\.com/([^/]+)/([^/]+)/blob/([^/?#]+)/([^?#]+)(?:\?[^#]*)?(?:#L(\d+)(?:-L(\d+))?)?$"
+        ).unwrap()
+    });
 
-    let caps = re.captures(url)?;
+    let caps = GITHUB_LINK_RE.captures(url)?;
 
     Some(GitHubLink {
         owner: caps.get(1)?.as_str().to_string(),
@@ -825,9 +836,10 @@ fn is_valid_html_tag(content: &str) -> bool {
 /// Preprocess markdown to handle custom embed syntax
 fn preprocess_embeds(markdown: &str) -> String {
     // SpeakerDeck: @[sd](slideId,slideNo,aspectRatio,dataRatio)
-    let sd_re = Regex::new(r"@\[sd\]\(([^,]+),([^,]*),([^,]+),([^)]+)\)").unwrap();
+    static SD_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"@\[sd\]\(([^,]+),([^,]*),([^,]+),([^)]+)\)").unwrap());
 
-    sd_re
+    SD_RE
         .replace_all(markdown, |caps: &regex::Captures| {
             let slide_id = &caps[1];
             let slide_no = &caps[2];
@@ -852,9 +864,11 @@ fn process_containers<F>(markdown: &str, convert_inner: F) -> String
 where
     F: Fn(&str) -> String,
 {
-    let container_re = Regex::new(r"(?s):::[ \t]*(details|message)[ \t]*([^\n]*)\n(.*?):::").unwrap();
+    static CONTAINER_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?s):::[ \t]*(details|message)[ \t]*([^\n]*)\n(.*?):::").unwrap()
+    });
 
-    container_re
+    CONTAINER_RE
         .replace_all(markdown, |caps: &regex::Captures| {
             let container_type = &caps[1];
             let argument = caps[2].trim();
@@ -883,7 +897,7 @@ where
 
 /// Markdown to HTML converter with syntax highlighting
 pub struct MarkdownConverter {
-    syntect_adapter: SyntectAdapter,
+    syntect_adapter: &'static SyntectAdapter,
 }
 
 impl Default for MarkdownConverter {
@@ -895,7 +909,7 @@ impl Default for MarkdownConverter {
 impl MarkdownConverter {
     pub fn new() -> Self {
         Self {
-            syntect_adapter: SyntectAdapter::new(Some("base16-ocean.dark")),
+            syntect_adapter: &SYNTECT_ADAPTER,
         }
     }
 
@@ -932,19 +946,16 @@ impl MarkdownConverter {
 
     /// Highlight code using syntect
     fn highlight_code(&self, code: &str, lang: &str) -> String {
-        use syntect::highlighting::ThemeSet;
         use syntect::html::highlighted_html_for_string;
-        use syntect::parsing::SyntaxSet;
 
-        let ss = SyntaxSet::load_defaults_newlines();
-        let ts = ThemeSet::load_defaults();
-        let theme = &ts.themes["base16-ocean.dark"];
+        let ss = &*SYNTAX_SET;
+        let theme = &THEME_SET.themes["base16-ocean.dark"];
 
         let syntax = ss
             .find_syntax_by_token(lang)
             .unwrap_or_else(|| ss.find_syntax_plain_text());
 
-        highlighted_html_for_string(code, &ss, syntax, theme).unwrap_or_else(|_| html_escape(code))
+        highlighted_html_for_string(code, ss, syntax, theme).unwrap_or_else(|_| html_escape(code))
     }
 
     /// Simple conversion without container processing (used for inner content)
@@ -963,14 +974,16 @@ impl MarkdownConverter {
         options.render.github_pre_lang = true;
 
         let mut plugins = comrak::options::Plugins::default();
-        plugins.render.codefence_syntax_highlighter = Some(&self.syntect_adapter);
+        plugins.render.codefence_syntax_highlighter = Some(self.syntect_adapter);
 
         comrak::markdown_to_html_with_plugins(markdown, &options, &plugins)
     }
 
     fn add_target_blank_to_external_links(&self, html: &str) -> String {
-        let re = Regex::new(r#"<a href="(https?://[^"]*)""#).unwrap();
-        re.replace_all(html, r#"<a href="$1" target="_blank" rel="noopener noreferrer""#)
+        static EXTERNAL_LINK_RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r#"<a href="(https?://[^"]*)""#).unwrap());
+        EXTERNAL_LINK_RE
+            .replace_all(html, r#"<a href="$1" target="_blank" rel="noopener noreferrer""#)
             .to_string()
     }
 }

--- a/apps/blog-api/src/bin/app.rs
+++ b/apps/blog-api/src/bin/app.rs
@@ -12,6 +12,7 @@ use axum::Router;
 use shared::config::AppConfig;
 use shared::telemetry::Telemetry;
 use tokio::net::TcpListener;
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 use tracing::Level;
@@ -89,6 +90,8 @@ async fn bootstrap(telemetry: Option<Telemetry>) -> Result<()> {
                 .on_response(DefaultOnResponse::new().level(Level::INFO)),
         )
         .layer(cors)
+        // syntect がインライン style を吐くため content_html が大きく、gzip の効果が高い
+        .layer(CompressionLayer::new())
         .with_state(registry);
 
     let addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), app_config.server.port);


### PR DESCRIPTION
## 概要

blog-api のレイテンシ改善のうち、スキーマ変更を伴わない小さい独立した改善4点をまとめた PR です。

- syntect のシンタックス定義・テーマと `SyntectAdapter` を `LazyLock` static 化（従来はコードブロックごとに `SyntaxSet::load_defaults_newlines()` / `ThemeSet::load_defaults()` をロードしており、1回あたり数十msかかっていた）
- 呼び出しごとに `Regex::new` していた5箇所を `static LazyLock<Regex>` 化
- 記事一覧 API の SELECT と COUNT を `tokio::try_join!` で並列化（DB が Tailscale 越しの TiDB で RTT が大きいため直列 await が重い）
- `CompressionLayer` (gzip) を追加し、公開記事 GET 2本に `Cache-Control: public, max-age=60, stale-while-revalidate=300` を付与

## 変更詳細

| ファイル | 変更 |
| --- | --- |
| `apps/blog-api/markdown/src/lib.rs` | `SYNTAX_SET` / `THEME_SET` / `SYNTECT_ADAPTER` を static 化。`highlight_code` と `MarkdownConverter::new` が使い回すように変更。`parse_github_link` / `preprocess_embeds` / `process_containers` / `add_target_blank_to_external_links` の Regex を static 化 |
| `apps/blog-api/api/src/handler/webhooks.rs` | `extract_branch_name` の Regex を static 化 |
| `apps/blog-api/adapter/src/repository/users_articles.rs` | `find_published_by_user_name_and_type` の一覧取得と件数取得を `tokio::try_join!` で並列実行 |
| `apps/blog-api/adapter/Cargo.toml` | `tokio` を追加（`try_join!` 用） |
| `Cargo.toml` | tower-http の features に `compression-gzip` を追加 |
| `apps/blog-api/src/bin/app.rs` | `CompressionLayer::new()` を追加（syntect がインライン style を吐くため `content_html` が大きく gzip の効果が高い） |
| `apps/blog-api/api/src/handler/users_articles.rs` | 公開記事 GET 2本の成功レスポンスに `Cache-Control: public, max-age=60, stale-while-revalidate=300` を付与（エラー応答には付けない） |

## テスト

- [x] `cargo build` 成功
- [x] `cargo test` 全パス（markdown crate 47件含む）
- [x] `cargo clippy --all-targets` 警告なし

## 補足

記事詳細 API のオンザフライ Markdown 変換（OGP/GitHub 埋め込みの同期 HTTP フェッチ含む）の廃止は、スキーマ変更（`articles.content_html` カラム追加）を伴うため別 PR で行います。
