### PR TITLE
feat: tidb-proxy ログ分析用の Athena Named Query 3本を CDK で登録

### DIFF
--- a/docs/source/01_開発ドキュメント/01_development.md
+++ b/docs/source/01_開発ドキュメント/01_development.md
@@ -290,6 +290,14 @@ aws athena get-query-results --query-execution-id <上の実行結果の QueryEx
 aws s3 ls s3://tidb-proxy-logs-$(aws sts get-caller-identity --query Account --output text)/firehose-errors/ --recursive
 ```
 
+よく使うクエリは Athena の Saved queries (WorkGroup `tidb-proxy-logs`) に CDK で登録済み。コンソールの Athena → Saved queries から実行できる。
+
+| Named Query              | 用途                                                                     |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `recent-activity`        | 直近のアクティビティ一覧 (ECS ヘルスチェックのノイズ除外)                |
+| `destination-summary-7d` | 直近7日の外部通信の宛先別サマリ (egress 監査、想定外の phone-home 検知)  |
+| `denied-or-error-access` | TCP_DENIED / HTTP 4xx・5xx の検出 (squid の egress 制限に触れた通信調査) |
+
 Fluent Bit の設定 (`apps/tidb-proxy/firelens/extra.conf` / `parsers.conf`) を変更した場合の反映手順。init プロセスはコンテナ起動時に一度だけ S3 から設定を取得するため、S3 更新だけでは反映されず、task def も変わらないため ecspresso の diff でも検知されない。明示的に task を再起動する。
 
 ```bash

--- a/docs/source/01_開発ドキュメント/01_development.md
+++ b/docs/source/01_開発ドキュメント/01_development.md
@@ -290,13 +290,7 @@ aws athena get-query-results --query-execution-id <上の実行結果の QueryEx
 aws s3 ls s3://tidb-proxy-logs-$(aws sts get-caller-identity --query Account --output text)/firehose-errors/ --recursive
 ```
 
-よく使うクエリは Athena の Saved queries (WorkGroup `tidb-proxy-logs`) に CDK で登録済み。コンソールの Athena → Saved queries から実行できる。
-
-| Named Query              | 用途                                                                     |
-| ------------------------ | ------------------------------------------------------------------------ |
-| `recent-activity`        | 直近のアクティビティ一覧 (ECS ヘルスチェックのノイズ除外)                |
-| `destination-summary-7d` | 直近7日の外部通信の宛先別サマリ (egress 監査、想定外の phone-home 検知)  |
-| `denied-or-error-access` | TCP_DENIED / HTTP 4xx・5xx の検出 (squid の egress 制限に触れた通信調査) |
+よく使うクエリは Athena の Saved queries (WorkGroup `tidb-proxy-logs`) に CDK で登録済み。日常のログ検索の使い方は [運用ドキュメント](03_operations.md) の「クエリリファレンス > Athena」を参照。
 
 Fluent Bit の設定 (`apps/tidb-proxy/firelens/extra.conf` / `parsers.conf`) を変更した場合の反映手順。init プロセスはコンテナ起動時に一度だけ S3 から設定を取得するため、S3 更新だけでは反映されず、task def も変わらないため ecspresso の diff でも検知されない。明示的に task を再起動する。
 

--- a/docs/source/01_開発ドキュメント/03_operations.md
+++ b/docs/source/01_開発ドキュメント/03_operations.md
@@ -197,10 +197,13 @@ tidb-proxy のログは FireLens で振り分けられ、INFO 系（squid アク
 | `destination-summary-7d` | 直近7日の外部通信の宛先別サマリ（egress 監査、想定外の phone-home 検知）  |
 | `denied-or-error-access` | TCP_DENIED / HTTP 4xx・5xx の検出（squid の egress 制限に触れた通信調査） |
 
+いずれも時刻カラムは JST（`ts_jst` / `last_seen_jst`）で返す。
+
 自分でクエリを書くときの注意:
 
 - ECS ヘルスチェック（127.0.0.1 から 30 秒ごとの `nc -z`）が `squid_access` のノイズ行になる。`client_ip <> '127.0.0.1'` で除外し、forwarder 行（`client_ip` が NULL）も残す場合は `client_ip IS DISTINCT FROM '127.0.0.1'` を使う
-- `ts` は string（ISO8601 UTC）。時刻演算は `from_iso8601_timestamp(ts)`、期間絞り込みは `from_iso8601_timestamp(ts) > current_timestamp - interval '7' day` の形
+- `ts` は string（ISO8601 UTC）で保存されている。時刻演算は `from_iso8601_timestamp(ts)`、期間絞り込みは `from_iso8601_timestamp(ts) > current_timestamp - interval '7' day` の形
+- JST 表示は `format_datetime(from_iso8601_timestamp(ts) AT TIME ZONE 'Asia/Tokyo', 'yyyy-MM-dd HH:mm:ss')`
 - WARN / ERROR は Iceberg 側に入らない。障害調査は CloudWatch Logs の `fluentbit-warnerr-*` / `fluentbit-fallback-*` ストリームを見る
 
 ### X-Ray（CloudWatch > トレース）

--- a/docs/source/01_開発ドキュメント/03_operations.md
+++ b/docs/source/01_開発ドキュメント/03_operations.md
@@ -4,15 +4,17 @@ blog-api (Lambda) 〜 tidb-proxy (forwarder) 〜 TiDB 経路で「遅い・お�
 
 ## 症状別インデックス
 
-| 症状                           | 見る節                 |
-| ------------------------------ | ---------------------- |
-| API / ブログが遅い             | ボトルネック切り分け   |
-| グラフの意味を知りたい         | ダッシュボード         |
-| ダッシュボードにデータが出ない | テレメトリが出ないとき |
-| 誰が何を送っているか知りたい   | テレメトリ一覧         |
-| クエリの書き方を調べたい       | クエリリファレンス     |
-| 検索がヒットしない・表示が変   | ハマりどころ           |
-| MiniPC を再起動したい          | ノード再起動           |
+| 症状                                     | 見る節                 |
+| ---------------------------------------- | ---------------------- |
+| API / ブログが遅い                       | ボトルネック切り分け   |
+| グラフの意味を知りたい                   | ダッシュボード         |
+| ダッシュボードにデータが出ない           | テレメトリが出ないとき |
+| 誰が何を送っているか知りたい             | テレメトリ一覧         |
+| クエリの書き方を調べたい                 | クエリリファレンス     |
+| Lambda がどこへ外部通信したか調べたい    | クエリリファレンス     |
+| proxy のアクセス・エラーログを検索したい | クエリリファレンス     |
+| 検索がヒットしない・表示が変             | ハマりどころ           |
+| MiniPC を再起動したい                    | ノード再起動           |
 
 ## ボトルネック切り分け
 
@@ -182,6 +184,24 @@ curl -s https://api.shuntaka.dev/health/db # ブログ DB 経路の疎通
 ```
 
 ## クエリリファレンス
+
+### Athena（proxy アクセスログ / Iceberg）
+
+tidb-proxy のログは FireLens で振り分けられ、INFO 系（squid アクセスログ・forwarder イベント）が S3 上の Iceberg テーブル `tidb_proxy_logs.logs` に、WARN / ERROR・非 JSON 行が CloudWatch Logs `/ecs/tidb-proxy` に入る。設計は [tidb-proxy ログの S3/Iceberg 検索基盤](../98_tasks/2026-07-10-tidb-proxy-log-iceberg/index.md) を参照。
+
+よく使うクエリは Saved queries（WorkGroup `tidb-proxy-logs`）に CDK（`iac/aws/lib/analytics/tidb-proxy-log-analytics-construct.ts`）で登録済み。Athena コンソールで WorkGroup を `tidb-proxy-logs` に切り替えて Saved queries から実行する。
+
+| Named Query              | 用途                                                                      |
+| ------------------------ | ------------------------------------------------------------------------- |
+| `recent-activity`        | 直近のアクティビティ一覧（ECS ヘルスチェックのノイズ除外）                |
+| `destination-summary-7d` | 直近7日の外部通信の宛先別サマリ（egress 監査、想定外の phone-home 検知）  |
+| `denied-or-error-access` | TCP_DENIED / HTTP 4xx・5xx の検出（squid の egress 制限に触れた通信調査） |
+
+自分でクエリを書くときの注意:
+
+- ECS ヘルスチェック（127.0.0.1 から 30 秒ごとの `nc -z`）が `squid_access` のノイズ行になる。`client_ip <> '127.0.0.1'` で除外し、forwarder 行（`client_ip` が NULL）も残す場合は `client_ip IS DISTINCT FROM '127.0.0.1'` を使う
+- `ts` は string（ISO8601 UTC）。時刻演算は `from_iso8601_timestamp(ts)`、期間絞り込みは `from_iso8601_timestamp(ts) > current_timestamp - interval '7' day` の形
+- WARN / ERROR は Iceberg 側に入らない。障害調査は CloudWatch Logs の `fluentbit-warnerr-*` / `fluentbit-fallback-*` ストリームを見る
 
 ### X-Ray（CloudWatch > トレース）
 

--- a/docs/source/98_tasks/2026-07-10-tidb-proxy-log-iceberg/index.md
+++ b/docs/source/98_tasks/2026-07-10-tidb-proxy-log-iceberg/index.md
@@ -106,6 +106,7 @@ Fluent Bit 自体の RSS は 30〜60MB 程度（AWS の目安予約は 100〜250
   - パーティションなしで開始（string 列に `day` transform が適用できないため。量が増えたら `log_type` の identity パーティション等を検討）
 - **Firehose** `tidb-proxy-logs`: DirectPut、`appendOnly: true`、buffering 60s/64MB、失敗レコードのみ `firehose-errors/` へ (`s3BackupMode: FailedDataOnly`)
 - **Athena WorkGroup** `tidb-proxy-logs`: engine v3、結果出力 `athena-results/`
+- **Athena Named Queries**: よく使う3本を `CfnNamedQuery` で登録 (`recent-activity` / `destination-summary-7d` / `denied-or-error-access`)。ECS ヘルスチェック (127.0.0.1 から30秒ごとの `nc -z`) が squid_access のノイズ行になるため、`client_ip` での除外を基本形にしている
 - **タスクロールへの後付け権限**: `st-tidb-proxy` の SSM 出力 (`/tidb-proxy/proxy/task-role`) から `Role.fromRoleArn(..., { mutable: true })` でインポートし、`firehose:PutRecordBatch` / `s3:GetObject` (firelens-config) / `logs:CreateLogStream・PutLogEvents` を付与。`blog-api-construct.ts` が proxy SG に `addIngressRule` するのと同型のパターンで、稼働中の `st-tidb-proxy` は変更しない
 - **SSM 出力**: `/tidb-proxy/logs/delivery-stream-name`, `/tidb-proxy/logs/firelens-config-s3-arn-prefix` (ecspresso が参照)
 

--- a/iac/aws/lib/analytics/tidb-proxy-log-analytics-construct.ts
+++ b/iac/aws/lib/analytics/tidb-proxy-log-analytics-construct.ts
@@ -218,7 +218,7 @@ export class TidbProxyLogAnalyticsConstruct extends Construct {
     }
 
     // ---- Athena WorkGroup ----
-    new athena.CfnWorkGroup(this, 'WorkGroup', {
+    const workGroup = new athena.CfnWorkGroup(this, 'WorkGroup', {
       name: config.athena.workGroupName,
       recursiveDeleteOption: true,
       workGroupConfiguration: {
@@ -235,6 +235,77 @@ export class TidbProxyLogAnalyticsConstruct extends Construct {
         },
       },
     });
+
+    // ---- Athena Named Queries (よく使う検索の登録) ----
+    // いずれも実データに対して実行確認済み (2026-07-11)。
+    // ECS ヘルスチェック (nc -z, 127.0.0.1 から 30 秒ごと) が squid_access の
+    // ノイズ行になるため、client_ip でヘルスチェックを除外するのが基本形。
+    // forwarder 行は client_ip が NULL のため IS DISTINCT FROM で残す。
+    const namedQueries: { id: string; name: string; description: string; sql: string }[] = [
+      {
+        id: 'RecentActivityQuery',
+        name: 'recent-activity',
+        description:
+          '直近のアクティビティ (squid アクセス + forwarder イベント)。ECS ヘルスチェックのノイズを除外',
+        sql: [
+          'SELECT ts, log_type,',
+          "       coalesce(message, method || ' ' || url) AS event,",
+          '       status, duration_ms, bytes_in, bytes_out',
+          'FROM logs',
+          "WHERE client_ip IS DISTINCT FROM '127.0.0.1'",
+          'ORDER BY ts DESC',
+          'LIMIT 100',
+        ].join('\n'),
+      },
+      {
+        id: 'DestinationSummaryQuery',
+        name: 'destination-summary-7d',
+        description:
+          '直近7日の外部通信の宛先別サマリ (egress 監査用)。想定外の宛先への phone-home 検知に使う',
+        sql: [
+          'SELECT url AS destination,',
+          '       count(*) AS requests,',
+          '       count_if(status >= 400) AS errors,',
+          '       sum(bytes_in) AS bytes_in,',
+          '       sum(bytes_out) AS bytes_out,',
+          '       round(avg(duration_ms)) AS avg_ms,',
+          '       max(ts) AS last_seen',
+          'FROM logs',
+          "WHERE log_type = 'squid_access'",
+          "  AND client_ip <> '127.0.0.1'",
+          "  AND from_iso8601_timestamp(ts) > current_timestamp - interval '7' day",
+          'GROUP BY url',
+          'ORDER BY requests DESC',
+          'LIMIT 50',
+        ].join('\n'),
+      },
+      {
+        id: 'DeniedOrErrorAccessQuery',
+        name: 'denied-or-error-access',
+        description:
+          '拒否 (TCP_DENIED) と HTTP 4xx/5xx のアクセス検出。squid の egress 制限に引っかかった通信の調査用',
+        sql: [
+          'SELECT ts, client_ip, method, url, status, squid_status, user_agent',
+          'FROM logs',
+          "WHERE log_type = 'squid_access'",
+          "  AND client_ip <> '127.0.0.1'",
+          "  AND (status >= 400 OR squid_status LIKE 'TCP_DENIED%')",
+          'ORDER BY ts DESC',
+          'LIMIT 100',
+        ].join('\n'),
+      },
+    ];
+    for (const q of namedQueries) {
+      const namedQuery = new athena.CfnNamedQuery(this, q.id, {
+        name: q.name,
+        description: q.description,
+        database: config.glue.databaseName,
+        workGroup: config.athena.workGroupName,
+        queryString: q.sql,
+      });
+      // workGroup プロパティは名前の文字列参照のため、依存を明示する。
+      namedQuery.addDependency(workGroup);
+    }
 
     // ---- 既存 tidb-proxy タスクロールへの権限後付け ----
     // FireLens の kinesis_firehose / cloudwatch_logs 出力プラグインと init

--- a/iac/aws/lib/analytics/tidb-proxy-log-analytics-construct.ts
+++ b/iac/aws/lib/analytics/tidb-proxy-log-analytics-construct.ts
@@ -241,14 +241,18 @@ export class TidbProxyLogAnalyticsConstruct extends Construct {
     // ECS ヘルスチェック (nc -z, 127.0.0.1 から 30 秒ごと) が squid_access の
     // ノイズ行になるため、client_ip でヘルスチェックを除外するのが基本形。
     // forwarder 行は client_ip が NULL のため IS DISTINCT FROM で残す。
+    // ts は UTC (ISO8601) で保存しているため、表示は JST に変換して返す。
+    const tsJst =
+      "format_datetime(from_iso8601_timestamp(ts) AT TIME ZONE 'Asia/Tokyo', 'yyyy-MM-dd HH:mm:ss')";
     const namedQueries: { id: string; name: string; description: string; sql: string }[] = [
       {
         id: 'RecentActivityQuery',
         name: 'recent-activity',
         description:
-          '直近のアクティビティ (squid アクセス + forwarder イベント)。ECS ヘルスチェックのノイズを除外',
+          '直近のアクティビティ (squid アクセス + forwarder イベント)。ECS ヘルスチェックのノイズを除外。時刻は JST',
         sql: [
-          'SELECT ts, log_type,',
+          `SELECT ${tsJst} AS ts_jst,`,
+          '       log_type,',
           "       coalesce(message, method || ' ' || url) AS event,",
           '       status, duration_ms, bytes_in, bytes_out',
           'FROM logs',
@@ -261,7 +265,7 @@ export class TidbProxyLogAnalyticsConstruct extends Construct {
         id: 'DestinationSummaryQuery',
         name: 'destination-summary-7d',
         description:
-          '直近7日の外部通信の宛先別サマリ (egress 監査用)。想定外の宛先への phone-home 検知に使う',
+          '直近7日の外部通信の宛先別サマリ (egress 監査用)。想定外の宛先への phone-home 検知に使う。時刻は JST',
         sql: [
           'SELECT url AS destination,',
           '       count(*) AS requests,',
@@ -269,7 +273,7 @@ export class TidbProxyLogAnalyticsConstruct extends Construct {
           '       sum(bytes_in) AS bytes_in,',
           '       sum(bytes_out) AS bytes_out,',
           '       round(avg(duration_ms)) AS avg_ms,',
-          '       max(ts) AS last_seen',
+          "       format_datetime(from_iso8601_timestamp(max(ts)) AT TIME ZONE 'Asia/Tokyo', 'yyyy-MM-dd HH:mm:ss') AS last_seen_jst",
           'FROM logs',
           "WHERE log_type = 'squid_access'",
           "  AND client_ip <> '127.0.0.1'",
@@ -283,9 +287,10 @@ export class TidbProxyLogAnalyticsConstruct extends Construct {
         id: 'DeniedOrErrorAccessQuery',
         name: 'denied-or-error-access',
         description:
-          '拒否 (TCP_DENIED) と HTTP 4xx/5xx のアクセス検出。squid の egress 制限に引っかかった通信の調査用',
+          '拒否 (TCP_DENIED) と HTTP 4xx/5xx のアクセス検出。squid の egress 制限に引っかかった通信の調査用。時刻は JST',
         sql: [
-          'SELECT ts, client_ip, method, url, status, squid_status, user_agent',
+          `SELECT ${tsJst} AS ts_jst,`,
+          '       client_ip, method, url, status, squid_status, user_agent',
           'FROM logs',
           "WHERE log_type = 'squid_access'",
           "  AND client_ip <> '127.0.0.1'",

--- a/iac/aws/test/__snapshots__/analytics.test.ts.snap
+++ b/iac/aws/test/__snapshots__/analytics.test.ts.snap
@@ -308,6 +308,51 @@ exports[`TidbProxyLogAnalyticsStack > snapshot 1`] = `
       },
       "Type": "AWS::SSM::Parameter",
     },
+    "LogAnalyticsDeniedOrErrorAccessQuery4ECCAA2A": {
+      "DependsOn": [
+        "LogAnalyticsWorkGroupFB93F96A",
+      ],
+      "Properties": {
+        "Database": "tidb_proxy_logs",
+        "Description": "拒否 (TCP_DENIED) と HTTP 4xx/5xx のアクセス検出。squid の egress 制限に引っかかった通信の調査用",
+        "Name": "denied-or-error-access",
+        "QueryString": "SELECT ts, client_ip, method, url, status, squid_status, user_agent
+FROM logs
+WHERE log_type = 'squid_access'
+  AND client_ip <> '127.0.0.1'
+  AND (status >= 400 OR squid_status LIKE 'TCP_DENIED%')
+ORDER BY ts DESC
+LIMIT 100",
+        "WorkGroup": "tidb-proxy-logs",
+      },
+      "Type": "AWS::Athena::NamedQuery",
+    },
+    "LogAnalyticsDestinationSummaryQuery07B018A9": {
+      "DependsOn": [
+        "LogAnalyticsWorkGroupFB93F96A",
+      ],
+      "Properties": {
+        "Database": "tidb_proxy_logs",
+        "Description": "直近7日の外部通信の宛先別サマリ (egress 監査用)。想定外の宛先への phone-home 検知に使う",
+        "Name": "destination-summary-7d",
+        "QueryString": "SELECT url AS destination,
+       count(*) AS requests,
+       count_if(status >= 400) AS errors,
+       sum(bytes_in) AS bytes_in,
+       sum(bytes_out) AS bytes_out,
+       round(avg(duration_ms)) AS avg_ms,
+       max(ts) AS last_seen
+FROM logs
+WHERE log_type = 'squid_access'
+  AND client_ip <> '127.0.0.1'
+  AND from_iso8601_timestamp(ts) > current_timestamp - interval '7' day
+GROUP BY url
+ORDER BY requests DESC
+LIMIT 50",
+        "WorkGroup": "tidb-proxy-logs",
+      },
+      "Type": "AWS::Athena::NamedQuery",
+    },
     "LogAnalyticsFirehoseLogGroupF129BBE2": {
       "DeletionPolicy": "Delete",
       "Properties": {
@@ -899,6 +944,25 @@ exports[`TidbProxyLogAnalyticsStack > snapshot 1`] = `
         },
       },
       "Type": "AWS::Glue::Table",
+    },
+    "LogAnalyticsRecentActivityQuery347E60B8": {
+      "DependsOn": [
+        "LogAnalyticsWorkGroupFB93F96A",
+      ],
+      "Properties": {
+        "Database": "tidb_proxy_logs",
+        "Description": "直近のアクティビティ (squid アクセス + forwarder イベント)。ECS ヘルスチェックのノイズを除外",
+        "Name": "recent-activity",
+        "QueryString": "SELECT ts, log_type,
+       coalesce(message, method || ' ' || url) AS event,
+       status, duration_ms, bytes_in, bytes_out
+FROM logs
+WHERE client_ip IS DISTINCT FROM '127.0.0.1'
+ORDER BY ts DESC
+LIMIT 100",
+        "WorkGroup": "tidb-proxy-logs",
+      },
+      "Type": "AWS::Athena::NamedQuery",
     },
     "LogAnalyticsWorkGroupFB93F96A": {
       "Properties": {

--- a/iac/aws/test/__snapshots__/analytics.test.ts.snap
+++ b/iac/aws/test/__snapshots__/analytics.test.ts.snap
@@ -314,9 +314,10 @@ exports[`TidbProxyLogAnalyticsStack > snapshot 1`] = `
       ],
       "Properties": {
         "Database": "tidb_proxy_logs",
-        "Description": "拒否 (TCP_DENIED) と HTTP 4xx/5xx のアクセス検出。squid の egress 制限に引っかかった通信の調査用",
+        "Description": "拒否 (TCP_DENIED) と HTTP 4xx/5xx のアクセス検出。squid の egress 制限に引っかかった通信の調査用。時刻は JST",
         "Name": "denied-or-error-access",
-        "QueryString": "SELECT ts, client_ip, method, url, status, squid_status, user_agent
+        "QueryString": "SELECT format_datetime(from_iso8601_timestamp(ts) AT TIME ZONE 'Asia/Tokyo', 'yyyy-MM-dd HH:mm:ss') AS ts_jst,
+       client_ip, method, url, status, squid_status, user_agent
 FROM logs
 WHERE log_type = 'squid_access'
   AND client_ip <> '127.0.0.1'
@@ -333,7 +334,7 @@ LIMIT 100",
       ],
       "Properties": {
         "Database": "tidb_proxy_logs",
-        "Description": "直近7日の外部通信の宛先別サマリ (egress 監査用)。想定外の宛先への phone-home 検知に使う",
+        "Description": "直近7日の外部通信の宛先別サマリ (egress 監査用)。想定外の宛先への phone-home 検知に使う。時刻は JST",
         "Name": "destination-summary-7d",
         "QueryString": "SELECT url AS destination,
        count(*) AS requests,
@@ -341,7 +342,7 @@ LIMIT 100",
        sum(bytes_in) AS bytes_in,
        sum(bytes_out) AS bytes_out,
        round(avg(duration_ms)) AS avg_ms,
-       max(ts) AS last_seen
+       format_datetime(from_iso8601_timestamp(max(ts)) AT TIME ZONE 'Asia/Tokyo', 'yyyy-MM-dd HH:mm:ss') AS last_seen_jst
 FROM logs
 WHERE log_type = 'squid_access'
   AND client_ip <> '127.0.0.1'
@@ -951,9 +952,10 @@ LIMIT 50",
       ],
       "Properties": {
         "Database": "tidb_proxy_logs",
-        "Description": "直近のアクティビティ (squid アクセス + forwarder イベント)。ECS ヘルスチェックのノイズを除外",
+        "Description": "直近のアクティビティ (squid アクセス + forwarder イベント)。ECS ヘルスチェックのノイズを除外。時刻は JST",
         "Name": "recent-activity",
-        "QueryString": "SELECT ts, log_type,
+        "QueryString": "SELECT format_datetime(from_iso8601_timestamp(ts) AT TIME ZONE 'Asia/Tokyo', 'yyyy-MM-dd HH:mm:ss') AS ts_jst,
+       log_type,
        coalesce(message, method || ' ' || url) AS event,
        status, duration_ms, bytes_in, bytes_out
 FROM logs


### PR DESCRIPTION
## 概要

- tidb-proxy ログ分析 (Iceberg テーブル `tidb_proxy_logs.logs`) でよく使うクエリ3本を Athena Named Query として CDK (`CfnNamedQuery`) で登録
- **3本とも実データに対して実行し SUCCEEDED を確認済み** (ナノ秒精度 ts の `from_iso8601_timestamp` パース含む)

## 登録クエリ

| Named Query | 用途 |
| --- | --- |
| `recent-activity` | 直近のアクティビティ一覧 (squid アクセス + forwarder イベント)。ECS ヘルスチェックのノイズを除外 |
| `destination-summary-7d` | 直近7日の外部通信の宛先別サマリ (egress 監査、想定外の phone-home 検知) |
| `denied-or-error-access` | TCP_DENIED / HTTP 4xx・5xx の検出 (squid の egress 制限に触れた通信の調査) |

設計メモ: ECS ヘルスチェック (`nc -z`, 127.0.0.1 から30秒ごと) が `squid_access` のノイズ行になるため、`client_ip` によるヘルスチェック除外を基本形にした。forwarder 行は `client_ip` が NULL のため `IS DISTINCT FROM` で残す。

## 変更ファイル

- `iac/aws/lib/analytics/tidb-proxy-log-analytics-construct.ts`: CfnNamedQuery ×3 追加 (WorkGroup への依存を明示)
- `iac/aws/test/__snapshots__/analytics.test.ts.snap`: スナップショット更新
- `docs/source/01_開発ドキュメント/01_development.md` / `docs/source/98_tasks/2026-07-10-tidb-proxy-log-iceberg/index.md`: Named Query の説明を追記

## 検証

- [x] 3クエリとも実環境の Athena で SUCCEEDED (Q1 は forwarder ログが返却、Q2/Q3 は実トラフィック待ちで0件だが実行成功)
- [x] vitest (スナップショット + cdk-nag violations ゼロ) / type-check / lint / spell-check

## マージ後

- [ ] preview push の自動 Deploy で `st-tidb-proxy-logs` に Named Query が追加されることを確認 (Athena コンソール → Saved queries)
