### PR TITLE
feat: 検索ショートカット追加とフッター区切り線

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -108,7 +108,7 @@ moments（180 字 + 写真必須の一文投稿）は写真が主役の情緒的
 - タグ絞り込みは画面下部中央の `FloatingTagFilter`（`position: fixed`）。アイコンのみの円形トリガー + IDE のファイルツリー風パネル（`TagFilterTree`、フォルダ/タグの stroke アイコン + チェブロン展開）。一覧側はフローティングバーとの重なりを避ける bottom padding を確保する。
 - 記事ページ = 左コンテンツ + `--layout-sidebar-w` 固定の右 TOC サイドバーを `flex justify-between` で並べる。`lg` 以下でサイドバーは折りたたまれる。
 - TOC の sticky オフセットは `top: calc(var(--layout-header-h) + var(--layout-nav-h) + var(--space-5))` で計算する。マジックナンバー禁止。
-- フッターは `position: absolute; bottom: 0;` で body 下部に `--layout-footer-h` 分の余白を予約。ヘッダーは sticky **にしない**。
+- フッターは `position: absolute; bottom: 0;` で body 下部に `--layout-footer-h` 分の余白を予約し、上辺に `--color-border-subtle` の 1px 区切り線を引く。ヘッダーは sticky **にしない**。
 - **`display: grid` を使わない.** マルチカラムは Flex + `gap`。
 
 ### 透過 / blur

--- a/apps/web/src/components/BaseLayout.tsx
+++ b/apps/web/src/components/BaseLayout.tsx
@@ -88,7 +88,7 @@ export function BaseLayout({
       </div>
 
       {/* Footer */}
-      <div className="absolute bottom-0 mx-auto w-full">
+      <div className="absolute bottom-0 mx-auto w-full border-t border-[var(--color-border-subtle)]">
         <Footer />
       </div>
     </div>

--- a/apps/web/src/components/SearchProvider.tsx
+++ b/apps/web/src/components/SearchProvider.tsx
@@ -12,13 +12,14 @@ import {
 import { useTagFilter } from '@/components/TagFilterProvider';
 import type { SearchArticleResult } from '@/lib/api';
 import { searchArticles } from '@/lib/api';
+import { ARTICLES_PER_PAGE } from '@/lib/constants';
 import { buildLocationSearch, parseSearchParam } from '@/lib/searchQuery';
 
 /** 検索 fetch の debounce（ms）。過剰な API 呼び出しを避けつつ体感速度は保つ */
 const DEBOUNCE_MS = 300;
 
-/** 検索結果の1ページあたり件数。通常の記事一覧 (ARTICLES_PER_PAGE) と揃える */
-const DEFAULT_LIMIT = 10;
+/** 検索結果の1ページあたり件数。通常の記事一覧と揃える */
+const DEFAULT_LIMIT = ARTICLES_PER_PAGE;
 
 interface SearchContextValue {
   /** input が現在保持している値。debounce 前 */
@@ -172,15 +173,13 @@ export function SearchProvider({ userName, children }: SearchProviderProps) {
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
     }
-    // 最新の入力値を確定させる（同期的に読める query state を使う）
-    setQueryState((current) => {
-      const trimmed = current.trim();
-      pushSearchUrl(trimmed);
-      setSubmittedQuery(trimmed);
-      setSearchPageState(1);
-      return current;
-    });
-  }, [pushSearchUrl]);
+    // state updater 内での副作用は render 中に実行され React が警告するため、
+    // deps の query から最新値を読む（controlled input なので Enter 時点で確定済み）
+    const trimmed = query.trim();
+    pushSearchUrl(trimmed);
+    setSubmittedQuery(trimmed);
+    setSearchPageState(1);
+  }, [query, pushSearchUrl]);
 
   const clearQuery = useCallback(() => {
     if (debounceRef.current) {
@@ -196,6 +195,30 @@ export function SearchProvider({ userName, children }: SearchProviderProps) {
   const openModal = useCallback(() => setModalOpen(true), []);
   const closeModal = useCallback(() => setModalOpen(false), []);
   const setSearchPage = useCallback((p: number) => setSearchPageState(p), []);
+
+  // `/` と cmd+K (Windows/Linux は ctrl+K) で検索モーダルを開く。閉じるのは
+  // useFullScreenModal の Escape。`/` は入力フィールドでは通常のタイプとして扱う
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.isComposing) return;
+      const isCmdK = (event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k';
+      const isSlash = event.key === '/' && !event.metaKey && !event.ctrlKey && !event.altKey;
+      if (!isCmdK && !isSlash) return;
+      if (isSlash) {
+        const target = event.target;
+        if (
+          target instanceof HTMLElement &&
+          (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+        ) {
+          return;
+        }
+      }
+      event.preventDefault();
+      openModal();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [openModal]);
 
   const value = useMemo<SearchContextValue>(
     () => ({

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -3,4 +3,5 @@ export const USER_NAME = process.env.NEXT_PUBLIC_USER_NAME || 'shuntaka';
 export const SITE_TITLE = 'shuntaka.dev';
 export const SITE_DESCRIPTION =
   'shuntaka.devは、技術・開発・ガジェットについてshuntakaが思ったことをシェアするブログです。';
+/** 一覧・検索共通の1ページあたり件数 */
 export const ARTICLES_PER_PAGE = 10;


### PR DESCRIPTION
## 概要

- `/` と `cmd+K`(Windows/Linux は `ctrl+K`)で検索モーダルを開くグローバルショートカットを追加
- Enter で検索確定した際に React の `Cannot update a component (Router)` 警告が出る既存バグを修正
- フッター上辺に `--color-border-subtle` の 1px 区切り線を追加し、縦に長い画面での下部余白を「ページの底」として見せる

## 変更詳細

### apps/web/src/components/SearchProvider.tsx

- `document` への keydown リスナーを追加。`/` と `cmd+K` / `ctrl+K` で `openModal()` を呼ぶ
  - 入力フィールド(input / textarea / contentEditable)フォーカス中の `/` は通常入力として素通し
  - IME 変換中(`isComposing`)は無視
  - 閉じる操作は既存の `useFullScreenModal` の Escape をそのまま利用
- `submitNow` の修正: `setQueryState` の updater 関数内で `pushSearchUrl`(`history.pushState`)と `setSubmittedQuery` を呼んでいた副作用を updater の外へ移動。updater は render 中に実行されるため、Next.js Router の更新と衝突して警告が出ていた
- 検索結果の 1 ページ件数 `DEFAULT_LIMIT` を値の重複(`10`)から `ARTICLES_PER_PAGE` の直接参照に一本化

### apps/web/src/components/BaseLayout.tsx / apps/web/DESIGN.md

- フッターコンテナに `border-t border-[var(--color-border-subtle)]` を追加(下部固定の構造は変更なし)
- DESIGN.md のレイアウトルールを同期

### apps/web/src/lib/constants.ts

- `ARTICLES_PER_PAGE` に用途コメントを追加(値は 10 のまま)

## テストプラン

- [x] `bun run --filter @shuntaka-dev/web type-check`
- [x] `bun run lint`(vp / fmt / spell-check)
- [x] `bun run --filter @shuntaka-dev/web test`(39 pass)
- [x] ローカル(dev サーバー)で `/`・`cmd+K` によるモーダル起動、入力欄への自動フォーカス、Escape の 2 段挙動(クリア → 閉じる)を確認
- [x] `/` → `vim` → Enter で検索確定し、結果表示・URL 同期(`?q=vim`)・console 警告なしを確認
- [x] フッター区切り線の表示をライトモードで確認
- [ ] デプロイ後、ダークモードでの区切り線の見え方を確認
