### PR TITLE
fix: update README architecture image path after docs restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@
 [![Docs](https://img.shields.io/badge/-Docs-3b82f6?style=flat-square)](https://shuntaka9576.github.io/shuntaka-dev/)
 [![Storybook](https://img.shields.io/badge/-Storybook-FF4785?style=flat-square&logo=storybook&logoColor=white)](https://shuntaka9576.github.io/shuntaka-dev/storybook/)
 
-![architecture](docs/source/assets/architecture.drawio.png)
+![architecture](docs/source/01_開発ドキュメント/assets/architecture.drawio.png)


### PR DESCRIPTION
## 概要

- docs 再構成（`0x/9x` 番号付け、one-entry-one-directory レイアウト）で `docs/source/assets/` から `docs/source/01_開発ドキュメント/assets/` に移動していた architecture 画像のリンクを README 側で追従修正。
- 現状の README では画像が壊れている（404）状態を解消。

## 変更内容

- `README.md`
  - `docs/source/assets/architecture.drawio.png` → `docs/source/01_開発ドキュメント/assets/architecture.drawio.png`

## 動作確認

- [ ] GitHub 上の README プレビューで architecture 画像が表示されることを確認
