### PR TITLE
docs: backfill SQL の適用コマンドを実ファイルパスに修正

### DIFF
--- a/docs/source/tasks/2026-07-05-article-tags.md
+++ b/docs/source/tasks/2026-07-05-article-tags.md
@@ -209,7 +209,7 @@ gh workflow run deploy.yaml --field stageName=dev --field stack=main
 mysql -h tidb.$TAILNET -P 4000 -u root -D $SCHEMA \
   -e 'SELECT MAX(updated_at) FROM articles'
 
-mysql -h tidb.$TAILNET -P 4000 -u root -D $SCHEMA < backfill.sql
+mysql -h tidb.$TAILNET -P 4000 -u root -D $SCHEMA < tools/dsql-cli/dsl-tidb/backfill/2026-07-05-article-tags.sql
 
 # タグ別記事数
 mysql -h tidb.$TAILNET -P 4000 -u root -D $SCHEMA -e '


### PR DESCRIPTION
## 概要

- 記事タグ機能の手順書（`docs/source/tasks/2026-07-05-article-tags.md`）で、backfill SQL の適用コマンドがプレースホルダ（`backfill.sql`）のままだったため、実ファイルパス `tools/dsql-cli/dsl-tidb/backfill/2026-07-05-article-tags.sql` に修正

## 変更内容

| ファイル | 変更 |
| --- | --- |
| docs/source/tasks/2026-07-05-article-tags.md | Phase F 手順 4 の mysql リダイレクト先を実パスに修正（1行） |

## チェックリスト

- [x] 修正後のコマンドが生成される SQL の実パス（dry-run で `tools/dsql-cli/dsl-tidb/backfill/2026-07-05-article-tags.sql` に出力）と一致することを確認
- [x] lint / spell-check 通過（pre-push hook で実行済み）
