### PR TITLE
style: 本文末尾とフッター区切り線の間に余白を追加

### DIFF
--- a/apps/web/DESIGN.md
+++ b/apps/web/DESIGN.md
@@ -108,7 +108,7 @@ moments（180 字 + 写真必須の一文投稿）は写真が主役の情緒的
 - タグ絞り込みは画面下部中央の `FloatingTagFilter`（`position: fixed`）。アイコンのみの円形トリガー + IDE のファイルツリー風パネル（`TagFilterTree`、フォルダ/タグの stroke アイコン + チェブロン展開）。一覧側はフローティングバーとの重なりを避ける bottom padding を確保する。
 - 記事ページ = 左コンテンツ + `--layout-sidebar-w` 固定の右 TOC サイドバーを `flex justify-between` で並べる。`lg` 以下でサイドバーは折りたたまれる。
 - TOC の sticky オフセットは `top: calc(var(--layout-header-h) + var(--layout-nav-h) + var(--space-5))` で計算する。マジックナンバー禁止。
-- フッターは `position: absolute; bottom: 0;` で body 下部に `--layout-footer-h` 分の余白を予約し、上辺に `--color-border-subtle` の 1px 区切り線を引く。ヘッダーは sticky **にしない**。
+- フッターは `position: absolute; bottom: 0;` で body 下部に `calc(var(--layout-footer-h) + 2rem)` 分の余白を予約する（+2rem はコンテンツ末尾と区切り線の間の呼吸）。上辺に `--color-border-subtle` の 1px 区切り線を引く。ヘッダーは sticky **にしない**。
 - **`display: grid` を使わない.** マルチカラムは Flex + `gap`。
 
 ### 透過 / blur

--- a/apps/web/src/components/BaseLayout.tsx
+++ b/apps/web/src/components/BaseLayout.tsx
@@ -82,7 +82,7 @@ export function BaseLayout({
 
       {/* Page Body */}
       <div
-        className={`mx-auto px-8 pt-2 pb-[var(--layout-footer-h)] max-sm:px-4 max-sm:pt-3 ${widthClass}`}
+        className={`mx-auto px-8 pt-2 pb-[calc(var(--layout-footer-h)+2rem)] max-sm:px-4 max-sm:pt-3 ${widthClass}`}
       >
         {children}
       </div>


### PR DESCRIPTION
## 概要

- 本文末尾とフッター区切り線(#681 で追加)の間にほぼ余白がなく、モバイルの記事ページで特に窮屈だったのを解消
- フッター用の予約余白を `calc(var(--layout-footer-h) + 2rem)` に変更し、本文と線の間に約 31px の呼吸を確保

## 背景

`BaseLayout` の Page Body は絶対配置フッターと重ならないよう `pb-[var(--layout-footer-h)]`(58px)を予約していたが、フッターの実高は約 59.4px(p-4 + アイコン 22px + 区切り線 1px)で予約をわずかに上回っており、区切り線が本文領域にほぼ密着していた。#681 で線が可視化されたことで窮屈さが顕在化した。

## 変更詳細

### apps/web/src/components/BaseLayout.tsx

- Page Body の padding-bottom を `pb-[var(--layout-footer-h)]` → `pb-[calc(var(--layout-footer-h)+2rem)]` に変更
- BaseLayout 経由のため記事・一覧・about すべてに適用(ブレークポイント分岐なし)

### apps/web/DESIGN.md

- レイアウトルールのフッター記述を同期(+2rem はコンテンツ末尾と区切り線の間の呼吸、と明記)

## テストプラン

- [x] `bun run --filter @shuntaka-dev/web type-check`
- [x] `bun run lint`
- [x] `bun run --filter @shuntaka-dev/web test`(39 pass)
- [x] dev サーバーの記事ページで computed `padding-bottom` が 90px になること、本文末尾と線の間隔が約 0px → 約 31px になることを確認
