### PR TITLE
fix: .next を worktree コピー対象から除外し Turbopack persistence 汚染を防ぐ

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -7,6 +7,3 @@ target/
 
 # turbo キャッシュ
 .turbo/
-
-# Next.js の build cache
-apps/web/.next/


### PR DESCRIPTION
## 概要

- `apps/web/.next/` を `.worktreeinclude` から除外
- Next.js 16 Turbopack persistence の汚染で新規 worktree の dev サーバーが無限リスパーンする問題を予防

## 背景

test1 worktree で `bun run dev` を立ち上げると、`localhost:$WEB_PORT` にアクセスした瞬間に応答不能になり、CPU/メモリを食い潰す事象が発生した。

調査の結果、以下が判明した:

- `apps/web/.next/dev/build/*.js`（Turbopack persistence の worker スクリプト）から node の子プロセスが大量に湧いており、next-server 本体は `stuck` 状態
- test1 の `.next/dev/build/` 内のファイルタイムスタンプは worktree 作成前の時刻 → main の `.next` が reflink 複製で持ち込まれていた
- Turbopack persistence は絶対パス依存のビルドグラフを保持しており、別ディレクトリから読み出すと解決に失敗して worker 無限リスパーンを引き起こす
- `.next/dev/lock` も複製されるため、別プロセス起動と誤認する副次的リスクもある

`bun run clean` (`rm -rf .next .turbo storybook-static`) で復旧を確認済み。

## 変更内容

`.worktreeinclude` から以下を削除:

```
# Next.js の build cache
apps/web/.next/
```

`target/` と `.turbo/` はそのまま維持（Rust の cargo target は cold rebuild が数分と重く、turbo キャッシュはパス非依存なので安全）。

## トレードオフ

新規 worktree の Next.js dev cold start が数十秒遅くなるが、刺さり時の復旧コストと引き合わない。Rust の cargo target のような桁違いの遅延ではない。

## テストプラン

- [x] 症状再現（test1 worktree で dev がハングすることを確認）
- [x] `bun run clean` で復旧することを確認
- [ ] 本 PR マージ後、新規に `wt` で worktree を作って `.next` が複製されないことを確認
- [ ] 新規 worktree で `bun run dev` が正常に起動することを確認
