### PR TITLE
perf: react-tweet を遅延ロード化して記事ページの初期バンドルを削減

### DIFF
--- a/apps/web/src/components/ArticleContent.tsx
+++ b/apps/web/src/components/ArticleContent.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import type { ComponentProps } from 'react';
 import { useEffect, useMemo, useRef } from 'react';
 import { useNavigationProgress } from '@/components/NavigationProgressProvider';
-import { SafeTweet } from '@/components/SafeTweet';
+
+// react-tweet (+ swr) はツイートを含む記事でのみ必要なので遅延ロードする
+const SafeTweet = dynamic(() => import('@/components/SafeTweet').then((m) => m.SafeTweet));
 
 function AvatarImg({ src, ...props }: ComponentProps<'img'>) {
   const hiResSrc = typeof src === 'string' ? src.replace('_normal.', '_bigger.') : src;


### PR DESCRIPTION
## 概要

- `ArticleContent` が `SafeTweet` を静的 import していたため、react-tweet (+ swr) を含む約 14KB gz のチャンクがツイートを含まない記事ページでも常にロードされていた
- `next/dynamic` による遅延ロードに切り替え、ツイートを含む記事のみがハイドレーション後にチャンクを取得するように変更
- ツイート無し記事のページ固有 JS は約 54.8KB gz → 約 42.7KB gz（約 12KB gz / 22% 削減）

## 変更内容

### apps/web/src/components/ArticleContent.tsx

- `SafeTweet` の静的 import を `next/dynamic` の遅延 import に変更（4行の変更のみ）
- ツイート有無の判定は既存の `parseHtmlWithTweets` のままで、描画ロジックに変更なし

## テストプラン

- [x] `bun run build` 成功。ビルド後のチャンクを実測し、react-tweet が記事ページの client-reference manifest から外れて遅延チャンク（約 13KB gz）に分離されたことを確認
- [x] `bun run type-check` / `bun run lint` パス
- [x] 本番ビルド（`next start`）+ Playwright ヘッドレスで検証
  - ツイート5件の記事: 埋め込み全件描画、フォールバック 0、遅延チャンクがオンデマンドでロードされる
  - ツイート無し記事: 遅延チャンクは一切ロードされず、本文描画・コードコピーボタン・目次が正常
