### PR TITLE
fix: docs CI の依存関係セットアップ順を修正

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -41,9 +41,6 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
-      - name: Setup node
-        uses: ./.github/actions/setup-node
-
       - name: Setup Python
         working-directory: docs
         run: uv python install
@@ -51,6 +48,9 @@ jobs:
       - name: Install Sphinx dependencies
         working-directory: docs
         run: uv sync
+
+      - name: Setup node
+        uses: ./.github/actions/setup-node
 
       - name: Build documentation and search index
         run: bun run --cwd docs build-docs


### PR DESCRIPTION
## 概要

- Docs CI で Python 依存関係を Node.js 依存関係より先にセットアップする
- `docs/node_modules` を setuptools の editable build より後に生成し、flat-layout の誤検出を防ぐ

## 変更内容

- `.github/workflows/docs.yaml` の `Setup node` を `Install Sphinx dependencies` の後へ移動
- 依存関係やビルド処理自体は変更せず、ステップ順だけを修正

## テスト

- [x] 修正前の順序（`bun install` → `uv 0.11.28 sync`）で `Multiple top-level packages discovered` を再現
- [x] 修正後の順序（`uv 0.11.28 sync` → `bun install`）で依存関係セットアップ成功
- [x] Sphinx / Pagefind ビルドと検索品質チェック成功
- [x] Storybook ビルド成功
- [x] `bun run lint:fmt`
- [x] pre-push の lint / 型チェック / spell-check / zizmor
