### PR TITLE
fix: ツイート埋め込み記事の目次欠落を修正、見出しなし記事は本文を中央揃えに

### DIFF
--- a/apps/web/src/app/[userName]/articles/[slug]/page.tsx
+++ b/apps/web/src/app/[userName]/articles/[slug]/page.tsx
@@ -81,6 +81,9 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
   }
 
   const articleUrl = `${SITE_URL}/${userName}/articles/${slug}`;
+  const contentHtml = article.contentHtml ?? '';
+  // 目次対象の見出し（h1-h3）が無い記事はサイドバーを出さず本文を中央に寄せる
+  const hasToc = /<h[1-3][\s>]/.test(contentHtml);
 
   return (
     <>
@@ -103,7 +106,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
             </div>
           </div>
         </div>
-        <div className="article-body">
+        <div className={hasToc ? 'article-body' : 'article-body article-body-centered'}>
           <article className="article-content">
             {article.thumbnail && (
               <Image
@@ -117,12 +120,14 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
               />
             )}
             <div className="article-content-wrapper">
-              <ArticleContent html={article.contentHtml ?? ''} />
+              <ArticleContent html={contentHtml} />
             </div>
           </article>
-          <aside className="right-sidebar">
-            <TableOfContents />
-          </aside>
+          {hasToc && (
+            <aside className="right-sidebar">
+              <TableOfContents />
+            </aside>
+          )}
         </div>
       </BaseLayout>
     </>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -576,6 +576,11 @@ a:hover {
   justify-content: space-between;
 }
 
+/* 見出しが無く目次サイドバーを出さない記事は本文を中央に寄せる */
+.article-body-centered {
+  justify-content: center;
+}
+
 .article-content {
   position: relative;
   width: calc(100% - var(--layout-sidebar-w) - var(--space-4));

--- a/apps/web/src/components/TableOfContents.tsx
+++ b/apps/web/src/components/TableOfContents.tsx
@@ -8,7 +8,8 @@ export function TableOfContents() {
 
   useEffect(() => {
     const initTocbot = async () => {
-      const content = document.querySelector('.prose');
+      // 本文はツイート埋め込みで複数の .prose に分割されるため、全体を包むラッパーを見る
+      const content = document.querySelector('.article-content-wrapper');
       if (!content) return;
 
       const headings = content.querySelectorAll('h1, h2, h3');
@@ -27,7 +28,7 @@ export function TableOfContents() {
 
       tocbot.init({
         tocSelector: '.toc',
-        contentSelector: '.prose',
+        contentSelector: '.article-content-wrapper',
         headingSelector: 'h1, h2, h3',
         scrollSmooth: false,
         headingsOffset: 100,


### PR DESCRIPTION
## 概要

- ツイート埋め込みを含む記事で、目次に最初の見出ししか表示されない問題を修正
- 見出し（h1〜h3）が無い記事では目次サイドバーを出さず、本文を中央揃えに変更

## 変更内容

### apps/web/src/components/TableOfContents.tsx

- 見出しの探索先を `.prose` から `.article-content-wrapper` に変更
- `ArticleContent` はツイート埋め込み位置で本文を複数の `.prose` に分割するため、`querySelector('.prose')` では最初のブロックの見出ししか拾えなかった。全ブロックを包むラッパーを参照することで、分割後も全見出しが目次に載る

### apps/web/src/app/[userName]/articles/[slug]/page.tsx

- `contentHtml` に h1〜h3 が含まれるかをサーバー側で判定する `hasToc` を追加
- 見出しが無い記事では `right-sidebar`（目次）をレンダリングせず、`article-body-centered` クラスを付与

### apps/web/src/app/globals.css

- `.article-body-centered { justify-content: center; }` を追加（見出しなし記事の本文中央揃え用）

## 確認内容

- [x] `/shuntaka/articles/20260321-opencode-composer-2`（ツイート3つ + h2 3つ）で目次に「はじめに」「連携設定」「参考」がすべて表示される
- [x] 目次リンククリックでスクロールし、アクティブハイライトが追従する
- [x] `/shuntaka/articles/20260711-poem`（見出しなし）で空の目次ボックスが消え、本文がページ中央に配置される
- [x] `bun run lint` / `bun run type-check` が成功
