### PR TITLE
fix: wt step copy-ignored の対象を .worktreeinclude で限定

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,12 @@
+# wt step copy-ignored の対象を限定。ここに列挙したもの「かつ」 gitignore 済みだけ複製される。
+# node_modules は bun install (pre-start install) が担うため意図的に除外し、
+# copy と install の並列実行での EEXIST を防ぐ。
+
+# Rust cargo target (workspace root)。cold rebuild が数分 → reflink で数秒
+target/
+
+# turbo キャッシュ
+.turbo/
+
+# Next.js の build cache
+apps/web/.next/


### PR DESCRIPTION
## Summary
- `wt switch --create` 時、`pre-start` の `copy`（`wt step copy-ignored`）と `install`（`bun install`）が並列実行され、両方が `node_modules/` に書き込んで `EEXIST` で bun install が数パッケージ失敗していた
- `.worktreeinclude` で copy 対象を `target/` / `.turbo/` / `apps/web/.next/` のビルドキャッシュだけに絞ることで、`node_modules/` は bun install の専有下に戻す

## Test plan
- [x] 現在の main + 本 patch を当てた main worktree から `wsc test` して pre-start が全ステップ成功
- [x] `install │ 2181 packages installed` で "Failed to install X packages" が出ない
- [x] `copy │ ✓ Copied 14878 files · 6.2 GiB`（node_modules 除外で削減）