### PR TITLE
chore: 自動生成の CHANGELOG.md を cspell 対象外に変更

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -19,7 +19,8 @@
     "tools/tidb-seeder/out/**",
     "**/go.mod",
     "**/go.sum",
-    "tools/dsql-cli/dsl-tidb/backfill/**"
+    "tools/dsql-cli/dsl-tidb/backfill/**",
+    "CHANGELOG.md"
   ],
   "language": "en",
   "words": [

--- a/docs/source/98_tasks/2026-07-11-release-flow-tagpr-calver/index.md
+++ b/docs/source/98_tasks/2026-07-11-release-flow-tagpr-calver/index.md
@@ -125,3 +125,4 @@ cd main && direnv allow .
 - Songmu/tagpr の SHA ピンを v1 タグの annotated tag オブジェクト SHA で書いていたため zizmor の ref-version-mismatch が発生。v1.20.0 のコミット SHA（e84001b）に修正
 - カットオーバー実施（default branch 切替 → main へ code_scanning ルールが自動追従、以降 main への直接 push は不可で PR 経由に）
 - tagpr 初回実行がリリース PR 本文の 65536 文字上限超過（422）で失敗。タグ未作成のため全履歴から本文を生成したのが原因で、ベースラインタグ `2026.0711.0` を手動で打つ対処を Phase C に追記
+- ベースラインタグ push 後、tagpr がリリース PR（Release for 2026.0711.1）を正常に作成。ただし自動生成の CHANGELOG.md に cspell 未知語（依存名・Renovate 由来の PR タイトル）が含まれ CI の spell-check が失敗するため、CHANGELOG.md を cspell の ignorePaths に追加


### PR DESCRIPTION
## 概要

- tagpr のリリース PR #604 の CI が、自動生成 CHANGELOG.md 内の未知語（`starlette` / `autoclosed` / `aidd`）で spell-check 失敗するため、CHANGELOG.md を cspell の対象外にする
- CHANGELOG は依存名や Renovate 由来の PR タイトルが入り続ける自動生成物のため、辞書追加ではなく `ignorePaths` での除外を選択

## 変更内容

- `cspell.json`: `ignorePaths` に `CHANGELOG.md` を追加
- `docs/source/98_tasks/2026-07-11-release-flow-tagpr-calver/index.md`: 作業ログに本件（リリース PR 作成成功と spell-check 失敗の対処）を追記

## チェック

- [x] `bun run lint:fmt` / `bun run spell-check` パス
- [x] マージ後、tagpr が #604 を自動更新し CI が緑になることを確認
