### PR TITLE
fix: X-Ray セグメントの status 欠落と DB 接続先の localhost 表示を修正

### DIFF
--- a/apps/blog-api/adapter/src/observability.rs
+++ b/apps/blog-api/adapter/src/observability.rs
@@ -150,6 +150,10 @@ where
         db.statement_hash = %statement_hash,
         db.query_type = query_type,
         net.peer.name = peer_name,
+        // awsxray exporter は db.connection_string が無いと接続先を localhost に
+        // フォールバックするため実ホストを明示する。server.address は新 semconv 用
+        server.address = peer_name,
+        db.connection_string = peer_name,
         db.rows_returned = tracing::field::Empty,
         otel.status_code = tracing::field::Empty,
         error.message = tracing::field::Empty,

--- a/apps/blog-api/api/src/observability.rs
+++ b/apps/blog-api/api/src/observability.rs
@@ -63,18 +63,31 @@ pub async fn observe_request(req: Request, next: Next) -> Response {
         http.request.method = %method,
         cold_start = cold_start,
         http.response.status_code = tracing::field::Empty,
+        // ADOT collector (awsxray exporter) が旧 semconv キーしか見ない場合でも
+        // X-Ray セグメントの http.response.status に反映されるよう旧キーも併記する
+        http.status_code = tracing::field::Empty,
         otel.status_code = tracing::field::Empty,
     );
 
     let start = Instant::now();
-    let response = next.run(req).instrument(span.clone()).await;
-    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
-
-    let status = response.status();
-    span.record("http.response.status_code", status.as_u16());
-    if status.is_server_error() {
-        span.record("otel.status_code", "ERROR");
+    // status は span が生きている instrument スコープ内で record し、
+    // await 完了 = span の最後のハンドル drop で flush() より前に確実に close させる。
+    // close 前に flush が走ると、このリクエストの span 自体が今回の export に
+    // 乗らない (次の invoke まで持ち越される) ため。
+    let response = async {
+        let response = next.run(req).await;
+        let status = response.status();
+        let current = tracing::Span::current();
+        current.record("http.response.status_code", status.as_u16());
+        current.record("http.status_code", status.as_u16());
+        if status.is_server_error() {
+            current.record("otel.status_code", "ERROR");
+        }
+        response
     }
+    .instrument(span)
+    .await;
+    let elapsed_ms = start.elapsed().as_secs_f64() * 1000.0;
 
     REQUEST_DURATION.record(
         elapsed_ms,

--- a/cspell.json
+++ b/cspell.json
@@ -144,6 +144,7 @@
     "rustup",
     "sarif",
     "segoe",
+    "semconv",
     "serde",
     "shuntaka",
     "speakerdeck",


### PR DESCRIPTION
## 概要

#523 の OTel 計装で X-Ray セグメントに出ていた2つの不備を修正します（dev の実トレースで確認された症状）。

## 症状と修正

### 1. `http.response.status` が常に 0

`observe_request` はハンドラ完了後に `span.record("http.response.status_code", ...)` していましたが、X-Ray に届くセグメントでは status が 0 のままでした（annotations / metadata にも出ていない）。

修正: status の record を instrument 中の future 内（`Span::current()`）に移し、`.instrument(span)` に所有権を渡すことで await 完了時点（`flush()` より前）に span が確実に close される構造に変更。あわせて ADOT collector の awsxray exporter が旧 semconv キーしか見ないバージョンでも拾えるよう `http.status_code`（旧キー）を併記。

これで X-Ray 上の 4xx/5xx が error/fault として分類されるようになり、span が「自分のリクエストの flush に乗らず次の invoke まで持ち越される」順序問題も解消されます。

### 2. `sql.connection_string` が `localhost/blog_dev`

db span はホストを旧 semconv の `net.peer.name` にしか入れておらず、awsxray exporter が `db.connection_string` 不在時のフォールバックで `localhost/<db名>` を生成していました。実際の接続先（`tidb-proxy.internal`）と異なる表示になりサービスマップが誤解を招く状態でした。

修正: `db.connection_string` と `server.address`（新 semconv）に実ホストを設定。

## テスト

- [x] `cargo test` 全パス
- [x] `cargo clippy --all --all-targets -- -D warnings` 警告なし
- [x] `bun run lint` 全パス

デプロイ後、dev で新しいトレースを取得して `http.response.status` が実ステータス、`connection_string` が `tidb-proxy.internal/blog_dev` になることを確認してください。
