### PR TITLE
fix: X-Ray の http.response.status が 0 になる問題を修正（status を i64 で record）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,13 +68,17 @@ dependencies = [
  "kernel",
  "markdown",
  "opentelemetry",
+ "opentelemetry_sdk",
  "regex",
  "registry",
  "serde",
  "serde_json",
  "shared",
  "tokio",
+ "tower",
  "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "utoipa",
  "utoipa-swagger-ui",
 ]
@@ -2548,6 +2552,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.4",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/apps/blog-api/api/Cargo.toml
+++ b/apps/blog-api/api/Cargo.toml
@@ -20,3 +20,9 @@ futures.workspace = true
 regex.workspace = true
 shared.workspace = true
 opentelemetry.workspace = true
+
+[dev-dependencies]
+opentelemetry_sdk = { version = "0.32.0", features = ["testing"] }
+tracing-opentelemetry.workspace = true
+tracing-subscriber.workspace = true
+tower = { version = "0.5.3", features = ["util"] }

--- a/apps/blog-api/api/src/observability.rs
+++ b/apps/blog-api/api/src/observability.rs
@@ -78,8 +78,11 @@ pub async fn observe_request(req: Request, next: Next) -> Response {
         let response = next.run(req).await;
         let status = response.status();
         let current = tracing::Span::current();
-        current.record("http.response.status_code", status.as_u16());
-        current.record("http.status_code", status.as_u16());
+        // i64 で record する。u16/u64 のままだと tracing-opentelemetry (0.33) が
+        // record_u64 未実装のため Debug 文字列になり、ADOT の awsxray translator の
+        // Value.Int() が 0 を返して X-Ray の http.response.status が 0 に化ける
+        current.record("http.response.status_code", i64::from(status.as_u16()));
+        current.record("http.status_code", i64::from(status.as_u16()));
         if status.is_server_error() {
             current.record("otel.status_code", "ERROR");
         }
@@ -102,4 +105,84 @@ pub async fn observe_request(req: Request, next: Next) -> Response {
     shared::telemetry::flush();
 
     response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request as HttpRequest;
+    use axum::routing::get;
+    use opentelemetry::trace::TracerProvider as _;
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+    use tower::ServiceExt;
+    use tracing::Level;
+    use tracing_subscriber::Layer;
+    use tracing_subscriber::filter::Targets;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    /// 本番 (src/bin/app.rs) と同じ「Targets フィルタ付き otel layer」構成で、
+    /// export された lambda.handler span に後から record した status が
+    /// 乗ることを検証する回帰テスト。
+    /// X-Ray で http.response.status が 0 になる問題の切り分け用。
+    #[tokio::test]
+    async fn lambda_handler_span_exports_response_status() {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("test");
+
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_opentelemetry::layer().with_tracer(tracer).with_filter(
+                Targets::new()
+                    .with_target("api", Level::INFO)
+                    .with_target("adapter", Level::INFO),
+            ),
+        );
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let app = Router::new()
+            .route("/ping", get(|| async { "pong" }))
+            .route_layer(axum::middleware::from_fn(observe_request));
+
+        let response = app
+            .oneshot(HttpRequest::get("/ping").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+
+        provider.force_flush().unwrap();
+        let spans = exporter.get_finished_spans().unwrap();
+        let handler = spans
+            .iter()
+            .find(|s| s.name == "lambda.handler")
+            .unwrap_or_else(|| panic!("lambda.handler span not exported: {spans:?}"));
+
+        let attr = |key: &str| {
+            handler
+                .attributes
+                .iter()
+                .find(|kv| kv.key.as_str() == key)
+                .map(|kv| kv.value.clone())
+        };
+        // 値の「型」まで検証する。u16 のまま record すると tracing-opentelemetry が
+        // record_u64 を実装していないため Debug 文字列 ("200") になり、ADOT の
+        // awsxray translator の Value.Int() が 0 を返して X-Ray の status が 0 になる
+        assert_eq!(
+            attr("http.response.status_code"),
+            Some(opentelemetry::Value::I64(200)),
+            "attributes: {:?}",
+            handler.attributes
+        );
+        assert_eq!(
+            attr("http.status_code"),
+            Some(opentelemetry::Value::I64(200))
+        );
+        assert_eq!(
+            attr("app.route"),
+            Some(opentelemetry::Value::from("/ping".to_string()))
+        );
+    }
 }

--- a/cspell.json
+++ b/cspell.json
@@ -115,6 +115,7 @@
     "notesansjpmid",
     "noto",
     "omitempty",
+    "oneshot",
     "onig",
     "ocha",
     "oembed",


### PR DESCRIPTION
## 概要

#528 のあとも X-Ray セグメントの `http.response.status` が 0 のままだった問題の根本修正です。

## 原因

status を `status.as_u16()` のまま `span.record()` していたのが原因でした。

1. tracing は u16 を `record_u64` として扱う（tracing-core の `impl_values!` で u16/u32 等は u64 に昇格）
2. tracing-opentelemetry 0.33 の属性 visitor は `record_u64` を実装していない（OTel の `Value` に u64 型が無いため。実装は bool / f64 / i64 / str / debug のみ）
3. その結果 `Visit` トレイトのデフォルト実装で `record_debug` に落ち、OTel 属性値が文字列 `"200"` になる
4. ADOT collector の awsxray translator は `http.response.status_code` / `http.status_code` を見つけると Go pdata の `Value.Int()` を呼ぶが、Int 型でない値には 0 を返すため `status: 0` が書き込まれる

`db.rows_returned` が正しく数値で出ていたのは i64 で record していたためで、症状の切り分けと整合します（#528 で直した接続先ホストと違い、status は「属性が届いていない」のではなく「文字列型で届いて 0 に化けていた」）。

## 修正

- `i64::from(status.as_u16())` で record し、`record_i64` → `Value::I64` 経路に乗せる
- 回帰テストを追加: 本番と同じ Targets フィルタ付き otel layer + `InMemorySpanExporter` で `observe_request` を通し、export された span の `http.response.status_code` / `http.status_code` が「I64 型の 200」であることを検証（`to_string()` 比較だと文字列 "200" でも通ってしまうため、型まで assert する）。修正前のコードではこのテストは fail する

record 箇所は全数確認済みで、unsigned のまま record していたのは status の2箇所のみです（他は str / display / i64）。

## テスト

- [x] `cargo test` 全パス（api crate に回帰テスト1件追加）
- [x] `cargo clippy --all --all-targets -- -D warnings` 警告なし
- [x] `bun run lint` 全パス

デプロイ後、dev の新しいトレースで `http.response.status` が 200 になることを確認してください。
