### PR TITLE
ci: tidb-proxy の ecspresso デプロイを workflow_dispatch で実行できるワークフローを追加

### DIFF
--- a/.github/workflows/deploy-tidb-proxy.yaml
+++ b/.github/workflows/deploy-tidb-proxy.yaml
@@ -1,0 +1,45 @@
+name: Deploy tidb-proxy
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'デプロイする commit SHA / タグ（空なら実行ブランチの HEAD）'
+        required: false
+        default: ''
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: deploy-tidb-proxy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build & Deploy (ecspresso)
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ inputs.ref }}
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          # tidb-proxy は dev/prd 共用スタックのため dev ロール固定
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/dev-shuntaka-assume-role
+          aws-region: ap-northeast-1
+
+      - name: Install ecspresso
+        uses: kayac/ecspresso@d4d5193102a5fb45e84fa8fd0fc9a524a7bf8893 # v2.8.0
+        with:
+          version: v2.6.0
+
+      - name: Deploy tidb-proxy
+        run: ./scripts/deploy-tidb-proxy.sh

--- a/docs/source/01_development.md
+++ b/docs/source/01_development.md
@@ -239,10 +239,13 @@ brew install kayac/tap/ecspresso
 ecspresso version
 ```
 
-tidb-proxy コンテナ image の build & push と ecspresso deploy をまとめた `scripts/deploy-tidb-proxy.sh` を実行する。`IMAGE_TAG` は git short SHA が自動で使われる（環境変数で上書き可）。
+tidb-proxy コンテナ image の build & push と ecspresso deploy をまとめた `scripts/deploy-tidb-proxy.sh` を実行する。`IMAGE_TAG` は git short SHA が自動で使われる（環境変数で上書き可）。GitHub Actions の Deploy tidb-proxy ワークフロー（workflow_dispatch、`ref` 入力で commit SHA / タグ指定可）でも同じスクリプトを実行できる。
 
 ```bash
 scripts/deploy-tidb-proxy.sh
+
+# GitHub Actions から実行する場合
+gh workflow run deploy-tidb-proxy.yaml --ref preview
 ```
 
 tidb-proxy task の動作確認。`runningCount: 1` かつ `events[0]` が `steady state` になり、ログに `Accepting HTTP Socket connections` と `forwarder: pre-warm dial ok` が出れば成功。<https://login.tailscale.com/admin/machines> で `tidb-proxy` device が `tag:proxy` 付きで Connected (緑) になっているかも確認する。


### PR DESCRIPTION
## 概要

- `scripts/deploy-tidb-proxy.sh`（ECR push + ecspresso deploy）を GitHub Actions から手動実行できるワークフローを追加
- トリガーは workflow_dispatch のみ。`ref` 入力で commit SHA / タグを指定可能（空なら実行ブランチの HEAD）
- 既存の CDK デプロイ（`deploy.yaml` / `reusable-deploy.yaml`）には組み込まず、独立ワークフローとして分離

## 変更詳細

### `.github/workflows/deploy-tidb-proxy.yaml`（新規）

- ランナーは `ubuntu-24.04-arm`。public リポジトリのため無料で利用でき、native arm64 なので `docker buildx build --platform linux/arm64` が QEMU なしで動く
- AWS 認証は既存の OIDC ロール `dev-shuntaka-assume-role` を流用（tidb-proxy は dev/prd 共用スタックのため dev ロール固定）。ECR push・`ecs:*`・`ssm:GetParameter`・PassRole は既存権限で充足しており IAM 変更なし
- ecspresso は `kayac/ecspresso@d4d5193` (v2.8.0、タグ SHA 照合済み) で v2.6.0 バイナリをインストール
- デプロイ本体は `scripts/deploy-tidb-proxy.sh` を呼ぶだけ。`IMAGE_TAG` は checkout した HEAD の short SHA が自動採用される
- `concurrency: deploy-tidb-proxy` で同時実行を直列化

### `docs/source/01_development.md`

- tidb-proxy デプロイの節に GitHub Actions からの実行方法（`gh workflow run deploy-tidb-proxy.yaml --ref preview`）を追記

## テストプラン

- [x] prettier --check / cspell パス
- [x] zizmor ローカル監査で findings なし
- [ ] preview マージ後に `gh workflow run deploy-tidb-proxy.yaml --ref preview` を実行し、ECR push と ecspresso deploy の成功を確認
- [ ] ECS サービス `tidb-proxy` が新タスク定義リビジョンで steady state になることを確認
