### PR TITLE
docs: 運用ドキュメントに tag-facets ルートとタグ絞り込みの span 変化を追記

### DIFF
--- a/docs/source/03_operations.md
+++ b/docs/source/03_operations.md
@@ -197,14 +197,15 @@ annotation キーはドットがアンダースコアに変換される。
 
 `app.route` に入る値（axum の MatchedPath そのまま。health のルートは末尾スラッシュ付き `/health/` になる点に注意）:
 
-| `app.route`                     | メソッド | 内容                                                                     |
-| ------------------------------- | -------- | ------------------------------------------------------------------------ |
-| `/users/{name}/articles`        | GET      | 記事一覧                                                                 |
-| `/users/{name}/articles/{slug}` | GET      | 記事詳細                                                                 |
-| `/health/`                      | GET      | ヘルスチェック                                                           |
-| `/health/db`                    | GET      | DB ヘルスチェック（5 分毎の SELECT 1 プローブが叩く）                    |
-| `/webhooks/github`              | POST     | GitHub Webhook（記事同期）                                               |
-| `/swagger` ほか                 | GET      | Swagger UI（`/swagger/` / `/swagger/{*rest}` / `/swagger/openapi.json`） |
+| `app.route`                         | メソッド | 内容                                                                                             |
+| ----------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `/users/{name}/articles`            | GET      | 記事一覧（`tags` 指定時はタグ絞り込み。一覧 + COUNT + ページ内タグ取得の複数クエリ span が出る） |
+| `/users/{name}/articles/tag-facets` | GET      | タグファセット集計（絞り込みパネル用。tags なしは `tag_article_counts` 前計算読み）              |
+| `/users/{name}/articles/{slug}`     | GET      | 記事詳細                                                                                         |
+| `/health/`                          | GET      | ヘルスチェック                                                                                   |
+| `/health/db`                        | GET      | DB ヘルスチェック（5 分毎の SELECT 1 プローブが叩く）                                            |
+| `/webhooks/github`                  | POST     | GitHub Webhook（記事同期。`tag_article_counts` の同期再計算 subsegment を含む）                  |
+| `/swagger` ほか                     | GET      | Swagger UI（`/swagger/` / `/swagger/{*rest}` / `/swagger/openapi.json`）                         |
 
 クエリサンプル:
 


### PR DESCRIPTION
## 概要

- #551（タグ絞り込みのサーバーサイド化）で追加された API ルートと span の変化を運用ドキュメント（X-Ray クエリリファレンス）に反映

## 変更内容

`docs/source/03_operations.md` の `app.route` テーブルを更新:

- `/users/{name}/articles/tag-facets`（GET）の行を追加。tags なしは `tag_article_counts` 前計算読みである旨を注記
- `/users/{name}/articles`: `tags` 指定時の絞り込みと、一覧 + COUNT + ページ内タグ取得の複数クエリ span が出る旨を注記
- `/webhooks/github`: `tag_article_counts` 同期再計算の subsegment を含む旨を注記

## チェック

- [x] ドキュメントのみの変更（コード変更なし）
- [x] `vp fmt` / secretlint / gitleaks / zizmor パス（pre-commit / pre-push hook）
