### PR TITLE
feat: GitHub webhookでarticle embedding chunksを差し替える

### DIFF
--- a/apps/blog-api/adapter/src/repository/articles.rs
+++ b/apps/blog-api/adapter/src/repository/articles.rs
@@ -5,7 +5,9 @@ use kernel::model::article::{
     Article, ArticleId, Content, ContentHtml, Description, Slug, Status, Thumbnail, Title, UserId,
     normalize_tags, parse_tag_path,
 };
-use kernel::repository::articles::{ArticlesRepository, UpsertArticleInput, UpsertResult};
+use kernel::repository::articles::{
+    ArticleEmbeddingChunk, ArticlesRepository, UpsertArticleInput, UpsertResult,
+};
 use sqlx::FromRow;
 use uuid::Uuid;
 
@@ -19,6 +21,10 @@ const TAGS_SYNC_SQL: &str =
 /// sync_tag_article_counts 全体を 1 span で計装するための代表 SQL（statement_hash 用）
 const TAG_ARTICLE_COUNTS_SYNC_SQL: &str =
     "DELETE FROM tag_article_counts; INSERT INTO tag_article_counts";
+
+/// replace_article_chunks 全体を 1 span で計装するための代表 SQL（statement_hash 用）
+const CHUNKS_REPLACE_SQL: &str =
+    "DELETE FROM article_embedding_chunks; INSERT INTO article_embedding_chunks";
 
 #[derive(FromRow)]
 struct ArticleRow {
@@ -439,5 +445,57 @@ impl ArticlesRepository for ArticlesRepositoryImpl {
                 Ok(UpsertResult::Created(ArticleId::new(article_id)))
             }
         }
+    }
+
+    async fn replace_article_chunks(
+        &self,
+        article_id: &ArticleId,
+        chunks: &[ArticleEmbeddingChunk],
+        chunking_version: &str,
+        source_hash: &str,
+    ) -> Result<(), anyhow::Error> {
+        let article_id_str = article_id.as_uuid().to_string();
+
+        observe_query(
+            "article_chunks_replace",
+            CHUNKS_REPLACE_SQL,
+            async {
+                let mut tx = self.db.pool().begin().await?;
+
+                sqlx::query("DELETE FROM article_embedding_chunks WHERE article_id = ?")
+                    .bind(&article_id_str)
+                    .execute(&mut *tx)
+                    .await?;
+
+                for chunk in chunks {
+                    // TiDB の VECTOR 列は JSON 配列文字列を受け付ける。
+                    // tidb-embedder と同じ形式で送るため serde_json で serialize する。
+                    let embedding_json = serde_json::to_string(&chunk.embedding)?;
+                    sqlx::query(
+                        r#"
+                        INSERT INTO article_embedding_chunks
+                            (article_id, chunk_index, heading, content, token_count,
+                             chunking_version, source_hash, embedding)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        "#,
+                    )
+                    .bind(&article_id_str)
+                    .bind(chunk.chunk_index)
+                    .bind(chunk.heading.as_deref())
+                    .bind(&chunk.content)
+                    .bind(chunk.token_count)
+                    .bind(chunking_version)
+                    .bind(source_hash)
+                    .bind(&embedding_json)
+                    .execute(&mut *tx)
+                    .await?;
+                }
+
+                tx.commit().await?;
+                Ok::<(), anyhow::Error>(())
+            },
+            |_| Some(chunks.len() as i64),
+        )
+        .await
     }
 }

--- a/apps/blog-api/api/src/handler/webhooks.rs
+++ b/apps/blog-api/api/src/handler/webhooks.rs
@@ -2,14 +2,19 @@ use axum::{Json, body::Bytes, extract::State, http::HeaderMap};
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use futures::future::join_all;
+use infrastructure::embedding::client::{
+    CHUNKING_VERSION, DEFAULT_MAX_TOKENS, DEFAULT_OVERLAP_TOKENS, DocumentChunk, EmbeddingClient,
+    compute_source_hash,
+};
 use infrastructure::github::{GitHubAppClient, GitHubAppClientImpl, PushEvent};
 use infrastructure::webhook::verify_signature;
-use kernel::model::article::Slug;
+use kernel::model::article::{ArticleId, Slug};
 use kernel::model::frontmatter::ArticleFrontmatter;
-use kernel::repository::articles::UpsertArticleInput;
+use kernel::repository::articles::{ArticleEmbeddingChunk, UpsertArticleInput, UpsertResult};
 use markdown::convert_markdown_to_html;
 use registry::AppRegistry;
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use std::sync::LazyLock;
 use tracing::{error, info, warn};
 use utoipa::ToSchema;
@@ -317,6 +322,8 @@ async fn process_push_event(
     let mut succeeded = 0;
     let mut failed = 0;
     let mut errors: Vec<ArticleProcessError> = vec![];
+    // PLaMO Service へ到達できる環境でのみ Some。未設定でも記事の upsert 自体は成功させる。
+    let embedding_client = registry.embedding_client();
 
     for (file_path, fetch_result) in file_paths.iter().zip(fetch_results) {
         processed += 1;
@@ -377,6 +384,25 @@ async fn process_push_event(
                     None => true,
                 };
 
+                // ArticlesRepository の upsert が保存する description。frontmatter が
+                // None のときは既存値を維持、なければ title をデフォルトにする挙動と一致させる。
+                let effective_description = frontmatter
+                    .description
+                    .clone()
+                    .or_else(|| existing.as_ref().map(|a| a.description.as_str().to_string()))
+                    .unwrap_or_else(|| frontmatter.title.clone());
+
+                // title / description / content のいずれかが変わったら chunk を再生成する。
+                // upsert 内の判定と揃えるため、description は effective 値で比較する。
+                let needs_chunks = match &existing {
+                    Some(article) => {
+                        article.content.as_str() != content
+                            || article.title.as_str() != frontmatter.title
+                            || article.description.as_str() != effective_description
+                    }
+                    None => true,
+                };
+
                 let content_html = if needs_html {
                     // OGP リンクカードや GitHub 埋め込みで同期 HTTP フェッチが走るため
                     // blocking スレッドで実行して tokio ワーカーを塞がない
@@ -401,6 +427,8 @@ async fn process_push_event(
                 };
 
                 // Build upsert input
+                let title = frontmatter.title.clone();
+                let content_for_chunks = content.clone();
                 let input = UpsertArticleInput {
                     user_id: user_id.clone(),
                     slug: Slug::new(slug.clone()),
@@ -418,6 +446,20 @@ async fn process_push_event(
                     Ok(result) => {
                         info!("Article upserted: slug={}, result={:?}", slug, result);
                         succeeded += 1;
+
+                        if needs_chunks {
+                            let article_id = upsert_result_article_id(&result);
+                            regenerate_chunks(
+                                registry,
+                                embedding_client.as_ref(),
+                                &article_id,
+                                &slug,
+                                &title,
+                                &effective_description,
+                                &content_for_chunks,
+                            )
+                            .await;
+                        }
                     }
                     Err(e) => {
                         error!("Failed to upsert article: slug={}, error={}", slug, e);
@@ -459,4 +501,109 @@ async fn process_push_event(
         succeeded: Some(succeeded),
         failed: Some(failed),
     })
+}
+
+fn upsert_result_article_id(result: &UpsertResult) -> ArticleId {
+    match result {
+        UpsertResult::Created(id)
+        | UpsertResult::Updated(id)
+        | UpsertResult::TagsUpdated(id)
+        | UpsertResult::NoChange(id) => id.clone(),
+    }
+}
+
+/// 記事 upsert 直後に呼ぶ chunk 再生成。PLaMO 呼び出しや DB 書き込みの失敗は
+/// warn ログを残して呑み込み、既存 chunk を保持する。上位ループは記事 upsert 自体を
+/// 成功として扱う。
+async fn regenerate_chunks(
+    registry: &AppRegistry,
+    embedding_client: Option<&Arc<dyn EmbeddingClient>>,
+    article_id: &ArticleId,
+    slug: &str,
+    title: &str,
+    description: &str,
+    content: &str,
+) {
+    let Some(client) = embedding_client else {
+        info!(
+            "Skipping chunk regeneration (PLAMO_EMBED_ENDPOINT not configured): slug={}",
+            slug
+        );
+        return;
+    };
+
+    let chunks = match client
+        .chunk_document(
+            title,
+            description,
+            content,
+            DEFAULT_MAX_TOKENS,
+            DEFAULT_OVERLAP_TOKENS,
+        )
+        .await
+    {
+        Ok(chunks) => chunks,
+        Err(e) => {
+            warn!(
+                "Failed to chunk article, keeping existing chunks: slug={}, error={}",
+                slug, e
+            );
+            return;
+        }
+    };
+
+    let mut embedded: Vec<ArticleEmbeddingChunk> = Vec::with_capacity(chunks.len());
+    for chunk in chunks {
+        let DocumentChunk {
+            index,
+            heading,
+            content: chunk_content,
+            embedding_text,
+            token_count,
+        } = chunk;
+        match client.embed_document(&embedding_text).await {
+            Ok(vector) => {
+                embedded.push(ArticleEmbeddingChunk {
+                    chunk_index: index,
+                    heading,
+                    content: chunk_content,
+                    token_count,
+                    embedding: vector,
+                });
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to embed chunk, keeping existing chunks: slug={}, chunk_index={}, error={}",
+                    slug, index, e
+                );
+                return;
+            }
+        }
+    }
+
+    let source_hash = compute_source_hash(
+        title,
+        description,
+        content,
+        DEFAULT_MAX_TOKENS,
+        DEFAULT_OVERLAP_TOKENS,
+    );
+
+    if let Err(e) = registry
+        .articles_repository()
+        .replace_article_chunks(article_id, &embedded, CHUNKING_VERSION, &source_hash)
+        .await
+    {
+        warn!(
+            "Failed to persist article chunks, keeping existing chunks: slug={}, error={}",
+            slug, e
+        );
+        return;
+    }
+
+    info!(
+        "Article chunks replaced: slug={}, chunks={}",
+        slug,
+        embedded.len()
+    );
 }

--- a/apps/blog-api/infrastructure/src/embedding/client.rs
+++ b/apps/blog-api/infrastructure/src/embedding/client.rs
@@ -3,22 +3,47 @@ use std::time::Duration;
 use async_trait::async_trait;
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use crate::error::EmbeddingError;
 use crate::observability::observe_external_request;
 
 const EXPECTED_DIMENSION: usize = 2048;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+/// PLaMo Service の chunking.py で公開されている version と一致させる。
+/// tidb-embedder (バッチ backfill) が同じ値で source_hash を作るため、webhook 側で
+/// 生成した chunk と後段のバッチが同じ hash になる。
+pub const CHUNKING_VERSION: &str = "plamo-markdown-1024-v1";
+pub const DEFAULT_MAX_TOKENS: u32 = 1024;
+pub const DEFAULT_OVERLAP_TOKENS: u32 = 128;
+
+#[derive(Debug, Clone)]
+pub struct DocumentChunk {
+    pub index: u32,
+    pub heading: Option<String>,
+    pub content: String,
+    pub embedding_text: String,
+    pub token_count: u32,
+}
 
 #[async_trait]
 pub trait EmbeddingClient: Send + Sync {
     async fn embed_query(&self, text: &str) -> Result<Vec<f32>, EmbeddingError>;
     async fn embed_document(&self, text: &str) -> Result<Vec<f32>, EmbeddingError>;
+    async fn chunk_document(
+        &self,
+        title: &str,
+        description: &str,
+        content: &str,
+        max_tokens: u32,
+        overlap_tokens: u32,
+    ) -> Result<Vec<DocumentChunk>, EmbeddingError>;
 }
 
 pub struct EmbeddingClientImpl {
     http_client: Client,
-    endpoint: Url,
+    embed_endpoint: Url,
+    chunks_endpoint: Url,
 }
 
 #[derive(Serialize)]
@@ -33,19 +58,49 @@ struct EmbedResponse {
     dim: usize,
 }
 
+#[derive(Serialize)]
+struct ChunksRequest<'a> {
+    title: &'a str,
+    description: &'a str,
+    content: &'a str,
+    max_tokens: u32,
+    overlap_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChunkItemResponse {
+    index: u32,
+    heading: Option<String>,
+    content: String,
+    embedding_text: String,
+    token_count: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChunksResponse {
+    version: String,
+    max_tokens: u32,
+    overlap_tokens: u32,
+    chunks: Vec<ChunkItemResponse>,
+}
+
 impl EmbeddingClientImpl {
     pub fn new(base_url: &str) -> Result<Self, EmbeddingError> {
-        let mut endpoint = Url::parse(base_url)
+        let mut base = Url::parse(base_url)
             .map_err(|error| EmbeddingError::InvalidEndpoint(error.to_string()))?;
-        if endpoint.scheme() != "http" && endpoint.scheme() != "https" {
+        if base.scheme() != "http" && base.scheme() != "https" {
             return Err(EmbeddingError::InvalidEndpoint(
                 "scheme must be http or https".to_string(),
             ));
         }
-        let base_path = endpoint.path().trim_end_matches('/');
-        endpoint.set_path(&format!("{base_path}/embed"));
-        endpoint.set_query(None);
-        endpoint.set_fragment(None);
+        let base_path = base.path().trim_end_matches('/').to_string();
+        base.set_query(None);
+        base.set_fragment(None);
+
+        let mut embed_endpoint = base.clone();
+        embed_endpoint.set_path(&format!("{base_path}/embed"));
+        let mut chunks_endpoint = base;
+        chunks_endpoint.set_path(&format!("{base_path}/chunks"));
 
         let http_client = Client::builder()
             .timeout(REQUEST_TIMEOUT)
@@ -53,7 +108,8 @@ impl EmbeddingClientImpl {
             .map_err(EmbeddingError::HttpClient)?;
         Ok(Self {
             http_client,
-            endpoint,
+            embed_endpoint,
+            chunks_endpoint,
         })
     }
 
@@ -83,7 +139,7 @@ impl EmbeddingClientImpl {
         observe_external_request("plamo", mode, "POST", "/embed", async {
             let response = self
                 .http_client
-                .post(self.endpoint.clone())
+                .post(self.embed_endpoint.clone())
                 .json(&EmbedRequest { text, mode })
                 .send()
                 .await?;
@@ -109,6 +165,124 @@ impl EmbeddingClient for EmbeddingClientImpl {
     async fn embed_document(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
         self.embed(text, "document").await
     }
+
+    async fn chunk_document(
+        &self,
+        title: &str,
+        description: &str,
+        content: &str,
+        max_tokens: u32,
+        overlap_tokens: u32,
+    ) -> Result<Vec<DocumentChunk>, EmbeddingError> {
+        observe_external_request("plamo", "chunk", "POST", "/chunks", async {
+            let response = self
+                .http_client
+                .post(self.chunks_endpoint.clone())
+                .json(&ChunksRequest {
+                    title,
+                    description,
+                    content,
+                    max_tokens,
+                    overlap_tokens,
+                })
+                .send()
+                .await?;
+
+            if !response.status().is_success() {
+                let status = response.status().as_u16();
+                let message: String = response.text().await?.chars().take(500).collect();
+                return Err(EmbeddingError::Api { status, message });
+            }
+
+            let body = response.json::<ChunksResponse>().await?;
+            if body.version != CHUNKING_VERSION {
+                return Err(EmbeddingError::InvalidResponse(format!(
+                    "unexpected chunking version: expected={CHUNKING_VERSION}, actual={}",
+                    body.version
+                )));
+            }
+            if body.max_tokens != max_tokens || body.overlap_tokens != overlap_tokens {
+                return Err(EmbeddingError::InvalidResponse(format!(
+                    "chunks API returned different token config: max={}, overlap={}",
+                    body.max_tokens, body.overlap_tokens
+                )));
+            }
+            if body.chunks.is_empty() {
+                return Err(EmbeddingError::InvalidResponse(
+                    "chunks API returned no chunks".to_string(),
+                ));
+            }
+            for (index, chunk) in body.chunks.iter().enumerate() {
+                if chunk.index as usize != index {
+                    return Err(EmbeddingError::InvalidResponse(format!(
+                        "chunks API index is not sequential: expected={index}, actual={}",
+                        chunk.index
+                    )));
+                }
+                if chunk.token_count == 0 {
+                    return Err(EmbeddingError::InvalidResponse(format!(
+                        "chunks[{index}] token_count must be positive"
+                    )));
+                }
+                if chunk.token_count > max_tokens {
+                    return Err(EmbeddingError::InvalidResponse(format!(
+                        "chunks[{index}] token_count={} exceeds max_tokens={}",
+                        chunk.token_count, max_tokens
+                    )));
+                }
+            }
+
+            Ok(body
+                .chunks
+                .into_iter()
+                .map(|chunk| DocumentChunk {
+                    index: chunk.index,
+                    heading: chunk.heading,
+                    content: chunk.content,
+                    embedding_text: chunk.embedding_text,
+                    token_count: chunk.token_count,
+                })
+                .collect())
+        })
+        .await
+    }
+}
+
+/// tidb-embedder と同じ JSON レイアウトで SHA-256 を計算する。TS 側は
+/// `JSON.stringify({version, maxTokens, overlapTokens, title, description, content})`
+/// を hash 元にしているため、Rust 側の struct 順序と rename もこれに揃える。
+/// これにより、webhook で書いた chunk を後段の tidb-embedder バッチが同じ hash と
+/// 見なしてスキップできる。
+pub fn compute_source_hash(
+    title: &str,
+    description: &str,
+    content: &str,
+    max_tokens: u32,
+    overlap_tokens: u32,
+) -> String {
+    #[derive(Serialize)]
+    struct HashInput<'a> {
+        version: &'static str,
+        #[serde(rename = "maxTokens")]
+        max_tokens: u32,
+        #[serde(rename = "overlapTokens")]
+        overlap_tokens: u32,
+        title: &'a str,
+        description: &'a str,
+        content: &'a str,
+    }
+
+    let payload = serde_json::to_string(&HashInput {
+        version: CHUNKING_VERSION,
+        max_tokens,
+        overlap_tokens,
+        title,
+        description,
+        content,
+    })
+    .expect("HashInput is always serializable");
+    let digest = Sha256::digest(payload.as_bytes());
+    hex::encode(digest)
 }
 
 #[cfg(test)]
@@ -116,9 +290,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn endpoint_appends_embed_path() {
+    fn endpoints_append_paths() {
         let client = EmbeddingClientImpl::new("http://localhost:8080/base/").unwrap();
-        assert_eq!(client.endpoint.as_str(), "http://localhost:8080/base/embed");
+        assert_eq!(
+            client.embed_endpoint.as_str(),
+            "http://localhost:8080/base/embed"
+        );
+        assert_eq!(
+            client.chunks_endpoint.as_str(),
+            "http://localhost:8080/base/chunks"
+        );
     }
 
     #[test]
@@ -147,5 +328,15 @@ mod tests {
                 .len(),
             EXPECTED_DIMENSION
         );
+    }
+
+    #[test]
+    fn source_hash_matches_tidb_embedder_layout() {
+        // tidb-embedder が JSON.stringify で出す文字列と同じであること。
+        // Node.js の JSON.stringify で下記の値を hash して得られる SHA-256 と一致する。
+        let hash = compute_source_hash("title", "desc", "content", 1024, 128);
+        let expected_payload = r#"{"version":"plamo-markdown-1024-v1","maxTokens":1024,"overlapTokens":128,"title":"title","description":"desc","content":"content"}"#;
+        let expected: String = hex::encode(Sha256::digest(expected_payload.as_bytes()));
+        assert_eq!(hash, expected);
     }
 }

--- a/apps/blog-api/kernel/src/repository/articles.rs
+++ b/apps/blog-api/kernel/src/repository/articles.rs
@@ -2,6 +2,17 @@ use async_trait::async_trait;
 
 use crate::model::article::{Article, ArticleId, Slug, UserId};
 
+/// article_embedding_chunks 1 行分。webhook 側で PLaMO から取得した chunk と
+/// embedding vector をまとめて渡す。
+#[derive(Debug, Clone)]
+pub struct ArticleEmbeddingChunk {
+    pub chunk_index: u32,
+    pub heading: Option<String>,
+    pub content: String,
+    pub token_count: u32,
+    pub embedding: Vec<f32>,
+}
+
 /// Input data for creating or updating an article
 #[derive(Debug, Clone)]
 pub struct UpsertArticleInput {
@@ -42,4 +53,15 @@ pub trait ArticlesRepository: Send + Sync {
         &self,
         input: UpsertArticleInput,
     ) -> Result<UpsertResult, anyhow::Error>;
+
+    /// article_id 単位で既存 chunk を全削除して新 chunk を差し替える。
+    /// PLaMO で全 chunk の vector 生成に成功した後にだけ呼び出す想定。
+    /// 失敗時は transaction が rollback され、既存 chunk が残る。
+    async fn replace_article_chunks(
+        &self,
+        article_id: &ArticleId,
+        chunks: &[ArticleEmbeddingChunk],
+        chunking_version: &str,
+        source_hash: &str,
+    ) -> Result<(), anyhow::Error>;
 }

--- a/docs/source/98_tasks/2026-07-15-tidb-vector-search-implementation/index.md
+++ b/docs/source/98_tasks/2026-07-15-tidb-vector-search-implementation/index.md
@@ -1127,3 +1127,11 @@ Phase 4のローカルbackfillは、実行時点でsource hashが変わった記
 - 1記事1vectorの精度確認では `Rust Axum API` に対し本文全体がdistance 0.4674、タイトルのみが0.3815となり、長文による話題の希釈を確認
 - PLaMOの学習時context長1024 tokensに合わせ、同じtokenizerでMarkdownを見出し単位 + 128 tokens overlapに分割する方式へ変更
 - `article_embedding_chunks` とsource hashによる差分backfillを実装。全vector生成後に記事単位transactionで差し替える
+
+### 2026-07-16
+
+- Phase 7 実装。`EmbeddingClient` に `chunk_document` を追加し、`compute_source_hash` を tidb-embedder と同じ JSON レイアウトで書いて後段バッチと hash が揃うようにした
+- `ArticlesRepository::replace_article_chunks` を追加。`article_embedding_chunks` の記事単位 transaction 差し替えを webhook でも使えるようにした
+- `handler/webhooks.rs` で title / description / content の変更を検出したら chunk 再生成を走らせるようにした。effective description の判定は `upsert_article` の書き込み挙動と同じ (frontmatter が None なら既存値、無ければ title) に揃えた
+- 失敗時は `warn!` を残して既存 chunk を保持し、記事 upsert 自体は成功扱い。`PLAMO_EMBED_ENDPOINT` 未設定時は skip ログのみ (dev のみ有効化)
+- 動作確認は次回、`PLAMO_EMBED_ENDPOINT=http://plamo-embedding.${TAILNET}` を渡した状態で webhook を再送して行う

--- a/docs/source/98_tasks/2026-07-15-tidb-vector-search-implementation/index.md
+++ b/docs/source/98_tasks/2026-07-15-tidb-vector-search-implementation/index.md
@@ -1,4 +1,4 @@
-<!-- cspell:ignore fastapi huggingface pretrained pydantic QVEC sentencepiece urlencode uvicorn -->
+<!-- cspell:ignore eprintln fastapi huggingface pretrained pydantic QVEC sentencepiece urlencode uvicorn -->
 
 # TiDB Vector 検索実装 (PLaMo Embedding 1B + TiFlash)
 
@@ -1107,9 +1107,33 @@ Phase 4のローカルbackfillは、実行時点でsource hashが変わった記
 
 ### Phase 7 完了条件
 
-- [ ] webhookで記事が変わった場合、chunkが記事単位で差し替わる (dev)
+- [x] webhookで記事が変わった場合、chunkが記事単位で差し替わる (dev。`blog_dev.article_embedding_chunks` の created_at が webhook 処理ウィンドウ内で更新されることを確認)
 - [ ] PLaMo endpoint 未設定 / 呼び出し失敗でも記事更新自体は成功する
 - [ ] PLaMO失敗時に既存chunkが削除されない
+
+### 7-5. Followup: Lambda ループ内の tracing ログが CloudWatch に出ない
+
+dev で webhook を再送して DB の chunk 差し替えは検証できたが、`process_push_event` のループ**内側**で発火する `info!("Article upserted: ...")` / `info!("Article chunks replaced: ...")` / `warn!("Failed to chunk article ...")` などが CloudWatch Logs に一切現れない。
+
+観測結果 (2026-07-16, dev, requestId `e4a4e306-ba9a-49b8-8413-1ca77108bf47`):
+
+- ループ**外側**の `info!("Processing async push event")` / `info!("Found {} markdown files")` / `info!("Webhook processing complete: processed=2, succeeded=2, failed=0")` は出る
+- ループ**内側**の info!/warn! は 0 件 (`aws logs filter-log-events` で `Article`, `upserted`, `chunks`, `slug`, `keeping`, `Skipping`, `Failed`, `error`, `panic` すべてマッチしない)
+- 同じ target (`api::handler::webhooks`) / 同じレベル (INFO) / 同じ span (`lambda.handler`) なのに、ループの前後だけ通る
+- DB (`article_embedding_chunks`) は正しく差し替わっているので、code path は実行されている
+- Athena (tidb-proxy squid_access) には OGP 用の外部 fetch が記録されており、markdown 変換まで含めてループが完走した傍証はある
+
+推測される原因候補:
+
+- `spawn_blocking` から戻った直後の future の tracing context が壊れて event が subscribable でない
+- Lambda LWA の `response_stream` モードで、レスポンス書き出しと非同期な stdout flush の間で内部ログが失われる
+- tracing_opentelemetry layer が span を close する順序で fmt::layer への forwarding を妨げている
+
+暫定対応案 (別 PR):
+
+- `regenerate_chunks` に `#[tracing::instrument(skip_all, fields(slug, chunks))]` を張り、event を span 属性化する
+- ループの各記事に per-article span を張って明示的に enter する
+- 一部の重要 info!/warn! を `eprintln!` に差し替えて fmt::layer をバイパスし、CloudWatch に必ず載る形を確認する
 
 ---
 
@@ -1135,3 +1159,5 @@ Phase 4のローカルbackfillは、実行時点でsource hashが変わった記
 - `handler/webhooks.rs` で title / description / content の変更を検出したら chunk 再生成を走らせるようにした。effective description の判定は `upsert_article` の書き込み挙動と同じ (frontmatter が None なら既存値、無ければ title) に揃えた
 - 失敗時は `warn!` を残して既存 chunk を保持し、記事 upsert 自体は成功扱い。`PLAMO_EMBED_ENDPOINT` 未設定時は skip ログのみ (dev のみ有効化)
 - 動作確認は次回、`PLAMO_EMBED_ENDPOINT=http://plamo-embedding.${TAILNET}` を渡した状態で webhook を再送して行う
+- dev デプロイ後 (2c9371b, 02:44:16Z 反映) に webhook 再送。`blog_dev.article_embedding_chunks` の `0c646f1b-...` に 3 chunks が created_at=02:45:01.427842 で差し替え済み ✅
+- ただし CloudWatch Logs で `process_push_event` **ループ内側**の info!/warn! (Article upserted、Article chunks replaced 等) が全部消失。ループ**外側**の info! と DB 書き込みは動作しているので機能面は OK。詳細は 7-5 followup に記録


### PR DESCRIPTION
## 概要

- Phase 7 (`docs/source/98_tasks/2026-07-15-tidb-vector-search-implementation/index.md`): 記事の title / description / content が変わった webhook 契機で、PLaMO Embedding Service の `/chunks` と `/embed` を呼び、`article_embedding_chunks` を記事単位で差し替える経路を追加する
- `PLAMO_EMBED_ENDPOINT` 未設定 / PLaMO 呼び出し失敗 / DB 差し替え失敗のいずれでも既存 chunk を保持し、記事 upsert 自体は成功扱いにする
- tidb-embedder のバッチと `source_hash` が揃うように、chunking version・token 設定・title・description・content から SHA-256 を計算する

## 変更ファイル

### `apps/blog-api/infrastructure/src/embedding/client.rs`

- `EmbeddingClient` trait に `chunk_document(title, description, content, max_tokens, overlap_tokens)` を追加
- `DocumentChunk` 型を公開し、`/chunks` レスポンスの version / max_tokens / overlap_tokens / index 連番 / token 上限を検証する
- `compute_source_hash` を追加。tidb-embedder の `JSON.stringify({version, maxTokens, overlapTokens, title, description, content})` と同じレイアウトを Rust の serde struct で再現し、hash が一致することを unit test で担保する

### `apps/blog-api/kernel/src/repository/articles.rs`

- `ArticleEmbeddingChunk` (chunk_index / heading / content / token_count / embedding) を追加
- `ArticlesRepository::replace_article_chunks(article_id, chunks, chunking_version, source_hash)` を trait に追加

### `apps/blog-api/adapter/src/repository/articles.rs`

- `replace_article_chunks` を transaction 実装。`article_id` で既存 chunk を DELETE してから `article_embedding_chunks` を INSERT する
- `observe_query` の代表 SQL に `CHUNKS_REPLACE_SQL` を追加して計装できるようにする
- embedding は `serde_json::to_string(&Vec<f32>)` で TiDB VECTOR 列へ渡す (tidb-embedder と同じ形式)

### `apps/blog-api/api/src/handler/webhooks.rs`

- `process_push_event` のループで `AppRegistry::embedding_client` を 1 回だけ取得し、記事ごとに使い回す
- `effective_description` を `upsert_article` の書き込み挙動（frontmatter が None なら既存値、無ければ title）と揃えて計算する
- `needs_chunks` を title / effective_description / content の差分で判定する
- 記事 upsert 成功後にだけ `regenerate_chunks` を呼ぶ。`/chunks` → 各 chunk `/embed` を経て、全 vector 生成が成功したら `replace_article_chunks` を呼ぶ
- PLaMO endpoint 未設定・chunk 生成失敗・embed 失敗・DB 書き込み失敗のいずれも `warn!` を残して既存 chunk を保持する

### `docs/source/98_tasks/2026-07-15-tidb-vector-search-implementation/index.md`

- 作業ログの 2026-07-16 セクションに Phase 7 実装の内容を追記

## テストプラン

- [x] `cargo check` / `cargo test --workspace` / `cargo clippy --workspace --lib --bins --tests` が pass する
- [x] `compute_source_hash` が tidb-embedder の JSON レイアウトと一致することを unit test (`source_hash_matches_tidb_embedder_layout`) で確認
- [ ] dev デプロイ後、`PLAMO_EMBED_ENDPOINT=http://plamo-embedding.${TAILNET}` を渡した webhook 再送で `article_embedding_chunks` が記事単位で差し替わる
- [ ] `PLAMO_EMBED_ENDPOINT` 未設定でも記事 upsert 自体は成功する（skip ログのみ）
- [ ] PLaMO 呼び出し / DB 書き込みに失敗した場合、既存 chunk が保持されて記事 upsert 自体は成功する