### PR TITLE
feat: フローティングタグパネルをスクロール・外側タップ・Escape で閉じるように変更

### DIFF
--- a/apps/web/src/components/FloatingTagFilter.tsx
+++ b/apps/web/src/components/FloatingTagFilter.tsx
@@ -1,11 +1,16 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { TagFilterTree } from '@/components/TagFilterTree';
 import { TAG_FILTER_PANEL_ID, useTagFilter } from '@/components/TagFilterProvider';
+
+/** パネルを閉じるまでに許容するページスクロール量 (px)。絞り込みによるレイアウトシフト分を吸収する */
+const SCROLL_CLOSE_THRESHOLD = 30;
 
 /**
  * 画面下部中央に固定表示するタグ絞り込み UI。
  * トリガーピルをタップするとファイルツリー風のタグパネルが上に展開する。
+ * 開いている間はページスクロール・パネル外タップ・Escape で閉じる。
  */
 export function FloatingTagFilter() {
   const {
@@ -14,16 +19,56 @@ export function FloatingTagFilter() {
     mode,
     filtering,
     totalCount,
+    fetchedArticles,
     tagTree,
     facetsError,
     togglePanel,
+    closePanel,
     toggleTag,
     changeMode,
     clear,
   } = useTagFilter();
 
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scrollBaseline = useRef(0);
+
+  // パネルを開いた時点と絞り込み結果の再描画時に基準位置を取り直す。
+  // タグ選択で一覧の高さが変わるとブラウザが scrollY を丸めることがあり、
+  // 基準を据え置くとその移動だけで閾値を超えてしまうため
+  useEffect(() => {
+    scrollBaseline.current = window.scrollY;
+  }, [panelOpen, fetchedArticles]);
+
+  useEffect(() => {
+    if (!panelOpen) return;
+
+    const onScroll = () => {
+      if (Math.abs(window.scrollY - scrollBaseline.current) > SCROLL_CLOSE_THRESHOLD) {
+        closePanel();
+      }
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) closePanel();
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closePanel();
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [panelOpen, closePanel]);
+
   return (
-    <div className="fixed bottom-[calc(var(--space-5)+env(safe-area-inset-bottom))] left-1/2 z-20 flex w-[min(20rem,calc(100vw-2rem))] -translate-x-1/2 flex-col items-center">
+    <div
+      ref={containerRef}
+      className="fixed bottom-[calc(var(--space-5)+env(safe-area-inset-bottom))] left-1/2 z-20 flex w-[min(20rem,calc(100vw-2rem))] -translate-x-1/2 flex-col items-center"
+    >
       {panelOpen && (
         <div
           id={TAG_FILTER_PANEL_ID}

--- a/apps/web/src/components/TagFilterProvider.tsx
+++ b/apps/web/src/components/TagFilterProvider.tsx
@@ -44,6 +44,7 @@ interface TagFilterContextValue {
   /** タグパネルに表示するツリー（facets から構築） */
   tagTree: TagNode[];
   togglePanel: () => void;
+  closePanel: () => void;
   toggleTag: (path: string) => void;
   changeMode: (mode: TagFilterMode) => void;
   clear: () => void;
@@ -237,6 +238,9 @@ export function TagFilterProvider({
 
   const retry = useCallback(() => setRetryCount((c) => c + 1), []);
 
+  // FloatingTagFilter の effect 依存に入るため参照を安定させる
+  const closePanel = useCallback(() => setPanelOpen(false), []);
+
   const value: TagFilterContextValue = {
     panelOpen,
     selected,
@@ -251,6 +255,7 @@ export function TagFilterProvider({
     facetsError,
     tagTree,
     togglePanel: () => setPanelOpen((prev) => !prev),
+    closePanel,
     toggleTag: (path) => {
       const next = selected.includes(path)
         ? selected.filter((t) => t !== path)


### PR DESCRIPTION
## 概要

- 画面下部のフローティングタグパネルが、開いたあと「ページスクロール」「パネル外タップ」「Escape キー」のいずれかで自動的に閉じるようにした
- 従来はトリガーピルを再タップするまで開きっぱなしで、絞り込み後に結果を読もうとスクロールしてもパネル（最大 50vh）が一覧を覆い続けていた

## 変更内容

### `apps/web/src/components/FloatingTagFilter.tsx`

- パネルが開いている間だけ `scroll` / `pointerdown` / `keydown` のリスナーを登録し、いずれかの条件で `closePanel` を呼ぶ effect を追加
  - **スクロール**: 基準位置から 30px（`SCROLL_CLOSE_THRESHOLD`）以上動いたら閉じる。タグツリー内のスクロールは window に伝播しないため対象外
  - **外側タップ**: `pointerdown` の target がコンテナ外なら閉じる（トリガーピルは従来どおりトグル動作）
  - **Escape**: 押下で閉じる
- タグ選択で一覧の高さが変わると `scrollY` がブラウザに丸められて動くことがあるため、パネル開閉時と絞り込み結果（`fetchedArticles`）の再描画時にスクロール基準位置を取り直し、タグ複数選択中の誤クローズを防止

### `apps/web/src/components/TagFilterProvider.tsx`

- Context に `closePanel` を追加。FloatingTagFilter 側で effect の依存に入るため `useCallback` で参照を安定化

## テストプラン

- [x] `bun run type-check`（apps/web）
- [x] `bun run lint`（リポジトリルート）
- [ ] ローカルで動作確認
  - [ ] パネルを開いてページを 30px 以上スクロールすると閉じる
  - [ ] パネル外をタップすると閉じる
  - [ ] Escape で閉じる
  - [ ] パネル内のタグツリーをスクロールしても閉じない
  - [ ] タグを複数連続で選択しても閉じない
