### PR TITLE
docs: TiDB周りのSQLを整理

### DIFF
--- a/docs/source/97_survey/2026-07-19-tidb-vector-search-101/00_setup.sql
+++ b/docs/source/97_survey/2026-07-19-tidb-vector-search-101/00_setup.sql
@@ -1,0 +1,50 @@
+-- Step 0: 教材テーブルの作成
+--
+-- blog_dev に使い捨ての教材テーブルを 2 つ作る。終わったら 99_cleanup.sql で消す。
+--   * vec_lesson: 4 次元ベクトル 8 行。手計算できるサイズでコサイン類似度〜HNSW を試す
+--   * tag_lesson: 7 タグの 3 階層ツリー。再帰 CTE を試す
+--
+-- vec_lesson の embedding は 4 次元を「トピックの成分」に見立てたおもちゃデータ。
+--   [db, frontend, infra, ml] の順。例: tidb-intro = [9,0,2,0] は DB 成分 9、infra 成分 2
+
+DROP TABLE IF EXISTS vec_lesson;
+CREATE TABLE vec_lesson (
+  id INT PRIMARY KEY,
+  label VARCHAR(50) NOT NULL,
+  embedding VECTOR(4) NOT NULL
+);
+
+INSERT INTO vec_lesson VALUES
+  (1, 'tidb-intro',       '[9,0,2,0]'),
+  (2, 'mysql-tuning',     '[8,0,1,0]'),
+  (3, 'react-hooks',      '[0,9,0,0]'),
+  (4, 'nextjs-ssr',       '[1,8,1,0]'),
+  (5, 'k8s-basics',       '[1,0,9,0]'),
+  (6, 'terraform-aws',    '[0,1,8,0]'),
+  (7, 'llm-rag',          '[3,0,1,8]'),
+  (8, 'embedding-search', '[6,0,0,7]');
+
+-- 本番の tags と同じ隣接リスト（parent_tag_id で親を指す）。
+--   aws ── lambda ── snapstart
+--      └── s3
+--   frontend ── react
+--   misc（子なし）
+DROP TABLE IF EXISTS tag_lesson;
+CREATE TABLE tag_lesson (
+  tag_id INT PRIMARY KEY,
+  name VARCHAR(50) NOT NULL,
+  parent_tag_id INT NULL
+);
+
+INSERT INTO tag_lesson VALUES
+  (1, 'aws',       NULL),
+  (2, 'lambda',    1),
+  (3, 's3',        1),
+  (4, 'snapstart', 2),
+  (5, 'frontend',  NULL),
+  (6, 'react',     5),
+  (7, 'misc',      NULL);
+
+-- 確認
+SELECT id, label, VEC_AS_TEXT(embedding) AS embedding FROM vec_lesson;
+SELECT tag_id, name, parent_tag_id FROM tag_lesson;

--- a/docs/source/97_survey/2026-07-19-tidb-vector-search-101/01_tiflash_basics.sql
+++ b/docs/source/97_survey/2026-07-19-tidb-vector-search-101/01_tiflash_basics.sql
@@ -1,0 +1,87 @@
+-- Step 1: TiFlash 単体 — 列指向だからできること
+--
+-- ベクトルの前に、TiFlash そのものを一番単純な形で体感する。
+-- 行ストア（TiKV）と列ストア（TiFlash）はデータの物理的な並べ方が違う。
+--   * 行ストア: 1 行分の全列がディスク上で連続。「id=54321 の行を丸ごと 1 件」が得意
+--   * 列ストア: 1 列分の全行が連続。「全行のうち 2 列だけ舐めて集計」が得意
+-- これを見るために、集計に使う細い列（category, amount）と、集計には無関係な
+-- 太い列（note 500 バイト）を持つテーブルを 10 万行作る。
+
+-- (1) 実験台を作る。行生成は再帰 CTE で 0〜9 を作り 5 桁分掛け合わせて 10 万行
+--     （再帰 CTE 自体は Step 6 で学ぶ。ここでは行ジェネレータとして使うだけ）
+DROP TABLE IF EXISTS sales_lesson;
+CREATE TABLE sales_lesson (
+  id INT PRIMARY KEY,
+  category VARCHAR(20) NOT NULL,
+  amount INT NOT NULL,
+  note TEXT NOT NULL          -- 500 バイトの詰め物。行を太らせるためだけの列
+);
+
+INSERT INTO sales_lesson
+WITH RECURSIVE d AS (SELECT 0 AS n UNION ALL SELECT n + 1 FROM d WHERE n < 9)
+SELECT d1.n + d2.n*10 + d3.n*100 + d4.n*1000 + d5.n*10000 AS id,
+       ELT(1 + (d1.n + d2.n*10 + d3.n*100 + d4.n*1000 + d5.n*10000) % 5,
+           'food','book','game','music','travel') AS category,
+       (d1.n + d2.n*10 + d3.n*100 + d4.n*1000 + d5.n*10000) % 10000 AS amount,
+       REPEAT('x', 500) AS note
+  FROM d d1, d d2, d d3, d d4, d d5;
+
+-- (2) TiFlash レプリカを宣言して同期を待つ
+--   available = 1 かつ progress = 1 になるまで数秒〜数十秒（テーブル約 50MB）
+ALTER TABLE sales_lesson SET TIFLASH REPLICA 1;
+
+SELECT table_name, replica_count, available, progress
+  FROM information_schema.tiflash_replica
+ WHERE table_name = 'sales_lesson';
+
+-- (3) 列指向の得意技: 少数列の全行集計
+--   まず TiKV（行ストア）で。行ストアは行単位でしか読めないので、
+--   category と amount しか使わない集計でも note 500B を含む全行 約 50MB を読む。
+--   期待値 (実測 2026-07-19): 157.8ms、TableFullScan actRows = 100000 が cop[tikv]
+EXPLAIN ANALYZE
+SELECT /*+ READ_FROM_STORAGE(TIKV[sales_lesson]) */
+       category, COUNT(*) AS cnt, AVG(amount) AS avg_amount
+  FROM sales_lesson
+ GROUP BY category;
+
+--   次に同じ集計を TiFlash（列ストア）で。列ごとにファイルが分かれているので
+--   category と amount の 2 列だけ読めば済み、note の 50MB は一切触らない。
+--   期待値 (同上): 13.3ms（約 1/12）。プランは mpp[tiflash] + threads:16 の並列
+EXPLAIN ANALYZE
+SELECT /*+ READ_FROM_STORAGE(TIFLASH[sales_lesson]) */
+       category, COUNT(*) AS cnt, AVG(amount) AS avg_amount
+  FROM sales_lesson
+ GROUP BY category;
+
+--   結果はどちらも同じ（category 5 種 × 各 20000 行）
+SELECT /*+ READ_FROM_STORAGE(TIFLASH[sales_lesson]) */
+       category, COUNT(*) AS cnt, AVG(amount) AS avg_amount
+  FROM sales_lesson
+ GROUP BY category
+ ORDER BY category;
+
+-- (4) 逆方向: 1 行の点読みは行ストアの得意技
+--   期待値 (同上): Point_Get 1.7ms。PK で 1 行を直接取る最速パス
+EXPLAIN ANALYZE
+SELECT id, category, amount FROM sales_lesson WHERE id = 54321;
+
+--   TIFLASH ヒントを付けても Point_Get のまま変わらない。
+--   オプティマイザは「点読みを TiFlash に向ける」選択肢をそもそも採らない
+EXPLAIN ANALYZE
+SELECT /*+ READ_FROM_STORAGE(TIFLASH[sales_lesson]) */
+       id, category, amount FROM sales_lesson WHERE id = 54321;
+
+--   セッション変数で TiFlash しか使えないよう縛ると初めて TiFlash に行くが、
+--   TableRangeScan になり 9.2ms（Point_Get の約 5 倍）。列ストアには
+--   「1 行を丸ごとすぐ返す」ための行単位インデックスが無い。
+--   試したら SET SESSION ... = 'tikv,tiflash,tidb' で必ず戻すこと
+SET SESSION tidb_isolation_read_engines = 'tiflash';
+EXPLAIN ANALYZE
+SELECT id, category, amount FROM sales_lesson WHERE id = 54321;
+SET SESSION tidb_isolation_read_engines = 'tikv,tiflash,tidb';
+
+-- まとめ: 同じテーブルでも「全行×少数列」は列ストア、「1 行×全列」は行ストアが勝つ。
+-- TiDB は両方をレプリカとして持ち、クエリごとに使い分けられるのが特徴。
+-- ベクトル検索(2048 次元の embedding 列を全行舐めて距離計算)は「全行×少数列」の
+-- 極端な例なので TiFlash 向き、というのが以降のステップにつながる。
+-- sales_lesson はもう使わない。99_cleanup.sql で削除する

--- a/docs/source/97_survey/2026-07-19-tidb-vector-search-101/02_cosine.sql
+++ b/docs/source/97_survey/2026-07-19-tidb-vector-search-101/02_cosine.sql
@@ -1,0 +1,25 @@
+-- Step 2: コサイン類似度 = 「ベクトルの向きがどれだけ近いか」
+--
+-- VEC_COSINE_DISTANCE は距離（distance）を返す。distance = 1 - コサイン類似度。
+--   0 = 同じ向き / 1 = 直交（無関係）/ 2 = 真逆
+-- ポイントは「長さは無視して向きだけ見る」こと。
+
+-- (1) 基本の 4 パターン + 長さ不変の確認
+--   期待値: 0 / 0.2929 (45度) / 1 (90度) / 2 (180度)、長さが違っても向きが同じなら 0
+SELECT VEC_COSINE_DISTANCE('[1,0,0,0]', '[1,0,0,0]')  AS same_direction,          -- 0
+       VEC_COSINE_DISTANCE('[1,0,0,0]', '[1,1,0,0]')  AS deg45,                   -- 0.2929
+       VEC_COSINE_DISTANCE('[1,0,0,0]', '[0,1,0,0]')  AS deg90,                   -- 1
+       VEC_COSINE_DISTANCE('[1,0,0,0]', '[-1,0,0,0]') AS deg180,                  -- 2
+       VEC_COSINE_DISTANCE('[1,0,0,0]', '[2,0,0,0]')  AS same_direction_diff_len; -- 0
+
+-- (2) 組み込み関数と定義式が一致することを確認
+--   コサイン類似度 = 内積 / (ノルムの積)。distance = 1 - それ。
+--   期待値: builtin = manual = 0.023813
+SELECT VEC_COSINE_DISTANCE('[9,0,2,0]', '[1,0,0,0]') AS builtin,
+       1 - ( -VEC_NEGATIVE_INNER_PRODUCT('[9,0,2,0]', '[1,0,0,0]')
+             / (VEC_L2_NORM('[9,0,2,0]') * VEC_L2_NORM('[1,0,0,0]')) ) AS manual;
+
+-- (3) 落とし穴: 全 0 ベクトルはノルムが 0 でコサインが定義できず NULL になる
+--   （playground でダミーを作るとき先頭だけ 1 にするのはこのため）
+--   期待値: NULL
+SELECT VEC_COSINE_DISTANCE('[1,0,0,0]', '[0,0,0,0]') AS zero_vector;

--- a/docs/source/97_survey/2026-07-19-tidb-vector-search-101/03_exact_knn.sql
+++ b/docs/source/97_survey/2026-07-19-tidb-vector-search-101/03_exact_knn.sql
@@ -1,0 +1,33 @@
+-- Step 3: exact kNN = 全行と距離計算してソートする検索（brute force）
+--
+-- 「クエリベクトルに近い k 件」を求める一番素朴な方法。
+--   * 全行の距離を計算する → コストは行数に比例 O(N)
+--   * その代わり結果は 100% 正確
+-- SQL では「ORDER BY 距離関数 LIMIT k」がそのまま exact kNN になる。
+
+-- (1) クエリ「DB について知りたい」= [1,0,0,0]（db 成分だけのベクトル）
+--   期待値: mysql-tuning 0.0077 / tidb-intro 0.0238 / embedding-search 0.3492
+--   → DB 成分が濃い行から順に並ぶ
+SELECT id, label,
+       ROUND(VEC_COSINE_DISTANCE(embedding, '[1,0,0,0]'), 4) AS distance
+  FROM vec_lesson
+ ORDER BY VEC_COSINE_DISTANCE(embedding, '[1,0,0,0]')
+ LIMIT 3;
+
+-- (2) クエリ「DB × ML」= [1,0,0,1]
+--   期待値: embedding-search 0.0029 / llm-rag 0.0958 / mysql-tuning 0.2984
+--   → 成分の混ざり方が近い行が浮上する。キーワード一致では出せない並び
+SELECT id, label,
+       ROUND(VEC_COSINE_DISTANCE(embedding, '[1,0,0,1]'), 4) AS distance
+  FROM vec_lesson
+ ORDER BY VEC_COSINE_DISTANCE(embedding, '[1,0,0,1]')
+ LIMIT 3;
+
+-- (3) EXPLAIN で「全行走査している」ことを確認
+--   期待値: TableFullScan が task = cop[tikv] に出る。annIndex の文字は無い
+--   → インデックスを使わず TiKV（行ストア）で総当たりしている
+EXPLAIN
+SELECT id, label, VEC_COSINE_DISTANCE(embedding, '[1,0,0,0]') AS distance
+  FROM vec_lesson
+ ORDER BY VEC_COSINE_DISTANCE(embedding, '[1,0,0,0]')
+ LIMIT 3;

--- a/docs/source/97_survey/2026-07-19-tidb-vector-search-101/04_tiflash_vector.sql
+++ b/docs/source/97_survey/2026-07-19-tidb-vector-search-101/04_tiflash_vector.sql
@@ -1,0 +1,29 @@
+-- Step 4: ベクトル検索と TiFlash — HNSW の置き場所を用意する
+--
+-- TiFlash の性質（列指向、レプリカ宣言、ヒントで向ける）は Step 1 でやった通り。
+-- ここではそれをベクトル検索に当てはめる。
+--   * ベクトル距離計算は「全行 × embedding 列だけ」を舐める処理 = 列指向の得意な形
+--   * さらに TiDB のベクトルインデックス（HNSW）は TiFlash 上にしか作れない
+-- ので、まず vec_lesson にレプリカを張って置き場所を用意する。
+
+-- (1) レプリカ宣言（Step 1 と同じ操作）
+ALTER TABLE vec_lesson SET TIFLASH REPLICA 1;
+
+-- (2) available = 1 かつ progress = 1 になるまで待つ（8 行なら数秒）
+SELECT table_name, replica_count, available, progress
+  FROM information_schema.tiflash_replica
+ WHERE table_name = 'vec_lesson';
+
+-- (3) Step 3 の exact kNN クエリを TiFlash に向けて、EXPLAIN の task 列を見る
+--   期待値: TableFullScan の task が cop[tikv] → mpp[tiflash] に変わる
+--
+--   ★ここが重要: TiFlash に向けてもまだ TableFullScan = 総当たりのまま。
+--     列指向で「全行 × embedding 列」を読むのが速くなっただけで、
+--     全行の距離計算 O(N) という構造は変わっていない。
+--     行数そのものを減らすのが HNSW インデックス（次の Step 5）。
+EXPLAIN
+SELECT /*+ READ_FROM_STORAGE(TIFLASH[vec_lesson]) */
+       id, label, VEC_COSINE_DISTANCE(embedding, '[1,0,0,0]') AS distance
+  FROM vec_lesson
+ ORDER BY VEC_COSINE_DISTANCE(embedding, '[1,0,0,0]')
+ LIMIT 3;

--- a/docs/source/97_survey/2026-07-19-tidb-vector-search-101/05_hnsw.sql
+++ b/docs/source/97_survey/2026-07-19-tidb-vector-search-101/05_hnsw.sql
@@ -1,0 +1,46 @@
+-- Step 5: HNSW = 全行見ずに近傍を返す近似インデックス（ANN）
+--
+-- exact kNN は O(N)。行数が増えると比例して遅くなるので、
+-- 「多少の取りこぼしを許容して一部の行だけ見る」近似（ANN）に切り替える。
+-- HNSW は ANN の代表的実装で、ベクトルを多層グラフにしておき
+-- 上層（疎・長距離エッジ）で大まかに寄せて下層（密・短距離エッジ)で精密に寄せる。
+-- スキップリストのグラフ版と考えると掴みやすい。
+
+-- (1) インデックス作成。TiFlash レプリカが前提（Step 4 を先に）
+CREATE VECTOR INDEX idx_vec_lesson_embedding
+  ON vec_lesson ((VEC_COSINE_DISTANCE(embedding))) USING HNSW;
+
+-- (2) インデックスの実体を確認
+--   期待値: ROWS_DELTA_NOT_INDEXED = 8（全行が未インデックス）
+--   TiFlash は直近の書き込みを Delta 層に貯め、Delta 層は HNSW に入らない。
+--   検索時は「Stable 層 = HNSW / Delta 層 = 総当たり」を透過的にマージするので、
+--   書いた直後の行も検索には出る（インデックスが効かないだけ）
+SELECT TIDB_TABLE, INDEX_NAME, ROWS_STABLE_INDEXED, ROWS_DELTA_NOT_INDEXED
+  FROM INFORMATION_SCHEMA.TIFLASH_INDEXES
+ WHERE TIDB_TABLE = 'vec_lesson';
+
+-- (3) COMPACT で Delta 層を Stable 層へ落とす
+ALTER TABLE vec_lesson COMPACT TIFLASH REPLICA;
+
+-- (4) 再確認。期待値: ROWS_STABLE_INDEXED = 8, ROWS_DELTA_NOT_INDEXED = 0
+--   （反映まで数秒かかることがある）
+SELECT TIDB_TABLE, INDEX_NAME, ROWS_STABLE_INDEXED, ROWS_DELTA_NOT_INDEXED
+  FROM INFORMATION_SCHEMA.TIFLASH_INDEXES
+ WHERE TIDB_TABLE = 'vec_lesson';
+
+-- (5) EXPLAIN ANALYZE でインデックスが効いたことを確認
+--   期待値: TableFullScan の operator info に annIndex:COSINE(..., limit:3) が付き、
+--           execution info に vector_idx:{...search:{visited_nodes:8...}} が出る
+--
+--   annIndex が出れば HNSW 経由。8 行しかないので visited_nodes = 8（全ノード訪問）
+--   となり旨味はゼロだが、「効いているかは annIndex と visited_nodes で判定する」
+--   という読み方はこのサイズで覚えられる。実データでの差は 07_real_data.sql で見る。
+--
+--   効かせる条件は「ORDER BY 距離関数 LIMIT k」の形を崩さないこと。
+--   WHERE を足したり式を変形すると外れやすい（外れると Step 3 と同じ総当たりに戻る）。
+EXPLAIN ANALYZE
+SELECT /*+ READ_FROM_STORAGE(TIFLASH[vec_lesson]) */
+       id, label, VEC_COSINE_DISTANCE(embedding, '[1,0,0,0]') AS distance
+  FROM vec_lesson
+ ORDER BY VEC_COSINE_DISTANCE(embedding, '[1,0,0,0]')
+ LIMIT 3;

--- a/docs/source/97_survey/2026-07-19-tidb-vector-search-101/06_recursive_cte.sql
+++ b/docs/source/97_survey/2026-07-19-tidb-vector-search-101/06_recursive_cte.sql
@@ -1,0 +1,59 @@
+-- Step 6: 再帰 CTE = 「親子リストを何段でも辿る」SQL
+--
+-- タグは parent_tag_id で親を指す隣接リスト。「aws 指定で子孫の記事も拾う」には
+-- aws → lambda → snapstart と何段でも辿る必要があり、それをやるのが WITH RECURSIVE。
+-- 構造は必ず 2 パート。
+--   * anchor（UNION ALL の上）: 出発点の行。最初に 1 回だけ評価される
+--   * recursive（UNION ALL の下）: 「前のラウンドで増えた行」を参照して次の行を足す。
+--     何も増えなくなったら終了
+
+-- (1) まず anchor だけ実行してみる（= 再帰なしならこれしか取れない）
+--   期待値: aws の 1 行だけ
+SELECT tag_id, name FROM tag_lesson WHERE tag_id = 1;
+
+-- (2) 再帰 CTE で aws の子孫を全部辿る
+--   depth は「どのラウンドで追加されたか」。実行イメージ:
+--     ラウンド 0 (anchor):    aws
+--     ラウンド 1: 親が aws の行         → lambda, s3
+--     ラウンド 2: 親が lambda / s3 の行 → snapstart
+--     ラウンド 3: 親が snapstart の行   → 無し。終了
+--   期待値: aws(0) / lambda(1), s3(1) / snapstart(2) の 4 行
+WITH RECURSIVE descendants AS (
+    SELECT tag_id, name, 0 AS depth
+      FROM tag_lesson WHERE tag_id = 1
+    UNION ALL
+    SELECT t.tag_id, t.name, d.depth + 1
+      FROM tag_lesson t
+      JOIN descendants d ON t.parent_tag_id = d.tag_id
+)
+SELECT * FROM descendants ORDER BY depth, tag_id;
+
+-- (3) 本番形: root_tag_id を持ち回って 2 系列を同時に展開する
+--   タグ 2 件 AND 検索では「aws 系列を持つ」「frontend 系列を持つ」を記事ごとに
+--   別々に判定したい。そのため anchor で自分自身を root_tag_id として刻み、
+--   recursive で親の root_tag_id を引き継ぐ。各行が「どの系列の子孫か」を覚える。
+--   期待値:
+--     root_tag_id = 1 (aws):      aws, lambda, s3, snapstart
+--     root_tag_id = 5 (frontend): frontend, react
+WITH RECURSIVE tag_descendants AS (
+    SELECT tag_id, name, tag_id AS root_tag_id
+      FROM tag_lesson WHERE tag_id IN (1, 5)
+    UNION ALL
+    SELECT t.tag_id, t.name, td.root_tag_id
+      FROM tag_lesson t
+      JOIN tag_descendants td ON t.parent_tag_id = td.tag_id
+)
+SELECT * FROM tag_descendants ORDER BY root_tag_id, tag_id;
+
+-- (4) root_tag_id が無いとどうなるかを見る（OR 用の形）
+--   系列の区別が消え「どちらかの子孫」の集合になる。OR フィルタならこれで足りるが、
+--   AND フィルタは「aws 系列に属するか」を単独で問えなくなるため成立しない。
+--   本番クエリ（08_users_articles_search.sql）の B 節と C 節の差がまさにここ。
+WITH RECURSIVE tag_descendants AS (
+    SELECT tag_id, name FROM tag_lesson WHERE tag_id IN (1, 5)
+    UNION ALL
+    SELECT t.tag_id, t.name
+      FROM tag_lesson t
+      JOIN tag_descendants td ON t.parent_tag_id = td.tag_id
+)
+SELECT * FROM tag_descendants ORDER BY tag_id;

--- a/docs/source/97_survey/2026-07-19-tidb-vector-search-101/07_real_data.sql
+++ b/docs/source/97_survey/2026-07-19-tidb-vector-search-101/07_real_data.sql
@@ -1,0 +1,54 @@
+-- Step 7: 実データで exact と HNSW の差を見る
+--
+-- 教材テーブル（8 行）では差が出ないので、本物の article_embedding_chunks
+-- （2048 次元 PLaMo Embedding、約 1,100 chunk）で同じクエリを 2 通り流す。
+--   * TIKV ヒント    → TiKV にはベクトルインデックスが無いので必ず exact（総当たり）
+--   * TIFLASH ヒント → HNSW インデックス経由
+--
+-- 2048 次元のダミーベクトルはセッション変数で組み立てる（全 0 は NULL になるため
+-- 先頭だけ 1）。playground はステートメントごとに接続を切ることがあるので、
+-- BEGIN ... COMMIT で括って SET と本体を同一トランザクションで送る。
+
+-- (1) exact: 総当たり
+--   実測 (2026-07-19, blog_dev 1,108 chunks): 89.7ms。
+--   TableFullScan actRows = 1108 = 全行の 2048 次元距離計算
+BEGIN;
+SET @vector = CONCAT('[1,', REPEAT('0,', 2046), '0]');
+EXPLAIN ANALYZE
+SELECT /*+ READ_FROM_STORAGE(TIKV[c]) */
+       c.article_id, VEC_COSINE_DISTANCE(c.embedding, @vector) AS distance
+  FROM article_embedding_chunks AS c
+ ORDER BY VEC_COSINE_DISTANCE(c.embedding, @vector)
+ LIMIT 5;
+COMMIT;
+
+-- (2) HNSW: グラフを辿って一部だけ見る
+--   実測 (同上): 9.3ms、visited_nodes:68（1,101 ノード中 68 ノードだけ訪問）
+--   同じ top-5 を約 1/10 の時間で返す。行数が増えるほどこの差は開く（exact は O(N)）
+BEGIN;
+SET @vector = CONCAT('[1,', REPEAT('0,', 2046), '0]');
+EXPLAIN ANALYZE
+SELECT /*+ READ_FROM_STORAGE(TIFLASH[c]) */
+       c.article_id, VEC_COSINE_DISTANCE(c.embedding, @vector) AS distance
+  FROM article_embedding_chunks AS c
+ ORDER BY VEC_COSINE_DISTANCE(c.embedding, @vector)
+ LIMIT 5;
+COMMIT;
+
+-- (3) 結果は同じか（= 近似の取りこぼし確認）
+--   実測 (同上): top-5 の chunk_id と距離が完全一致。この規模なら recall 100%。
+--   件数が増えると HNSW は取りこぼしうるので、本番クエリは必要数より多めに取る
+--   （over-fetch）+ 後段フィルタで吸収する設計にしている
+BEGIN;
+SET @vector = CONCAT('[1,', REPEAT('0,', 2046), '0]');
+SELECT /*+ READ_FROM_STORAGE(TIKV[c]) */
+       'exact' AS mode, c.chunk_id, ROUND(VEC_COSINE_DISTANCE(c.embedding, @vector), 6) AS distance
+  FROM article_embedding_chunks AS c
+ ORDER BY VEC_COSINE_DISTANCE(c.embedding, @vector)
+ LIMIT 5;
+SELECT /*+ READ_FROM_STORAGE(TIFLASH[c]) */
+       'hnsw' AS mode, c.chunk_id, ROUND(VEC_COSINE_DISTANCE(c.embedding, @vector), 6) AS distance
+  FROM article_embedding_chunks AS c
+ ORDER BY VEC_COSINE_DISTANCE(c.embedding, @vector)
+ LIMIT 5;
+COMMIT;

--- a/docs/source/97_survey/2026-07-19-tidb-vector-search-101/99_cleanup.sql
+++ b/docs/source/97_survey/2026-07-19-tidb-vector-search-101/99_cleanup.sql
@@ -1,0 +1,11 @@
+-- Step 99: 片付け
+--
+-- 教材テーブルを削除する。TiFlash レプリカ・ベクトルインデックスも一緒に消える。
+
+DROP TABLE IF EXISTS sales_lesson;
+DROP TABLE IF EXISTS vec_lesson;
+DROP TABLE IF EXISTS tag_lesson;
+
+-- 消えたことの確認（0 行になれば OK）
+SELECT table_name FROM information_schema.tables
+ WHERE table_schema = 'blog_dev' AND table_name IN ('sales_lesson', 'vec_lesson', 'tag_lesson');

--- a/docs/source/97_survey/2026-07-19-tidb-vector-search-101/index.md
+++ b/docs/source/97_survey/2026-07-19-tidb-vector-search-101/index.md
@@ -1,0 +1,186 @@
+<!-- cspell:ignore mathbf -->
+
+# TiDB ベクトル検索の最小教材 — コサイン類似度 / exact / TiFlash / HNSW / 再帰 CTE
+
+- 対象: TiDB Vector（blog_dev）。本番検索クエリを構成する 5 概念
+- 調査日: 2026-07-19
+- きっかけ: [playground](../2026-07-16-blog-api-queryplayground/index.md) と[分解 survey](../2026-07-16-tidb-vector-tag-hybrid-search-breakdown/index.md) は本番クエリ前提で情報量が多い。手計算できるサイズの自作テーブル（4 次元ベクトル 8 行、タグ 7 行）で 1 概念ずつ確認できる教材にする
+
+## ゴール
+
+[08_users_articles_search.sql](../2026-07-16-blog-api-queryplayground/08_users_articles_search.sql) が読めるようになること。本番クエリは次の 5 部品でできている。
+
+| 部品           | 本番クエリでの役割                                          | 学ぶステップ |
+| -------------- | ----------------------------------------------------------- | ------------ |
+| TiFlash        | 列指向レプリカ。集計とベクトル距離計算の逃がし先            | Step 1, 4    |
+| コサイン類似度 | `VEC_COSINE_DISTANCE` で「意味の近さ」を数値にする          | Step 2       |
+| exact kNN      | タグ併用モード (B/C) の距離計算。全行総当たりだが 100% 正確 | Step 3       |
+| HNSW           | 検索のみモード (A) の距離計算。一部だけ見て近傍を返す       | Step 5       |
+| 再帰 CTE       | `tag_descendants`。親タグ指定で子孫タグまで展開する         | Step 6       |
+
+## 使い方
+
+- 接続先は playground と同じ `mysql://root@tidb.<tailnet>:4000/blog_dev`
+- `00_setup.sql` → `01`〜`07` の順に流し、終わったら `99_cleanup.sql` で片付ける
+- 教材テーブル `sales_lesson`（Step 1 内で作成）/ `vec_lesson` / `tag_lesson` を blog_dev に作る（使い捨て。Step 7 だけ本物の `article_embedding_chunks` を読む）
+- ベクトルが 4 次元なのでセッション変数もダミー生成も不要。リテラルを直接書ける
+- 各ファイルの「期待値」コメントは 2026-07-19 に blog_dev で実測した値
+
+## ステップ
+
+| ファイル              | 学ぶこと                                           | 確認ポイント                                      |
+| --------------------- | -------------------------------------------------- | ------------------------------------------------- |
+| 00_setup.sql          | 教材テーブル作成                                   | `VECTOR(4)` 8 行 + タグツリー 7 行                |
+| 01_tiflash_basics.sql | TiFlash 単体。行指向と列指向の得意分野の違い       | 集計 157.8ms → 13.3ms、点読みは行ストアが勝つ     |
+| 02_cosine.sql         | コサイン距離 = 1 - 類似度。向きだけ見て長さは無視  | 0 / 0.29 / 1 / 2 の 4 パターン、全 0 は NULL      |
+| 03_exact_knn.sql      | `ORDER BY 距離 LIMIT k` = exact kNN（総当たり）    | EXPLAIN に `TableFullScan cop[tikv]`              |
+| 04_tiflash_vector.sql | ベクトル用テーブルにレプリカ = HNSW の置き場所     | `task` 列が `mpp[tiflash]` に変わるがまだ総当たり |
+| 05_hnsw.sql           | ベクトルインデックス作成と Delta/Stable 二層       | `annIndex:` と `visited_nodes` が出る             |
+| 06_recursive_cte.sql  | anchor + recursive の 2 パート構造と `root_tag_id` | depth 列でラウンドが見える                        |
+| 07_real_data.sql      | 実データ 1,108 chunk で exact vs HNSW              | 89.7ms → 9.3ms、top-5 完全一致                    |
+| 99_cleanup.sql        | 片付け                                             | 教材テーブルが消える                              |
+
+## Step 1: TiFlash 単体 — 列指向だからできること
+
+ベクトルの前に TiFlash そのものを一番単純な形で体感する。行ストア（TiKV）と列ストア（TiFlash）はデータの物理的な並べ方が違う。
+
+- **行ストア**: 1 行分の全列がディスク上で連続。「id=54321 の行を丸ごと 1 件」が得意
+- **列ストア**: 1 列分の全行が連続。「全行のうち 2 列だけ舐めて集計」が得意
+
+これを見るため、集計に使う細い列（category, amount）と集計に無関係な太い列（note 500 バイト）を持つ `sales_lesson` を 10 万行作り、同じ `GROUP BY` 集計を両方に投げる。実測。
+
+| クエリ                                | TiKV（行ストア）     | TiFlash（列ストア）       |
+| ------------------------------------- | -------------------- | ------------------------- |
+| `GROUP BY category` の集計（10 万行） | 157.8ms              | 13.3ms（約 1/12）         |
+| `WHERE id = 54321` の点読み           | 1.7ms（`Point_Get`） | 9.2ms（`TableRangeScan`） |
+
+集計が速いのは、行ストアが **category と amount しか使わない集計でも note 500B を含む全行 約 50MB を読む**のに対し、列ストアは列ごとにファイルが分かれていて **2 列分だけ読めば済む**から。プランにも `mpp[tiflash] + threads:16` と並列実行が出る。
+
+逆に点読みは行ストアの圧勝。TIFLASH ヒントを付けてもオプティマイザは `Point_Get`（TiKV）を選び続け、セッション変数 `tidb_isolation_read_engines = 'tiflash'` で無理やり縛ると約 5 倍遅くなる。**同じテーブルでも「全行 × 少数列」は列ストア、「1 行 × 全列」は行ストアが勝つ**。TiDB は両方をレプリカとして持ち、クエリごとに使い分けられる。
+
+ベクトル検索（2048 次元の embedding 列を全行舐めて距離計算）は「全行 × 少数列」の極端な例なので TiFlash 向き、というのが以降のステップにつながる。
+
+## Step 2: コサイン類似度
+
+`VEC_COSINE_DISTANCE` は 2 本のベクトルの「向きの近さ」を距離で返す。
+
+コサイン類似度の定義式:
+
+$$
+\text{cosine\_similarity}(\mathbf{a}, \mathbf{b}) = \frac{\mathbf{a} \cdot \mathbf{b}}{\|\mathbf{a}\| \times \|\mathbf{b}\|} = \frac{\sum_{i=1}^{n} a_i b_i}{\sqrt{\sum_{i=1}^{n} a_i^2} \times \sqrt{\sum_{i=1}^{n} b_i^2}}
+$$
+
+TiDB の `VEC_COSINE_DISTANCE` はこれを距離に変換して返す:
+
+$$
+\text{cosine\_distance}(\mathbf{a}, \mathbf{b}) = 1 - \text{cosine\_similarity}(\mathbf{a}, \mathbf{b})
+$$
+
+同じ向きなら 0、直交（無関係）なら 1、真逆なら 2。実測値。
+
+| ペア                        | 角度 | distance |
+| --------------------------- | ---- | -------- |
+| `[1,0,0,0]` と `[1,0,0,0]`  | 0°   | 0        |
+| `[1,0,0,0]` と `[1,1,0,0]`  | 45°  | 0.2929   |
+| `[1,0,0,0]` と `[0,1,0,0]`  | 90°  | 1        |
+| `[1,0,0,0]` と `[-1,0,0,0]` | 180° | 2        |
+| `[1,0,0,0]` と `[2,0,0,0]`  | 0°   | 0        |
+
+最後の行が肝で、**長さが 2 倍でも向きが同じなら距離 0**。文章の埋め込みでは「長い文も短い文も、話題が同じなら近い」に対応する。定義式（内積 ÷ ノルムの積）を `VEC_NEGATIVE_INNER_PRODUCT` と `VEC_L2_NORM` で手組みすると組み込み関数と完全一致することも確認できる（`02_cosine.sql` の (2)）。
+
+落とし穴: 全 0 ベクトルはノルムが 0 でコサインが定義できず **NULL** になる。playground のダミーベクトルが「先頭だけ 1」なのはこのため。
+
+## Step 3: exact kNN（総当たり）
+
+「近い k 件」を求める一番素朴な方法は全行と距離計算してソートすること。SQL では `ORDER BY 距離関数 LIMIT k` がそのまま exact kNN になる。教材データは 4 次元を `[db, frontend, infra, ml]` のトピック成分に見立てているので、ランキングが直感と一致するか読める。
+
+クエリ `[1,0,0,0]`（DB について知りたい）の実測。
+
+| label            | embedding   | distance |
+| ---------------- | ----------- | -------- |
+| mysql-tuning     | `[8,0,1,0]` | 0.0077   |
+| tidb-intro       | `[9,0,2,0]` | 0.0238   |
+| embedding-search | `[6,0,0,7]` | 0.3492   |
+
+クエリ `[1,0,0,1]`（DB × ML）にすると embedding-search (0.0029) と llm-rag (0.0958) が浮上する。**キーワードの一致ではなく成分の混ざり方で並ぶ**のがベクトル検索。
+
+EXPLAIN を見ると `TableFullScan` が `cop[tikv]` に出る。全行走査なのでコストは行数に比例（O(N)）、その代わり結果は 100% 正確。本番クエリのタグ併用モード (B/C) は「タグで絞った後なら対象が少ないので exact で総当たりしても安い」という判断でこの方式を使っている。
+
+## Step 4: ベクトル検索と TiFlash
+
+Step 1 の操作（レプリカ宣言 → 同期確認 → ヒント）をベクトル用の `vec_lesson` にも適用する。ベクトル距離計算は「全行 × embedding 列だけ」を舐める処理なので列指向の得意な形であり、さらに **TiDB のベクトルインデックス（HNSW）は TiFlash 上にしか作れない**ため、まず置き場所を用意する意味もある。
+
+ここで重要なのは、**TiFlash に向けてもプランはまだ `TableFullScan` = 総当たりのまま**なこと。列指向で読むのが速くなっただけで、全行の距離計算 O(N) という構造は変わっていない。行数そのものを減らすのが次のステップの HNSW インデックス。
+
+## Step 5: HNSW
+
+exact kNN は行数に比例して遅くなるので、大規模では「多少の取りこぼしを許容して一部の行だけ見る」近似（ANN）に切り替える。HNSW はその代表的実装で、ベクトルを多層グラフにしておき、上層（疎・長距離エッジ）で大まかに寄せ、下層（密・短距離エッジ）で精密に寄せる。スキップリストのグラフ版。
+
+```sql
+CREATE VECTOR INDEX idx_vec_lesson_embedding
+  ON vec_lesson ((VEC_COSINE_DISTANCE(embedding))) USING HNSW;
+```
+
+作成直後の `INFORMATION_SCHEMA.TIFLASH_INDEXES` は `ROWS_DELTA_NOT_INDEXED = 8`（全行が未インデックス）。TiFlash は直近の書き込みを Delta 層に貯めており、検索時は **Stable 層 = HNSW / Delta 層 = 総当たり**を透過的にマージする。書いた直後の行も検索に出るが index は効かない。`ALTER TABLE ... COMPACT TIFLASH REPLICA;` で Stable 層に落とすと `ROWS_STABLE_INDEXED = 8` になる。
+
+効いたかどうかは EXPLAIN ANALYZE で判定する。
+
+- operator info に `annIndex:COSINE(..., limit:3)` が付く
+- execution info に `vector_idx:{...search:{visited_nodes:8...}}` が出る
+
+8 行だと全ノード訪問（visited_nodes:8）で旨味はゼロだが、この「読み方」を覚えるのが目的。効かせる条件は **`ORDER BY 距離関数 LIMIT k` の形を崩さない**ことで、CTE の内側に WHERE を足すと総当たりに戻る。本番クエリが検索のみモード (A) でフィルタを全部 HNSW の外側に置いているのはこのため。
+
+## Step 6: 再帰 CTE
+
+タグは `parent_tag_id` で親を指す隣接リスト。「aws 指定で子孫タグの記事も拾う」には aws → lambda → snapstart と何段でも辿る必要があり、それをやるのが `WITH RECURSIVE`。構造は必ず 2 パート。
+
+- **anchor**（UNION ALL の上）: 出発点の行。最初に 1 回だけ評価される
+- **recursive**（UNION ALL の下）: 「前のラウンドで増えた行」を参照して次の行を足す。増えなくなったら終了
+
+depth 列（anchor で 0、recursive で +1）を付けるとラウンドの進行がそのまま見える。実測。
+
+| tag_id | name      | depth |
+| ------ | --------- | ----- |
+| 1      | aws       | 0     |
+| 2      | lambda    | 1     |
+| 3      | s3        | 1     |
+| 4      | snapstart | 2     |
+
+本番形はさらに `root_tag_id` を持ち回る。anchor で自分自身を root として刻み、recursive で親の値を引き継ぐと、aws と frontend を同時に展開しても各行が「どの系列の子孫か」を覚えている。
+
+| tag_id | name      | root_tag_id |
+| ------ | --------- | ----------- |
+| 1      | aws       | 1           |
+| 2      | lambda    | 1           |
+| 3      | s3        | 1           |
+| 4      | snapstart | 1           |
+| 5      | frontend  | 5           |
+| 6      | react     | 5           |
+
+これが必要なのは**タグ 2 件 AND** のとき。「aws 系列を持つ」AND「frontend 系列を持つ」を記事ごとに別々の EXISTS で判定するには系列の区別が要る。OR なら「どちらかの子孫」の集合で足りるので `root_tag_id` は不要（`06_recursive_cte.sql` の (4)）。本番クエリの B 節と C 節の差がまさにここ。
+
+## Step 7: 実データで exact vs HNSW
+
+教材テーブルでは差が出ないので、本物の `article_embedding_chunks`（2048 次元、1,108 chunk）で同じ top-5 クエリを 2 通り流す。TiKV にはベクトルインデックスが無いので、`TIKV` ヒント = 強制 exact になる。実測。
+
+| 方式  | ヒント       | 時間   | 見た行/ノード            |
+| ----- | ------------ | ------ | ------------------------ |
+| exact | `TIKV[c]`    | 89.7ms | 1,108 行すべて距離計算   |
+| HNSW  | `TIFLASH[c]` | 9.3ms  | visited_nodes:68 / 1,101 |
+
+top-5 の chunk_id と距離は**完全一致**。この規模なら recall 100% で、約 1/10 の時間になる。exact は O(N) なので行数が増えるほど差は開く。一方 HNSW は原理的に取りこぼしうるため、本番クエリは必要数より多めに候補を取り（over-fetch）、後段のフィルタと固定候補窓で吸収する設計にしている。
+
+## まとめ: 本番クエリの読み方
+
+5 部品が入った状態で [08_users_articles_search.sql](../2026-07-16-blog-api-queryplayground/08_users_articles_search.sql) を見ると、こう分解できる。
+
+- **(A) 検索のみ**: Step 5 の HNSW クエリに固定候補窓 1000 を付けたもの。TiFlash 境界（Step 1, 4）を守るためフィルタは全部外側
+- **(B) タグ AND**: Step 6 の `root_tag_id` 付き再帰 CTE + EXISTS ×2 で先に絞り、残りに Step 3 の exact を掛ける
+- **(C) タグ OR**: B の EXISTS が 1 個になり `root_tag_id` が消えるだけ
+
+さらに深く（EXPLAIN ANALYZE の生プラン、他 DB との比較、HNSW の近似が生むページネーション問題）は[分解 survey](../2026-07-16-tidb-vector-tag-hybrid-search-breakdown/index.md) へ。
+
+## 未検証 / TODO
+
+- [ ] HNSW の探索幅（ef_search 相当）の調整方法は触れていない
+- [ ] 大規模データでの recall 低下は未確認（dev 1,108 件では exact と完全一致）

--- a/docs/source/97_survey/index.md
+++ b/docs/source/97_survey/index.md
@@ -7,6 +7,7 @@
 | 調査日     | タイトル                                                                                                                           |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | 0000-00-00 | [タイトル](0000-00-00-topic/index.md)                                                                                              |
+| 2026-07-19 | [TiDB ベクトル検索の最小教材 — コサイン類似度 / exact / TiFlash / HNSW / 再帰 CTE](2026-07-19-tidb-vector-search-101/index.md)     |
 | 2026-07-16 | [タグ AND × ベクトル検索クエリの分解 — TiFlash ANN と再帰 CTE](2026-07-16-tidb-vector-tag-hybrid-search-breakdown/index.md)        |
 | 2026-07-16 | [blog-api で使われているクエリの playground](2026-07-16-blog-api-queryplayground/index.md)                                         |
 | 2026-07-04 | [CloudWatch OTel Metrics と Classic メトリクスの機能差分](2026-07-04-cloudwatch-otel-vs-classic-metrics/index.md)                  |

--- a/docs/source/_templates/searchbox.html
+++ b/docs/source/_templates/searchbox.html
@@ -18,10 +18,14 @@
     const components = document.querySelector('#pagefind-search #pagefind-components');
 
     try {
+      const bundlePath = '/pagefind/';
+      const res = await fetch(`${bundlePath}pagefind.js`, { method: 'HEAD' });
+      if (!res.ok) throw new Error('search bundle not available');
+
       await import("./{{ pathto('pagefind/pagefind-component-ui.js', 1) }}");
       window.PagefindComponents.configureInstance('default', {
         baseUrl: '/',
-        bundlePath: '/pagefind/',
+        bundlePath,
       });
       components.innerHTML = `
         <pagefind-modal-trigger hidden placeholder="ドキュメントを検索"></pagefind-modal-trigger>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,9 +28,9 @@ html_search_language = "ja"
 # https://github.com/mgaitan/sphinxcontrib-mermaid?tab=readme-ov-file#markdown-support
 myst_fence_as_directive = ["mermaid"]
 
-# MyST の追加記法 (取り消し線 / ::: 記法のアドモニション / 定義リスト)
-# cspell:ignore deflist
-myst_enable_extensions = ["strikethrough", "colon_fence", "deflist"]
+# MyST の追加記法 (取り消し線 / ::: 記法のアドモニション / 定義リスト / $ 数式)
+# cspell:ignore deflist dollarmath
+myst_enable_extensions = ["strikethrough", "colon_fence", "deflist", "dollarmath"]
 
 # H1〜H3 の見出しに自動 slug を付けて `foo.md#slug` のアンカー参照を有効にする
 myst_heading_anchors = 3


### PR DESCRIPTION
## 概要

- TiDB ベクトル検索を構成する 5 概念（TiFlash / コサイン類似度 / exact kNN / HNSW / 再帰 CTE）を、手計算できるサイズの自作テーブルで 1 概念 = 1 ファイルずつ確認できる学習教材を `97_survey/2026-07-19-tidb-vector-search-101` に追加
- 各ステップの「期待値」コメントはすべて blog_dev で実測した値（集計 157.8ms → 13.3ms、実データの exact 89.7ms → HNSW 9.3ms など）
- あわせて docs 検索の searchbox に pagefind バンドルの存在チェックを追加

## 変更内容

### 教材 (`docs/source/97_survey/2026-07-19-tidb-vector-search-101/`)

| ファイル | 内容 |
| --- | --- |
| `00_setup.sql` | 教材テーブル作成（`VECTOR(4)` 8 行 + タグツリー 7 行） |
| `01_tiflash_basics.sql` | TiFlash 単体。10 万行の集計で行指向 vs 列指向を対比、点読みは行ストアが勝つことも確認 |
| `02_cosine.sql` | コサイン距離の基本 4 パターン、定義式との一致、全 0 ベクトルが NULL になる落とし穴 |
| `03_exact_knn.sql` | `ORDER BY 距離 LIMIT k` = exact kNN。EXPLAIN で `TableFullScan cop[tikv]` を確認 |
| `04_tiflash_vector.sql` | ベクトル用テーブルへのレプリカ = HNSW の置き場所。TiFlash に向けてもまだ総当たりのまま |
| `05_hnsw.sql` | `CREATE VECTOR INDEX` と Delta/Stable 二層、`annIndex:` / `visited_nodes` の読み方 |
| `06_recursive_cte.sql` | anchor + recursive の 2 パート構造、depth 列でのラウンド可視化、`root_tag_id` の要否（AND vs OR） |
| `07_real_data.sql` | 実データ 1,108 chunk で exact vs HNSW。約 1/10 の時間で top-5 完全一致 |
| `99_cleanup.sql` | 教材テーブルの削除 |
| `index.md` | 各ステップの解説 + 実測値。コサイン類似度の定義式を dollarmath で数式表示 |

### その他

- `docs/source/conf.py`: MyST `dollarmath` 拡張を有効化（数式表示のため）
- `docs/source/97_survey/index.md`: 調査一覧に教材の行を追加
- `docs/source/_templates/searchbox.html`: pagefind バンドルへ HEAD リクエストを投げ、未生成時は検索 UI の初期化をスキップ

## チェックリスト

- [x] 全 SQL を blog_dev で実行し期待値コメントを実測値で記載（検証用テーブルは削除済み）
- [x] `bun run lint`（vp lint / fmt / cspell / type-check）通過
- [x] Sphinx ビルド警告なし
