### PR TITLE
feat: skip-changelog ラベルを新設し tagpr の CHANGELOG から除外

### DIFF
--- a/.github/infra.yaml
+++ b/.github/infra.yaml
@@ -6,7 +6,7 @@ metadata:
 reconcile:
   labels: authoritative
 spec:
-  description: https://shuntaka.dev blog source
+  description: 🍵 https://shuntaka.dev blog source
   homepage: https://shuntaka.dev
   visibility: public
   archived: false
@@ -14,6 +14,12 @@ spec:
     - name: bug
       description: Something isn't working
       color: d73a4a
+    - name: skip-changelog
+      description: tagpr の CHANGELOG / リリースノートから除外する
+      color: cccccc
+    - name: tagpr
+      description: ''
+      color: ededed
   features:
     issues: true
     projects: true
@@ -64,8 +70,17 @@ spec:
         required_signatures: false
   actions:
     enabled: true
-    allowed_actions: all
-    sha_pinning_required: false
+    allowed_actions: selected
+    selected_actions:
+      github_owned_allowed: true
+      verified_allowed: true
+      patterns_allowed:
+        - astral-sh/setup-uv@*
+        - aws-actions/configure-aws-credentials@*
+        - kayac/ecspresso@*
+        - oven-sh/setup-bun@*
+        - songmu/tagpr@*
+    sha_pinning_required: true
     workflow_permissions: read
     can_approve_pull_requests: true
     fork_pr_approval: all_external_contributors

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -2,3 +2,4 @@ changelog:
   exclude:
     labels:
       - tagpr
+      - skip-changelog


### PR DESCRIPTION
## 概要

- `skip-changelog` ラベルを新設し、付与した PR を tagpr が生成する CHANGELOG / リリースノートから除外できるようにする
- あわせて `.github/infra.yaml` の宣言を GitHub の実態に同期する

## 変更内容

### .github/release.yaml

- `changelog.exclude.labels` に `skip-changelog` を追加。tagpr の changelog は GitHub の Generate release notes API で生成されるため、この設定で除外される（tagpr 側の `.tagpr` 変更は不要。デフォルトパス `.github/release.yaml` がそのまま参照される）

### .github/infra.yaml

- labels に `skip-changelog` を追加（apply 済み。ラベルは GitHub 上に作成済み）
- labels に既存の `tagpr` ラベルを追記。`reconcile.labels: authoritative` のため、manifest 未記載だと apply 時に削除されてしまうのを防ぐ
- 宣言と実態のドリフトを解消（description の 🍵、`allowed_actions: selected` + `patterns_allowed`、`sha_pinning_required: true`）。`gh infra plan` は No changes

## 動作確認

- [x] `gh infra validate` / `gh infra plan` で差分なしを確認
- [x] `gh label list` で `skip-changelog` ラベルの作成を確認
- [x] リリース時に `skip-changelog` 付き PR が CHANGELOG に載らないことを確認
