### PR TITLE
fix: deploy-tidb-proxy ワークフローに environment: dev を指定して AWS_ACCOUNT_ID を解決可能にする

### DIFF
--- a/.github/workflows/deploy-tidb-proxy.yaml
+++ b/.github/workflows/deploy-tidb-proxy.yaml
@@ -20,6 +20,8 @@ jobs:
     name: Build & Deploy (ecspresso)
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
+    # AWS_ACCOUNT_ID は dev environment のシークレットのため environment 指定が必須
+    environment: dev
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## 概要

- Deploy tidb-proxy ワークフロー（#544）の実行時に OIDC AssumeRole が `Request ARN is invalid` で失敗する問題を修正
- `AWS_ACCOUNT_ID` はリポジトリシークレットではなく dev environment のシークレットのため、`environment: dev` 未指定だと `secrets.AWS_ACCOUNT_ID` が空になり、ロール ARN が `arn:aws:iam:::role/dev-shuntaka-assume-role` という不正な形になっていた

## 変更詳細

### `.github/workflows/deploy-tidb-proxy.yaml`

- deploy ジョブに `environment: dev` を追加（既存の `reusable-deploy.yaml` が `environment: ${{ inputs.stageName }}` で解決しているのと同じ仕組み）

## テストプラン

- [x] prettier --check / zizmor パス
- [ ] preview マージ後に `gh workflow run deploy-tidb-proxy.yaml --ref preview` を再実行し、AssumeRole 成功と ecspresso deploy 完了を確認
