### PR TITLE
fix: st-tidb-proxy-logs の cdk-nag suppression がアカウントID固定で synth に失敗する問題を修正

### DIFF
--- a/iac/aws/bin/cdk.ts
+++ b/iac/aws/bin/cdk.ts
@@ -69,6 +69,15 @@ const mainStack = new MainStack(app, `${config.stageName.short}-${config.project
 mainStack.addDependency(globalDnsStack);
 mainStack.addDependency(tokyoCertificateStack);
 
+// Lambda 用環境変数が未設定の場合、main stack のデプロイだけをブロックする。
+// エラーは stack 単位に付くため、deploy-role 等の他スタックは .env なしの
+// ローカル環境でも synth / deploy できる。
+if (config.missingLambdaEnvVars.length > 0) {
+  cdk.Annotations.of(mainStack).addError(
+    `Lambda 用環境変数が未設定のため main stack はデプロイできません: ${config.missingLambdaEnvVars.join(', ')} (iac/aws/.env か環境変数で設定してください)`,
+  );
+}
+
 const oidcProviderStack = new OidcProviderStack(app, `${config.projectName.short}-oidc-provider`, {
   ssmOidcProviderArn: config.ssm.oidc.providerArn,
   env: {

--- a/iac/aws/lib/config.ts
+++ b/iac/aws/lib/config.ts
@@ -82,6 +82,10 @@ interface AppParameter {
       cloudinaryApiSecretKeyName: string;
     };
   };
+  // 未設定の Lambda 用環境変数名。空でない場合、bin/cdk.ts が main stack に
+  // Annotations.addError を付けて main のデプロイだけをブロックする
+  // (deploy-role 等の他スタックはローカルで .env なしでもデプロイできるようにする)。
+  missingLambdaEnvVars: string[];
 }
 
 const commonParameters = {
@@ -101,8 +105,17 @@ const getCdkEnvVars = () => {
   });
 };
 
-const getLambdaEnvVars = () => {
-  return lambdaEnvSchema.parse({
+// Lambda (main stack) 用の環境変数を検証する。未設定でも throw せず placeholder で
+// 埋めて synth を通す。CDK は `cdk deploy <stack>` でも全スタックを synth するため、
+// ここで throw すると deploy-role 等の main と無関係なスタックまでローカルで
+// デプロイできなくなる。placeholder のまま main をデプロイする事故は、bin/cdk.ts の
+// Annotations.addError (missingLambdaEnvVars) が main stack 選択時に synth を
+// 失敗させることで防ぐ。
+const getLambdaEnvVars = (): {
+  values: z.infer<typeof lambdaEnvSchema>;
+  missing: string[];
+} => {
+  const parsed = lambdaEnvSchema.safeParse({
     GH_APP_ID: process.env.GH_APP_ID,
     GH_APP_SECRET_PEM_KEY_NAME: process.env.GH_APP_SECRET_PEM_KEY_NAME,
     GH_WEBHOOK_SECRET_KEY_NAME: process.env.GH_WEBHOOK_SECRET_KEY_NAME,
@@ -110,10 +123,28 @@ const getLambdaEnvVars = () => {
     CLOUDINARY_API_KEY: process.env.CLOUDINARY_API_KEY,
     CLOUDINARY_API_SECRET_KEY_NAME: process.env.CLOUDINARY_API_SECRET_KEY_NAME,
   });
+
+  if (parsed.success) {
+    return { values: parsed.data, missing: [] };
+  }
+
+  const missing = parsed.error.issues.map((issue) => issue.path.join('.'));
+  const placeholder = 'unset-local-placeholder';
+  return {
+    values: {
+      GH_APP_ID: process.env.GH_APP_ID ?? placeholder,
+      GH_APP_SECRET_PEM_KEY_NAME: process.env.GH_APP_SECRET_PEM_KEY_NAME ?? placeholder,
+      GH_WEBHOOK_SECRET_KEY_NAME: process.env.GH_WEBHOOK_SECRET_KEY_NAME ?? placeholder,
+      CLOUDINARY_CLOUD_NAME: process.env.CLOUDINARY_CLOUD_NAME ?? placeholder,
+      CLOUDINARY_API_KEY: process.env.CLOUDINARY_API_KEY ?? placeholder,
+      CLOUDINARY_API_SECRET_KEY_NAME: process.env.CLOUDINARY_API_SECRET_KEY_NAME ?? placeholder,
+    },
+    missing,
+  };
 };
 
 const stageConfig: {
-  [key in StageName]: Omit<AppParameter, 'cdkEnv' | 'ssm' | 'lambda'>;
+  [key in StageName]: Omit<AppParameter, 'cdkEnv' | 'ssm' | 'lambda' | 'missingLambdaEnvVars'>;
 } = {
   dev: {
     ...commonParameters,
@@ -299,14 +330,15 @@ export const getConfig = (stageName: string): AppParameter => {
     },
     lambda: {
       blogApi: {
-        githubAppId: lambdaEnvVars.GH_APP_ID,
-        githubAppSecretPemKeyName: lambdaEnvVars.GH_APP_SECRET_PEM_KEY_NAME,
-        githubWebhookSecretKeyName: lambdaEnvVars.GH_WEBHOOK_SECRET_KEY_NAME,
-        cloudinaryCloudName: lambdaEnvVars.CLOUDINARY_CLOUD_NAME,
-        cloudinaryApiKey: lambdaEnvVars.CLOUDINARY_API_KEY,
-        cloudinaryApiSecretKeyName: lambdaEnvVars.CLOUDINARY_API_SECRET_KEY_NAME,
+        githubAppId: lambdaEnvVars.values.GH_APP_ID,
+        githubAppSecretPemKeyName: lambdaEnvVars.values.GH_APP_SECRET_PEM_KEY_NAME,
+        githubWebhookSecretKeyName: lambdaEnvVars.values.GH_WEBHOOK_SECRET_KEY_NAME,
+        cloudinaryCloudName: lambdaEnvVars.values.CLOUDINARY_CLOUD_NAME,
+        cloudinaryApiKey: lambdaEnvVars.values.CLOUDINARY_API_KEY,
+        cloudinaryApiSecretKeyName: lambdaEnvVars.values.CLOUDINARY_API_SECRET_KEY_NAME,
       },
     },
+    missingLambdaEnvVars: lambdaEnvVars.missing,
   };
 };
 

--- a/iac/aws/lib/nag-suppressions.ts
+++ b/iac/aws/lib/nag-suppressions.ts
@@ -101,11 +101,15 @@ export const applyTidbProxyLogAnalyticsSuppressions = (stack: cdk.Stack): void =
       reason:
         'tidb-proxy タスクロールが FireLens init プロセスで取得する Fluent Bit 設定ファイル群。firelens-config/ prefix 配下の GetObject のみに限定済み。',
     },
-    {
-      id: 'AwsSolutions-IAM5[Resource::arn:<AWS::Partition>:s3:::cdk-hnb659fds-assets-123456789012-ap-northeast-1/*]',
+    // BucketDeployment の custom resource Lambda が CDK bootstrap の asset バケット
+    // から設定ファイルを取得するための CDK 既定権限。finding の ARN はアカウント ID
+    // を含み、partition もテスト synth ではトークン (<AWS::Partition>)、実アカウント
+    // の synth ではリテラル (aws) になるため、stack の env から動的に両方 acknowledge する。
+    ...['<AWS::Partition>', 'aws'].map((partition) => ({
+      id: `AwsSolutions-IAM5[Resource::arn:${partition}:s3:::cdk-hnb659fds-assets-${stack.account}-${stack.region}/*]`,
       reason:
         'BucketDeployment の custom resource Lambda が CDK bootstrap の asset バケットから設定ファイルを取得するための CDK 既定権限。',
-    },
+    })),
     {
       // cspell:disable-next-line -- CFN パラメータ論理 ID (自動生成トークン)
       id: 'AwsSolutions-IAM5[Resource::arn:aws:logs:<AWS::Region>:<AWS::AccountId>:log-group:<SsmParameterValuetidbproxyproxyloggroupnameC96584B6F00A464EAD1953AFF4B05118Parameter>:*]',


### PR DESCRIPTION
## 概要

- #585 マージ後の Deploy ワークフロー (st-tidb-proxy-logs) が cdk-nag エラーで失敗する問題の修正 ([失敗run](https://github.com/shuntaka9576/shuntaka-dev/actions/runs/29122084647/job/86459275365))
- あわせて、Lambda 用環境変数 (`GH_APP_ID` 等) が未設定のローカル環境でも main 以外のスタックを synth / deploy できるようにする

## 原因と修正

### 1. cdk-nag suppression のアカウント ID 固定 (CI 失敗の直接原因)

`applyTidbProxyLogAnalyticsSuppressions` の BucketDeployment 向け IAM5 acknowledge に、テスト synth の finding をそのまま貼ったためアカウント ID `123456789012` がハードコードされており、実アカウントでの synth では finding の ARN と一致せずエラーになっていた。

`stack.account` / `stack.region` から動的に生成し、partition の表現揺れ (テスト synth では `<AWS::Partition>` トークン、実アカウント synth では `aws` リテラル) も両方カバーするよう修正。

### 2. Lambda env 未設定時の全スタック synth 不能

`getConfig()` が `getLambdaEnvVars()` を eager に `zod.parse` していたため、main と無関係な deploy-role 等のデプロイでも `.env` が無いと ZodError で落ちていた。

`safeParse` + プレースホルダで synth 自体は通し、未設定時は `bin/cdk.ts` が **main stack にだけ** `Annotations.addError` を付ける方式に変更。プレースホルダのまま main をデプロイする事故はこのエラーで synth 段階でブロックされる (エラーは stack 単位のため他スタックには影響しない)。

## 検証

- [x] `CDK_DEFAULT_ACCOUNT=<実アカウントID>` + Lambda env なしで `cdk synth st-tidb-proxy-logs` が成功 (CI 失敗条件の再現)
- [x] 同条件で `cdk synth d-st-main` は「Lambda 用環境変数が未設定のため main stack はデプロイできません」で失敗 (ガード動作)
- [x] Lambda env なしで `cdk synth d-st-deploy-role` が成功
- [x] vitest (スナップショット + cdk-nag violations ゼロ) / type-check / lint / spell-check

## マージ後の手順

- [x] `gh workflow run deploy.yaml -f stageName=dev -f stack=st-tidb-proxy-logs` を再実行 (または preview push の自動実行に任せる)
- [x] ローカルで `d-st-deploy-role` を再デプロイ (glue/firehose/athena 権限。本修正により .env 不要になった)
