### PR TITLE
docs: node1 再起動時の uncordon 忘れ対策を追記し pd-ctl region の --jq を修正

### DIFF
--- a/docs/source/03_operations.md
+++ b/docs/source/03_operations.md
@@ -166,6 +166,7 @@ kubectl -n tidb-cluster get pods -o wide
 worker と同じ手順でよい。以下の点だけ異なる。
 
 - 再起動中は kubectl が返らなくなるが正常。node1 の kubelet が上がると static pod（apiserver / etcd）が自動復旧し、kubectl も戻る
+- kubectl が戻ったら **`kubectl uncordon node1` から手順を再開する**。`kubectl get nodes -w` の切断で手順が中断されるため uncordon を忘れやすい。忘れても既存 Pod は動き続けるので気付けず、後日 Pod を作り直したとき（TiKV rolling restart 等）に `volume node affinity conflict` で Pending になって発覚する（実績: 2026-07-05）
 - アクセスの少ない時間帯に行う
 - `ts-tidb-public` の proxy Pod が node1 に載っている場合、退避は**必ず再起動前に**行う。apiserver も同時に停止するため、落ちてからでは他ノードへ退避できず、ブログ DB 経路が node1 復帰まで止まる
 - 万一 node1 のディスクが死ぬと etcd（クラスタ状態）を失う。TiDB のデータ自体は TiKV 3 レプリカなので無事
@@ -173,7 +174,7 @@ worker と同じ手順でよい。以下の点だけ異なる。
 ### 復帰確認
 
 ```bash
-kubectl get nodes                          # 全ノード Ready
+kubectl get nodes                          # 全ノード Ready。SchedulingDisabled が残っていたら uncordon 忘れ
 kubectl -n kube-system get pods            # control plane / cilium / coredns が Running
 kubectl -n tidb-cluster get pods -o wide   # PD / TiKV / TiDB が Running
 kubectl -n tailscale get pods -o wide      # tidb-public の proxy Pod が Running

--- a/docs/source/tasks/2026-07-03-tikv-memory-after-drop-table.md
+++ b/docs/source/tasks/2026-07-03-tikv-memory-after-drop-table.md
@@ -60,9 +60,11 @@ kubectl exec -n tidb-cluster basic-tikv-0 -- sh -c \
 
 ```bash
 kubectl exec -n tidb-cluster basic-pd-0 -- sh -c '
-  /pd-ctl region --jq="length"
-  curl -s http://127.0.0.1:2379/pd/api/v1/stores | grep -E "region_count|region_size"'
+  /pd-ctl region --jq=".count"
+  curl -s http://127.0.0.1:2379/pd/api/v1/stores | grep -E "region_count|region_size|leader_count"'
 ```
+
+> `pd-ctl region` の出力は `{"count": N, "regions": [...]}` 形式。`--jq="length"` はトップレベルのキー数（常に 2）を返すので region 数には使えない。region 数は `.count`、リーダー偏りは stores 側の `leader_count` で見る（`region_count` はレプリカ数なので全 store で揃い、偏り判定には使えない）。
 
 実測: region はクラスタ全体で 5 個 / 約 24MB。500 万行分の region は GC・マージ済みで存在しない。
 


### PR DESCRIPTION
## 概要

- 2026-07-05 に発生した「node1 の uncordon 忘れにより、TiKV rolling restart 時に basic-tikv-0 が `volume node affinity conflict` で Pending になる」トラブルの再発防止をドキュメントに反映
- あわせて調査中に見つけた `pd-ctl region --jq="length"` の誤り（region 数ではなくトップレベルのキー数を返す）を修正

## 変更内容

### docs/source/03_operations.md

- control plane（node1）再起動の注意点に「kubectl が戻ったら `kubectl uncordon node1` から手順を再開する」を追記。uncordon を忘れても既存 Pod は動き続けるため気付けず、後日 Pod 再作成時に Pending で発覚するという失敗パターンを実績日付きで記載
- 復帰確認の `kubectl get nodes` に「SchedulingDisabled が残っていたら uncordon 忘れ」の注記を追加

### docs/source/tasks/2026-07-03-tikv-memory-after-drop-table.md

- `pd-ctl region --jq="length"` を `--jq=".count"` に修正（`length` は `{"count": N, "regions": [...]}` のキー数で常に 2 を返す）
- stores の grep に `leader_count` を追加し、`region_count` はレプリカ数のため偏り判定に使えない旨の注記を追加

## チェックリスト

- [x] ドキュメントのみの変更（アプリコードへの影響なし）
- [x] pre-push hook（lint / spell-check / zizmor）通過
