### PR TITLE
fix: 記事一覧の下部余白を footer 予約分と合算し過剰な空白を解消

### DIFF
--- a/apps/web/src/components/ArticleListView.tsx
+++ b/apps/web/src/components/ArticleListView.tsx
@@ -61,8 +61,9 @@ export async function ArticleListView({ page, baseHref }: ArticleListViewProps) 
       baseHref={baseHref}
     >
       <BaseLayout showTypeHeader currentTab="posts" narrow>
-        {/* pb はフローティングタグバーとページネーションの重なりを避けるための余白 */}
-        <main className="w-full pb-24">
+        {/* pb はフローティングタグバー（下端24px+高さ約44px）とページネーションの重なりを避けるための余白。
+            BaseLayout の footer 予約 58px と合算して確保する */}
+        <main className="w-full pb-8">
           <TagFilterControls />
           <FilteredArticleList userName={USER_NAME}>
             {articles.length === 0 ? (


### PR DESCRIPTION
## 概要

- 記事一覧の下部余白 `pb-24` が BaseLayout の footer 予約分 (58px) と二重に確保され、ページ下部に過剰な空白が生じていたため `pb-8` に縮小
- 余白の算出根拠（フローティングタグバー: 下端 24px + 高さ約 44px、footer 予約 58px と合算）をコメントに明記

## 変更内容

- `apps/web/src/components/ArticleListView.tsx`
  - `<main>` の下部パディングを `pb-24` から `pb-8` に変更
  - 余白の意図を説明するコメントを詳細化

## テストプラン

- [ ] `bun run dev` で記事一覧を表示し、フローティングタグバーとページネーションが重ならないことを確認
- [ ] ページ下部に過剰な空白が出ていないことを確認
- [ ] `bun run check` が通ること
