### PR TITLE
docs: SQL playgroundのタグID例をSELECT INTOに変更

### DIFF
--- a/docs/source/97_survey/2026-07-16-blog-api-queryplayground/08_users_articles_search.sql
+++ b/docs/source/97_survey/2026-07-16-blog-api-queryplayground/08_users_articles_search.sql
@@ -58,8 +58,8 @@ SELECT article_id, title, slug, user_id, thumbnail, description, status,
 --   ranked_articles CTE の WHERE に EXISTS を積む
 -- ────────────────────────────────────
 
-SET @tag_id_a = '00000000-0000-0000-0000-000000000001';
-SET @tag_id_b = '00000000-0000-0000-0000-000000000002';
+SELECT tag_id INTO @tag_id_a FROM tags WHERE name = 'tech';
+SELECT tag_id INTO @tag_id_b FROM tags WHERE name = 'misc';
 
 WITH RECURSIVE tag_descendants AS (
     SELECT tag_id, tag_id AS root_tag_id FROM tags WHERE tag_id IN (@tag_id_a, @tag_id_b)


### PR DESCRIPTION
## Summary

- SQL playground の `08_users_articles_search.sql` にあるタグ ID 変数 (`@tag_id_a` / `@tag_id_b`) の代入方法を、ハードコードされた UUID プレースホルダから `SELECT tag_id INTO @... FROM tags WHERE name = '...'` に変更
- `tags.name` には UNIQUE 制約があるため、環境ごとに UUID が異なっても `tech` / `misc` を名前で解決できる

## Test plan

- [ ] `docs/source/97_survey/2026-07-16-blog-api-queryplayground/08_users_articles_search.sql` の該当箇所が `SELECT ... INTO @tag_id_a/@tag_id_b` になっている
- [ ] mysql クライアントから `blog_dev` に接続し、当該 SQL を実行して結果が返ることを確認
