### PR TITLE
feat: 現在の worktree のポート一覧を表示する bun run port を追加

### DIFF
--- a/docs/source/01_開発ドキュメント/01_development.md
+++ b/docs/source/01_開発ドキュメント/01_development.md
@@ -595,17 +595,16 @@ direnv allow .
 | `NEXT_PUBLIC_API_URL`  | API URL                     | `http://localhost:43003` |
 | `ORIGIN_ALLOWLIST`     | admin-api CSRF 許可 Origin  | `http://localhost:43002` |
 
-新規worktreeではブランチ名から10000-19999の範囲でポートがサービスごとに決定的に生成される。同じブランチ名なら常に同じポートになる（連番ではない）。現worktreeに割り当てられたポートを確認するには`.env.local`を参照する。
+新規worktreeではブランチ名から10000-19999の範囲でポートがサービスごとに決定的に生成される。同じブランチ名なら常に同じポートになる（連番ではない）。現worktreeに割り当てられたポートは `bun run port` で確認できる。
 
 ```bash
-grep _PORT .env.local
-# WEB_PORT=12345
-# API_PORT=18291
-# PORT=18291
-# DOCS_PORT=11284
-# ADMIN_API_PORT=10932
-# ADMIN_WEB_PORT=15607
-# STORYBOOK_PORT=19012
+bun run port
+# web         http://localhost:17265
+# api         http://localhost:14261
+# docs        http://localhost:18224
+# admin-api   http://localhost:13664
+# admin-web   http://localhost:11286
+# storybook   http://localhost:12372
 ```
 
 ブランチ作業は、`wt switch --create`で新しいworktreeを作成する。pre-startフックにより`.env.local`（ポート設定）、`.envrc`、依存関係のインストールが自動で行われる。

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "turbo dev storybook",
+    "port": "bash scripts/port.sh",
     "spell-check": "cspell lint . --cache --gitignore",
     "build": "turbo build",
     "type-check": "bun --filter '*' type-check",

--- a/scripts/port.sh
+++ b/scripts/port.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -f .env.local ]; then
+  echo ".env.local not found. Run 'wt switch --create <branch>' or create it manually." >&2
+  exit 1
+fi
+
+set -a
+# shellcheck source=/dev/null
+source .env.local
+set +a
+
+printf "%-11s http://localhost:%s\n" web       "${WEB_PORT}"
+printf "%-11s http://localhost:%s\n" api       "${API_PORT}"
+printf "%-11s http://localhost:%s\n" docs      "${DOCS_PORT}"
+printf "%-11s http://localhost:%s\n" admin-api "${ADMIN_API_PORT}"
+printf "%-11s http://localhost:%s\n" admin-web "${ADMIN_WEB_PORT}"
+printf "%-11s http://localhost:%s\n" storybook "${STORYBOOK_PORT}"


### PR DESCRIPTION
## Summary

- 現在の worktree に割り当てられた各サービス (web / api / docs / admin-api / admin-web / storybook) の localhost URL を一覧表示する `bun run port` を追加
- 実体は `.env.local` を読み込む `scripts/port.sh`
- docs (`01_development.md`) のポート確認箇所を `grep _PORT .env.local` から `bun run port` の出力例に差し替え

## 変更内容

- `scripts/port.sh`: 新規追加。`.env.local` がない場合はエラー終了
- `package.json`: `port` script を追加
- `docs/source/01_開発ドキュメント/01_development.md`: ポート確認手順を差し替え

## Test plan

- [ ] worktree 内で `bun run port` を実行し、`.env.local` の各ポートに対応する URL が整形されて出力されることを確認
- [ ] `.env.local` が存在しない状態で実行し、ガイダンス付きで exit 1 になることを確認
