### PR TITLE
fix: 記事リンクを新しいタブで開くとローディングバーが止まらない問題を修正

### DIFF
--- a/apps/web/src/components/ProgressLink.tsx
+++ b/apps/web/src/components/ProgressLink.tsx
@@ -50,11 +50,28 @@ export function ProgressLink({
   );
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(e);
+
+    // 修飾キー / 中クリック / target="_blank" 等は現在のタブが遷移せず
+    // 別タブ・別ウィンドウで開くため、startProgress() を呼ぶとバーが完了せず残る。
+    // 同一タブでのクライアント遷移が実際に起きるクリックのときだけ開始する
+    const targetAttr = e.currentTarget.target;
+    if (
+      e.defaultPrevented ||
+      e.button !== 0 ||
+      e.metaKey ||
+      e.ctrlKey ||
+      e.shiftKey ||
+      e.altKey ||
+      (targetAttr && targetAttr !== '_self')
+    ) {
+      return;
+    }
+
     const targetPath = typeof href === 'string' ? href : href.pathname;
     if (targetPath !== pathname) {
       startProgress();
     }
-    onClick?.(e);
   };
 
   return (


### PR DESCRIPTION
## 概要

- 記事リンクを Cmd/Ctrl+クリックや中クリックで**新しいタブに開くと、元のタブのローディングバー（NProgress）が止まらず残る**バグを修正
- `ProgressLink` に「新しいタブ/ウィンドウで開く操作」を除外するガードを追加し、同一タブでのクライアント遷移が実際に起きるクリックのときだけ `startProgress()` を呼ぶようにした
- 記事リンクだけでなく、ヘッダーロゴ・ナビタブ・ページネーションを含む全 `ProgressLink` に効く

## 原因

すべての記事リンクは `ArticleCard` → `ProgressLink` 経由。その `handleClick` が修飾キー・非左ボタン・`target` を判定せず無条件で `startProgress()` を呼んでいた。新しいタブで開くと現在のタブは遷移しないため、完了役の `ArticleContent` / `PageReady`（`doneProgress()` の呼び出し元）が再マウントされず、NProgress バーが完了せず取り残されていた（`NavigationProgressProvider` の `isNavigatingRef` も `true` のまま）。

Next.js の `Link` 自体は内部の `isModifiedEvent` で修飾クリックを検知しクライアント遷移をスキップするが、`ProgressLink` 側に同等の判定がなかった。

## 変更内容

**`apps/web/src/components/ProgressLink.tsx`**

- `handleClick` に Next.js 内部の `isModifiedEvent` 相当のガードを追加。以下のいずれかに該当する場合は `startProgress()` をスキップ
  - `e.defaultPrevented`
  - `e.button !== 0`（中クリック等）
  - `e.metaKey / e.ctrlKey / e.shiftKey / e.altKey`（修飾キー付き）
  - `e.currentTarget.target` が `_self` 以外（`target="_blank"` 等）
- `onClick?.(e)` を先頭へ移動し、消費側が `preventDefault()` した場合も `defaultPrevented` で拾えるようにした（現状の消費側は副作用付き `onClick` を渡していないため影響なし）

## テストプラン

- [x] `bun run type-check`（tsc）パス
- [x] `vp lint` / `vp fmt --check`（対象ファイル）パス
- [x] pre-commit（gitleaks / secretlint）・pre-push（turbo lint / zizmor）パス
- [x] ブラウザ実機検証（稼働中の dev サーバー + API、記事一覧ページ）で以下を確認
  - Cmd / Ctrl / Shift+クリック・中クリック → ローディングバーが**開始されない**
  - 通常の左クリック → 従来どおりバーが開始される（リグレッションなし）
