### PR TITLE
feat: Markdownの脚注記法をサポートする

### DIFF
--- a/apps/blog-api/markdown/examples/storybook_fixture.rs
+++ b/apps/blog-api/markdown/examples/storybook_fixture.rs
@@ -158,6 +158,16 @@ https://x.com/shuntaka_jp/status/2007605987881169264
 ## SpeakerDeck 埋め込み
 
 @[sd](ceec399cc51849d0889601c597dd030b,1,560/420,1.3)
+
+## 脚注
+
+本文中に脚注[^1]を書けます。名前付きの脚注[^note]や、リンクを含む脚注[^2]も使えます。
+
+[^1]: 一つ目の脚注です。
+
+[^note]: 名前付きの脚注です。
+
+[^2]: [Zenn の脚注記法](https://zenn.dev/zenn/articles/markdown-guide#%E8%84%9A%E6%B3%A8) と同じ書き方です。
 "##;
 
 fn main() {

--- a/apps/blog-api/markdown/src/lib.rs
+++ b/apps/blog-api/markdown/src/lib.rs
@@ -1031,6 +1031,15 @@ where
         .to_string()
 }
 
+/// comrak が出力する脚注セクションの冒頭に Zenn 風のタイトルを挿入する
+/// (zenn-editor の footnote_block_open カスタマイズに相当)
+fn add_footnotes_title(html: &str) -> String {
+    html.replace(
+        "<section class=\"footnotes\" data-footnotes>",
+        "<section class=\"footnotes\" data-footnotes>\n<span class=\"footnotes-title\">脚注</span>",
+    )
+}
+
 /// Markdown to HTML converter with syntax highlighting
 pub struct MarkdownConverter {
     syntect_adapter: &'static SyntectAdapter,
@@ -1083,6 +1092,9 @@ impl MarkdownConverter {
         // 外部リンクに target="_blank" を追加
         html = self.add_target_blank_to_external_links(&html);
 
+        // 脚注セクションに Zenn 風のタイトルを挿入
+        html = add_footnotes_title(&html);
+
         html
     }
 
@@ -1109,6 +1121,7 @@ impl MarkdownConverter {
         options.extension.table = true;
         options.extension.autolink = true;
         options.extension.tasklist = true;
+        options.extension.footnotes = true;
         options.extension.header_id_prefix = Some("".to_string());
 
         // Render options
@@ -1317,6 +1330,58 @@ mod tests {
             html,
             "<div class=\"message \"><p>here be dragons</p>\n</div>\n"
         );
+    }
+
+    #[test]
+    fn test_footnote_basic() {
+        let markdown = "本文中の脚注[^1]。\n\n[^1]: 脚注の内容。";
+        let html = convert_markdown_to_html(markdown);
+        // 本文側の参照
+        assert!(html.contains(r##"<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup>"##));
+        // 末尾の脚注セクション (Zenn 風タイトル付き)
+        assert!(html.contains(r#"<section class="footnotes" data-footnotes>"#));
+        assert!(html.contains(r#"<span class="footnotes-title">脚注</span>"#));
+        assert!(html.contains(r#"<li id="fn-1">"#));
+        assert!(html.contains("脚注の内容。"));
+        // 脚注から本文へ戻るリンク
+        assert!(html.contains(r#"class="footnote-backref""#));
+    }
+
+    #[test]
+    fn test_footnote_named() {
+        let markdown = "named footnote[^note].\n\n[^note]: named content.";
+        let html = convert_markdown_to_html(markdown);
+        assert!(html.contains(r##"href="#fn-note""##));
+        assert!(html.contains(r#"<li id="fn-note">"#));
+    }
+
+    #[test]
+    fn test_footnote_with_external_link() {
+        let markdown = "ref[^1].\n\n[^1]: see [example](https://example.com).";
+        let html = convert_markdown_to_html(markdown);
+        // 脚注内の外部リンクにも target="_blank" が付く
+        assert!(html.contains(
+            r#"<a href="https://example.com" target="_blank" rel="noopener noreferrer">"#
+        ));
+    }
+
+    #[test]
+    fn test_footnote_undefined_ref_stays_literal() {
+        let markdown = "undefined ref[^nope].";
+        let html = convert_markdown_to_html(markdown);
+        assert!(html.contains("[^nope]"));
+        assert!(!html.contains("footnotes"));
+    }
+
+    #[test]
+    fn test_footnote_not_in_code_block() {
+        let markdown = "```\n[^1]: not a footnote\n```\n\nref[^1].\n\n[^1]: real footnote.";
+        let html = convert_markdown_to_html(markdown);
+        // コードブロック内の脚注記法は変換されない
+        assert!(html.contains("[^1]: not a footnote"));
+        // コードブロック外は変換される
+        assert!(html.contains(r#"<li id="fn-1">"#));
+        assert!(html.contains("real footnote."));
     }
 
     #[test]

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -480,6 +480,7 @@ a:hover {
 .prose sup.footnote-ref a {
   padding: 0 0.1em;
   text-decoration: none;
+  scroll-margin-top: var(--space-3);
 }
 
 .prose .footnotes {
@@ -500,6 +501,7 @@ a:hover {
 
 .prose .footnotes ol > li {
   margin-bottom: var(--space-1);
+  scroll-margin-top: var(--space-3);
 }
 
 .prose .footnotes li p {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -476,6 +476,41 @@ a:hover {
   font-style: italic;
 }
 
+/* Footnotes (comrak footnotes 拡張 + Zenn 風タイトル) */
+.prose sup.footnote-ref a {
+  padding: 0 0.1em;
+  text-decoration: none;
+}
+
+.prose .footnotes {
+  margin-top: var(--space-8);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--color-border-subtle);
+  font-size: var(--fs-caption);
+}
+
+.prose .footnotes-title {
+  display: block;
+  font-weight: var(--fw-bold);
+}
+
+.prose .footnotes ol {
+  margin-top: var(--space-2);
+}
+
+.prose .footnotes ol > li {
+  margin-bottom: var(--space-1);
+}
+
+.prose .footnotes li p {
+  margin: 0;
+  line-height: var(--lh-list);
+}
+
+.prose .footnote-backref {
+  text-decoration: none;
+}
+
 /* Message container styles (global, legacy compatible) */
 .message {
   position: relative;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -511,6 +511,14 @@ a:hover {
   text-decoration: none;
 }
 
+/* ジャンプ先を可視化する。参照と脚注が近接していてスクロールが
+   発生しない（ページ末尾で clamp される）ケースでも戻り先が分かる */
+.prose sup.footnote-ref a:target,
+.prose .footnotes li:target {
+  background: var(--color-warning-bg);
+  border-radius: var(--radius-sm);
+}
+
 /* Message container styles (global, legacy compatible) */
 .message {
   position: relative;

--- a/apps/web/src/components/__fixtures__/articleFullHtml.ts
+++ b/apps/web/src/components/__fixtures__/articleFullHtml.ts
@@ -8,7 +8,7 @@
  * のうえで、このファイルのテンプレートリテラル部分を差し替える。
  */
 export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプル記事です。本文には <strong>太字</strong>、<em>斜体</em>、<del>取り消し線</del>、<code>inline code</code>、<a href="https://zenn.dev" target="_blank" rel="noopener noreferrer">外部リンク</a>、<a href="/shuntaka/articles/sample">内部リンク</a> といったインライン要素を含みます。</p>
-<h2><a href="#テキストとリスト" aria-hidden="true" class="anchor" id="テキストとリスト"></a>テキストとリスト</h2>
+<h2 id="テキストとリスト">テキストとリスト<a href="#テキストとリスト" aria-label="Link to heading 'テキストとリスト'" data-heading-content="テキストとリスト" class="anchor"></a></h2>
 <ul>
 <li>箇条書きリスト</li>
 <li>2 つ目の項目
@@ -25,7 +25,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 <li><input type="checkbox" checked="" disabled="" /> 完了したタスク</li>
 <li><input type="checkbox" disabled="" /> 未完了のタスク</li>
 </ul>
-<h2><a href="#テーブルと引用" aria-hidden="true" class="anchor" id="テーブルと引用"></a>テーブルと引用</h2>
+<h2 id="テーブルと引用">テーブルと引用<a href="#テーブルと引用" aria-label="Link to heading 'テーブルと引用'" data-heading-content="テーブルと引用" class="anchor"></a></h2>
 <table>
 <thead>
 <tr>
@@ -53,7 +53,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 引用のサンプルです。</p>
 </blockquote>
 <hr />
-<h2><a href="#コードブロック" aria-hidden="true" class="anchor" id="コードブロック"></a>コードブロック</h2>
+<h2 id="コードブロック">コードブロック<a href="#コードブロック" aria-label="Link to heading 'コードブロック'" data-heading-content="コードブロック" class="anchor"></a></h2>
 <p>言語指定なし</p>
 <pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">ls -al
 </span></code></pre>
@@ -70,7 +70,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 </span><span style="color:#c0c5ce;">    println!(&quot;</span><span style="color:#d08770;">{}</span><span style="color:#c0c5ce;">&quot;, converter.</span><span style="color:#96b5b4;">convert</span><span style="color:#c0c5ce;">(&quot;</span><span style="color:#a3be8c;"># Hello</span><span style="color:#c0c5ce;">&quot;));
 </span><span style="color:#c0c5ce;">}
 </span></code></pre>
-<h2><a href="#メッセージ" aria-hidden="true" class="anchor" id="メッセージ"></a>メッセージ</h2>
+<h2 id="メッセージ">メッセージ<a href="#メッセージ" aria-label="Link to heading 'メッセージ'" data-heading-content="メッセージ" class="anchor"></a></h2>
 <div class="message "><p>デフォルトのメッセージです。補足情報や注意喚起に使います。</p>
 </div>
 <div class="message info"><p>info メッセージです。</p>
@@ -81,7 +81,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 </div>
 <div class="message error"><p>error メッセージです。</p>
 </div>
-<h2><a href="#アコーディオン" aria-hidden="true" class="anchor" id="アコーディオン"></a>アコーディオン</h2>
+<h2 id="アコーディオン">アコーディオン<a href="#アコーディオン" aria-label="Link to heading 'アコーディオン'" data-heading-content="アコーディオン" class="anchor"></a></h2>
 <details><summary>実装の詳細を見る</summary><div class="details-content"><p>折りたたみの中にも Markdown を書けます。</p>
 <ul>
 <li>リスト項目</li>
@@ -90,9 +90,9 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 <pre lang="bash" style="background-color:#2b303b;"><code><span style="color:#8fa1b3;">bun</span><span style="color:#c0c5ce;"> run storybook
 </span></code></pre>
 </div></details>
-<h2><a href="#画像" aria-hidden="true" class="anchor" id="画像"></a>画像</h2>
+<h2 id="画像">画像<a href="#画像" aria-label="Link to heading '画像'" data-heading-content="画像" class="anchor"></a></h2>
 <p><img src="https://res.cloudinary.com/dkerzyk09/image/upload/v1767101809/blog/og/shuntaka.png" alt="shuntaka.dev の OGP 画像" /></p>
-<h2><a href="#github-埋め込み" aria-hidden="true" class="anchor" id="github-埋め込み"></a>GitHub 埋め込み</h2>
+<h2 id="github-埋め込み">GitHub 埋め込み<a href="#github-埋め込み" aria-label="Link to heading 'GitHub 埋め込み'" data-heading-content="GitHub 埋め込み" class="anchor"></a></h2>
 <p>1 行指定</p>
 <div class="github-embed-card">
 <div class="github-embed-header">
@@ -206,7 +206,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 </span><span style="color:#c0c5ce;">PostgreSQLを起動</span></pre>
 </div>
 </div>
-<h2><a href="#リンクカード" aria-hidden="true" class="anchor" id="リンクカード"></a>リンクカード</h2>
+<h2 id="リンクカード">リンクカード<a href="#リンクカード" aria-label="Link to heading 'リンクカード'" data-heading-content="リンクカード" class="anchor"></a></h2>
 <div class="link-card-wrapper"><a href="https://shuntaka.dev" target="_blank" rel="noopener noreferrer" class="link-card" target="_blank" rel="noopener noreferrer"><div class="link-card-content"><div class="link-card-text"><div class="link-card-title">shuntaka.dev</div><div class="link-card-description">shuntaka.devは、技術・開発・ガジェットについてshuntakaが思ったことをシェアするブログです。</div></div><div class="link-card-image"><img src="https://res.cloudinary.com/dkerzyk09/image/upload/v1767101809/blog/og/shuntaka.png" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div></div><div class="link-card-footer"><img class="link-card-favicon" src="https://shuntaka.dev/icons/icon.png" alt="" onerror="this.style.display='none'"><span class="link-card-domain">shuntaka.dev</span></div></a></div>
 <div class="link-card-wrapper"><a href="https://shuntaka.dev/shuntaka/articles/20251224-reflecting-on-2025" target="_blank" rel="noopener noreferrer" class="link-card" target="_blank" rel="noopener noreferrer"><div class="link-card-content"><div class="link-card-text"><div class="link-card-title">2025年の振り返り</div><div class="link-card-description">皆様2025年お疲れさまでした！毎年恒例の振り返りをしました！</div></div><div class="link-card-image"><img src="https://res.cloudinary.com/dkerzyk09/image/upload/v1767101809/blog/og/shuntaka.png" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div></div><div class="link-card-footer"><img class="link-card-favicon" src="https://shuntaka.dev/icons/icon.png" alt="" onerror="this.style.display='none'"><span class="link-card-domain">shuntaka.dev</span></div></a></div>
 <div class="link-card-wrapper"><a href="https://shuntaka.dev/shuntaka/articles/20260108-shuntaka-blog-rearchitecture" target="_blank" rel="noopener noreferrer" class="link-card" target="_blank" rel="noopener noreferrer"><div class="link-card-content"><div class="link-card-text"><div class="link-card-title">Rust(axum) on Lambda × Aurora DSQL × Next.js on Vercelで個人ブログをリーアーキした話</div><div class="link-card-description">2020年にNode.js on Lambda × DynamoDB × Next.js on Vercelで運用していたブログのアーキテクチャを刷新しました！</div></div><div class="link-card-image"><img src="https://res.cloudinary.com/dkerzyk09/image/upload/s--z-0zbcS9--/c_fit,co_rgb:525457,l_text:notesansjpmid.otf_48_bold:Rust%28axum%29%20on%20Lambda%20%C3%97%20Aurora%20DSQL%20%C3%97%20Next.js%20on%20Vercel%E3%81%A7%E5%80%8B%E4%BA%BA%E3%83%96%E3%83%AD%E3%82%B0%E3%82%92%E3%83%AA%E3%83%BC%E3%82%A2%E3%83%BC%E3%82%AD%E3%81%97%E3%81%9F%E8%A9%B1,w_600/v1/blog/og/ogp.webp" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div></div><div class="link-card-footer"><img class="link-card-favicon" src="https://shuntaka.dev/icons/icon.png" alt="" onerror="this.style.display='none'"><span class="link-card-domain">shuntaka.dev</span></div></a></div>
@@ -216,7 +216,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 #527
 この記法でSpeakerDeckで表示したいスライドの番号を指定し、表示します。
 @[speakerdeck](f005615e42d84c9b8bdb7fd722cbb...</div></div><div class="link-card-image"><img src="https://opengraph.githubassets.com/ad0bc4a3380f0940d2e82cce8f544cb2b51eae79ef186b2ac3b2dfb6333da8c4/zenn-dev/zenn-editor/pull/528" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div></div><div class="link-card-footer"><img class="link-card-favicon" src="https://github.githubassets.com/favicons/favicon.svg" alt="" onerror="this.style.display='none'"><span class="link-card-domain">github.com</span></div></a></div>
-<h2><a href="#x-ポスト埋め込み" aria-hidden="true" class="anchor" id="x-ポスト埋め込み"></a>X ポスト埋め込み</h2>
+<h2 id="x-ポスト埋め込み">X ポスト埋め込み<a href="#x-ポスト埋め込み" aria-label="Link to heading 'X ポスト埋め込み'" data-heading-content="X ポスト埋め込み" class="anchor"></a></h2>
 <p>通常</p>
 <div data-tweet-id="2005455430907216136"></div>
 <p>画像</p>
@@ -227,5 +227,21 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 <div data-tweet-id="2007325737725084022"></div>
 <p>引用 + 画像</p>
 <div data-tweet-id="2007605987881169264"></div>
-<h2><a href="#speakerdeck-埋め込み" aria-hidden="true" class="anchor" id="speakerdeck-埋め込み"></a>SpeakerDeck 埋め込み</h2>
-<div class="block-embed-service-speakerdeck"><iframe class="speakerdeck-iframe" frameborder="0" src="https://speakerdeck.com/player/ceec399cc51849d0889601c597dd030b?slide=1" allowfullscreen="true" style="border: 0px; background: padding-box padding-box rgba(0, 0, 0, 0.1); margin: 0px; padding: 0px; border-radius: 6px; box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 40px; width: 100%; height: auto; aspect-ratio: 560/420;" data-ratio="1.3"></iframe></div>`;
+<h2 id="speakerdeck-埋め込み">SpeakerDeck 埋め込み<a href="#speakerdeck-埋め込み" aria-label="Link to heading 'SpeakerDeck 埋め込み'" data-heading-content="SpeakerDeck 埋め込み" class="anchor"></a></h2>
+<div class="block-embed-service-speakerdeck"><iframe class="speakerdeck-iframe" frameborder="0" src="https://speakerdeck.com/player/ceec399cc51849d0889601c597dd030b?slide=1" allowfullscreen="true" style="border: 0px; background: padding-box padding-box rgba(0, 0, 0, 0.1); margin: 0px; padding: 0px; border-radius: 6px; box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 40px; width: 100%; height: auto; aspect-ratio: 560/420;" data-ratio="1.3"></iframe></div>
+<h2 id="脚注">脚注<a href="#脚注" aria-label="Link to heading '脚注'" data-heading-content="脚注" class="anchor"></a></h2>
+<p>本文中に脚注<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup>を書けます。名前付きの脚注<sup class="footnote-ref"><a href="#fn-note" id="fnref-note" data-footnote-ref>2</a></sup>や、リンクを含む脚注<sup class="footnote-ref"><a href="#fn-2" id="fnref-2" data-footnote-ref>3</a></sup>も使えます。</p>
+<section class="footnotes" data-footnotes>
+<span class="footnotes-title">脚注</span>
+<ol>
+<li id="fn-1">
+<p>一つ目の脚注です。 <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
+</li>
+<li id="fn-note">
+<p>名前付きの脚注です。 <a href="#fnref-note" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="2" aria-label="Back to reference 2">↩</a></p>
+</li>
+<li id="fn-2">
+<p><a href="https://zenn.dev/zenn/articles/markdown-guide#%E8%84%9A%E6%B3%A8" target="_blank" rel="noopener noreferrer">Zenn の脚注記法</a> と同じ書き方です。 <a href="#fnref-2" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="3" aria-label="Back to reference 3">↩</a></p>
+</li>
+</ol>
+</section>`;


### PR DESCRIPTION
## 概要

- Markdown の脚注記法 `[^1]` / `[^name]` をサポートする（これまでは comrak の footnotes 拡張が無効でリテラル出力されていた）
- zenn-editor (markdown-it-footnote) の出力に倣い、脚注セクション冒頭へ「脚注」タイトルを挿入する
- 脚注セクションのスタイルを追加し、storybook fixture を再生成する

## 変更詳細

### apps/blog-api/markdown/src/lib.rs

- `options.extension.footnotes = true` を有効化。参照 `<sup class="footnote-ref">` / 定義 `<section class="footnotes">` / 戻りリンク `footnote-backref` の GitHub 互換 HTML が出力される
- zenn-editor の `footnote_block_open` カスタマイズ相当の後処理 `add_footnotes_title` を追加し、`<span class="footnotes-title">脚注</span>` を挿入
- テスト 5 件追加（基本変換 / 名前付き脚注 / 脚注内外部リンクへの `target="_blank"` 付与 / 未定義参照はリテラル維持 / コードブロック内は非変換）

### apps/web/src/app/globals.css

- `.footnotes`（上ボーダー + `--fs-caption`）、`.footnotes-title`、参照 sup、戻りリンクのスタイルを既存トークンのみで追加

### storybook fixture

- `examples/storybook_fixture.rs` に「脚注」セクションを追加し、`articleFullHtml.ts` を再生成
- fixture には comrak 0.53 → 0.54 バンプ時の見出しアンカー構造変更（id が見出し要素直付けに）の未追随ドリフトが含まれていたため、今回の再生成で現行出力に追いついている。tocbot は id 無し見出しに自前で id を振るため影響なし

## 制約

- `:::message` / `:::details` の中身は別パスで変換されるため、コンテナ内の脚注参照はコンテナ外の定義を解決できない（コンテナ内で完結すれば動作する）
- `content_html` は保存時変換のため、既存記事で脚注を使う場合は `tools/content-html-backfill` での再変換が必要（これまで未サポートのため該当記事は無い想定）

## テストプラン

- [x] `cargo test`（markdown crate 58 件を含む全 121 件通過）
- [x] `bun run lint` / `bun run spell-check` / `bun run type-check` 通過
- [ ] dev 環境で articles-v2 のテスト記事（脚注セクション追加済み）のレンダリング確認
