### PR TITLE
feat: bun run port を .env.local 無しでも既定ポートで動くようフォールバック

### DIFF
--- a/scripts/port.sh
+++ b/scripts/port.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ ! -f .env.local ]; then
-  echo ".env.local not found. Run 'wt switch --create <branch>' or create it manually." >&2
-  exit 1
+if [ -f .env.local ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source .env.local
+  set +a
 fi
 
-set -a
-# shellcheck source=/dev/null
-source .env.local
-set +a
+# fallback: main worktree の既定値 (docs/source/01_開発ドキュメント/01_development.md 参照)
+: "${WEB_PORT:=43000}"
+: "${ADMIN_API_PORT:=43001}"
+: "${ADMIN_WEB_PORT:=43002}"
+: "${API_PORT:=43003}"
+: "${DOCS_PORT:=43004}"
+: "${STORYBOOK_PORT:=43005}"
 
 printf "%-11s http://localhost:%s\n" web       "${WEB_PORT}"
 printf "%-11s http://localhost:%s\n" api       "${API_PORT}"


### PR DESCRIPTION
## Summary

- `bun run port` を `.env.local` が無い状態 (main worktree など) でも main の既定ポートで動くようにフォールバックを追加
- `.env.local` がある場合はそちらの値が優先される (既存挙動)

## 背景

#642 でマージした `bun run port` は、`.env.local` が無いと exit 1 で落ちていた。main worktree は wt の pre-start フックの対象外で `.env.local` を持たないケースがあり、そのままだと使えなかったのでフォールバック値を導入する。

## 変更内容

- `scripts/port.sh`: `.env.local` を読み込みは条件付きにして、その後 `: "${VAR:=default}"` で main 既定値 (docs 記載) をフォールバックとして適用

## Test plan

- [ ] main worktree (`.env.local` 無し) で `bun run port` を実行し、43000-43005 の URL が出力されることを確認
- [ ] worktree (`.env.local` あり) で `bun run port` を実行し、`.env.local` のポートが出力されることを確認
