### PR TITLE
feat: 目次を刷新し見出しアンカーを追加

### DIFF
--- a/apps/admin-web/src/app/routeTree.gen.ts
+++ b/apps/admin-web/src/app/routeTree.gen.ts
@@ -9,25 +9,25 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as LoginRouteImport } from './routes/login'
-import { Route as AuthedRouteImport } from './routes/_authed'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthedRouteImport } from './routes/_authed'
+import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthedMomentsIndexRouteImport } from './routes/_authed.moments.index'
 import { Route as AuthedMomentsNewRouteImport } from './routes/_authed.moments.new'
 import { Route as AuthedMomentsMomentIdEditRouteImport } from './routes/_authed.moments.$momentId.edit'
 
-const LoginRoute = LoginRouteImport.update({
-  id: '/login',
-  path: '/login',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthedRoute = AuthedRouteImport.update({
   id: '/_authed',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthedMomentsIndexRoute = AuthedMomentsIndexRouteImport.update({
@@ -94,11 +94,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authed': {
@@ -108,11 +108,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authed/moments/': {

--- a/apps/blog-api/markdown/src/lib.rs
+++ b/apps/blog-api/markdown/src/lib.rs
@@ -1031,6 +1031,22 @@ where
         .to_string()
 }
 
+/// 見出しの先頭にアンカーリンク（# 記号）を挿入する。
+/// クリック時の挙動（リンクコピー）はフロントエンド側で実装する
+fn add_heading_anchors(html: &str) -> String {
+    static HEADING_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"<(h[1-6]) id="([^"]*)">"#).unwrap());
+    HEADING_RE
+        .replace_all(html, |caps: &regex::Captures| {
+            format!(
+                r##"<{tag} id="{id}"><a class="heading-anchor" href="#{id}" aria-label="この見出しへのリンクをコピー">#</a>"##,
+                tag = &caps[1],
+                id = &caps[2],
+            )
+        })
+        .to_string()
+}
+
 /// comrak が出力する脚注セクションの冒頭に Zenn 風のタイトルを挿入する
 /// (zenn-editor の footnote_block_open カスタマイズに相当)
 fn add_footnotes_title(html: &str) -> String {
@@ -1096,6 +1112,9 @@ impl MarkdownConverter {
 
         // Convert remaining markdown
         let mut html = self.convert_simple(&with_containers);
+
+        // 見出しにアンカーリンク（#）を挿入
+        html = add_heading_anchors(&html);
 
         // 外部リンクに target="_blank" を追加
         html = self.add_target_blank_to_external_links(&html);
@@ -1232,6 +1251,22 @@ mod tests {
         assert!(html.contains("<h1"));
         assert!(html.contains("<strong>bold</strong>"));
         assert!(html.contains("<em>italic</em>"));
+    }
+
+    #[test]
+    fn test_heading_anchor() {
+        let markdown = "## はじめに\n\n本文";
+        let html = convert_markdown_to_html(markdown);
+        assert!(html.contains(
+            r##"<h2 id="はじめに"><a class="heading-anchor" href="#はじめに" aria-label="この見出しへのリンクをコピー">#</a>はじめに"##
+        ));
+    }
+
+    #[test]
+    fn test_heading_anchor_inside_details() {
+        let markdown = ":::details 詳細\n\n### 内側見出し\n\n:::";
+        let html = convert_markdown_to_html(markdown);
+        assert!(html.contains(r##"<a class="heading-anchor" href="#内側見出し""##));
     }
 
     #[test]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,8 +22,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-tweet": "^3.3.1",
-    "rss": "^1.2.2",
-    "tocbot": "^4.36.8"
+    "rss": "^1.2.2"
   },
   "devDependencies": {
     "@next/env": "16.2.11",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -690,9 +690,16 @@ input[type='search']::-webkit-search-decoration {
   width: var(--layout-sidebar-w);
 }
 
+/* 1024px 以下はサイドバーを本文上部の目次アコーディオンに切り替える。
+   sticky の基準を記事全体を含む .article-body に取らせるため、
+   ラッパーの .right-sidebar は display: contents で消す */
 @media (max-width: 1024px) {
+  .article-body {
+    flex-direction: column;
+  }
+
   .right-sidebar {
-    display: none;
+    display: contents;
   }
 }
 
@@ -712,64 +719,121 @@ input[type='search']::-webkit-search-decoration {
   line-height: var(--lh-list);
 }
 
-.toc > ol.toc-list {
-  position: relative;
-}
-
-.toc > ol::before {
-  position: absolute;
-  content: '';
-  width: 2px;
-  background: var(--toc-list-color);
-  top: 10px;
-  bottom: 0;
-  left: 2px;
-  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
-}
-
 .toc ol li {
-  position: relative;
   color: var(--toc-list-text-color);
-}
-
-.toc ol li::before {
-  position: absolute;
-  content: '';
-  top: 8px;
-  height: 8px;
-  width: 8px;
-  left: -1px;
-  background: var(--toc-list-color);
-}
-
-.toc ol li.is-active-li::before {
-  background: var(--toc-list-color-active);
 }
 
 .toc ol li.is-active-li {
   color: var(--toc-list-color-active);
 }
 
-.toc ol ol li::before {
-  height: 6px;
-  width: 6px;
-  left: 0;
-  border-radius: var(--radius-full);
-}
-
-.toc ol ol ol li::before {
-  height: 4px;
-  width: 4px;
-  left: 1px;
-  border-radius: var(--radius-full);
-}
-
 .toc a {
-  position: relative;
-  padding-left: 0.8em;
   overflow: hidden;
   display: block;
   text-overflow: ellipsis;
+}
+
+/* ネスト階層はファイルツリー風の連続した罫線（角丸 L 字コネクタ）で表現する。
+   文字（├──）だと行間で縦線が途切れるため CSS で描く */
+.toc ol ol {
+  padding-left: 0.55em;
+}
+
+.toc ol ol > li {
+  position: relative;
+  padding-left: 1em;
+}
+
+/* 各項目へ分岐する L 字（テキスト行の中央まで） */
+.toc ol ol > li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 0.65em;
+  height: calc(var(--lh-list) * 0.5em);
+  border-left: 1px solid var(--toc-list-color);
+  border-bottom: 1px solid var(--toc-list-color);
+  border-bottom-left-radius: 6px;
+}
+
+/* 最後の子以外は縦線を下まで伸ばして連続させる */
+.toc ol ol > li:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  border-left: 1px solid var(--toc-list-color);
+}
+
+/* モバイル用目次（上部固定の「目次」ボタン + モーダル） */
+.toc-mobile-trigger {
+  display: none;
+  align-items: center;
+  gap: 0.25em;
+  background: var(--color-surface);
+  border: 1px solid var(--article-area-border-color);
+  border-radius: var(--radius-full);
+  padding: var(--space-1) var(--space-3);
+  color: var(--color-text-muted);
+  line-height: var(--lh-list);
+  cursor: pointer;
+}
+
+.toc-mobile-trigger svg {
+  width: 1em;
+  height: 1em;
+}
+
+/* 上部固定の「目次」ボタン（top: space-2 + 高さ約 37px）の直下に出す */
+.toc-mobile-dialog {
+  margin: 0;
+  position: fixed;
+  top: calc(var(--space-2) + 37px + var(--space-1));
+  right: var(--space-4);
+  left: auto;
+  width: min(80vw, 320px);
+  max-height: 60vh;
+  overflow-y: auto;
+  background: var(--color-surface);
+  border: 1px solid var(--article-area-border-color);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  color: inherit;
+}
+
+.toc-mobile-dialog::backdrop {
+  background: rgb(0 0 0 / 20%);
+}
+
+.toc-mobile-dialog .toc {
+  position: static;
+  max-width: 100%;
+  max-height: none;
+  border: none;
+  padding: 0;
+}
+
+/* 初期フォーカスの受け皿（tabindex=-1）にリングを出さない。リンクのキーボード操作時は通常どおり */
+.toc-mobile-dialog .toc:focus {
+  outline: none;
+}
+
+@media (max-width: 1024px) {
+  .toc-desktop {
+    display: none;
+  }
+
+  .toc-mobile-trigger {
+    display: inline-flex;
+    order: -1;
+    position: sticky;
+    top: var(--space-2);
+    z-index: 10;
+    align-self: flex-end;
+    margin-bottom: var(--space-2);
+  }
 }
 
 /* Toggle Switch */
@@ -1024,6 +1088,30 @@ input[type='search']::-webkit-search-decoration {
 
 .prose pre .copy-btn .copy-icon {
   display: flex;
+}
+
+/* 見出しアンカー（# クリックでリンクコピー） */
+.prose .heading-anchor {
+  position: relative;
+  margin-right: 0.35em;
+  color: var(--color-text-muted);
+  text-decoration: none;
+}
+
+.prose .heading-anchor:hover {
+  color: var(--color-accent);
+}
+
+.prose .heading-anchor .copied-float {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 2px);
+  font-size: 12px;
+  font-weight: var(--fw-regular);
+  color: var(--color-success-icon);
+  white-space: nowrap;
+  animation: float-up 0.8s ease-out forwards;
+  pointer-events: none;
 }
 
 .prose pre .copy-btn .copied-float {

--- a/apps/web/src/components/ArticleContent.tsx
+++ b/apps/web/src/components/ArticleContent.tsx
@@ -90,7 +90,36 @@ export function ArticleContent({ html }: ArticleContentProps) {
     const container = contentRef.current;
     if (!container) return;
 
+    const showCopiedFloat = (host: Element) => {
+      const floatingText = document.createElement('span');
+      floatingText.className = 'copied-float';
+      floatingText.textContent = 'Copied!';
+      host.appendChild(floatingText);
+
+      setTimeout(() => {
+        floatingText.remove();
+      }, 800);
+    };
+
     const handleCopyClick = (e: MouseEvent) => {
+      // 見出しアンカー（#）: ジャンプせずに hash を更新し、共有用 URL をコピーする
+      const headingAnchor = (e.target as Element).closest('.heading-anchor');
+      if (headingAnchor) {
+        e.preventDefault();
+        const href = headingAnchor.getAttribute('href');
+        if (!href) return;
+
+        const url = new URL(href, window.location.href);
+        window.history.pushState(null, '', url.hash);
+        navigator.clipboard.writeText(url.toString()).then(
+          () => showCopiedFloat(headingAnchor),
+          (err) => {
+            console.error('Failed to copy:', err);
+          },
+        );
+        return;
+      }
+
       const button = (e.target as Element).closest(
         '.github-embed-copy, .code-block-copy, .copy-btn',
       );
@@ -100,16 +129,7 @@ export function ArticleContent({ html }: ArticleContentProps) {
       if (!code) return;
 
       navigator.clipboard.writeText(code).then(
-        () => {
-          const floatingText = document.createElement('span');
-          floatingText.className = 'copied-float';
-          floatingText.textContent = 'Copied!';
-          button.appendChild(floatingText);
-
-          setTimeout(() => {
-            floatingText.remove();
-          }, 800);
-        },
+        () => showCopiedFloat(button),
         (err) => {
           console.error('Failed to copy:', err);
         },
@@ -128,7 +148,14 @@ export function ArticleContent({ html }: ArticleContentProps) {
     const hash = window.location.hash;
     if (!hash) return;
 
-    const id = hash.slice(1);
+    // location.hash はパーセントエンコードされたまま返るため、
+    // 日本語見出し ID と突き合わせるにはデコードが必要
+    let id: string;
+    try {
+      id = decodeURIComponent(hash.slice(1));
+    } catch {
+      id = hash.slice(1);
+    }
     let attempts = 0;
     const maxAttempts = 10;
     let timerId: ReturnType<typeof setTimeout> | null = null;

--- a/apps/web/src/components/TableOfContents.tsx
+++ b/apps/web/src/components/TableOfContents.tsx
@@ -1,51 +1,214 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
-import type tocbotModule from 'tocbot';
+import type { MouseEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+interface TocHeading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+interface TocNode extends TocHeading {
+  children: TocNode[];
+}
+
+// tocbot 相当の追従判定オフセット。見出しがこのラインを越えたらアクティブ扱い
+const HEADINGS_OFFSET = 100;
+
+// location.hash はパーセントエンコードされたまま返るため、
+// 日本語見出し ID と突き合わせるにはデコードが必要
+function decodeHashId(hash: string): string {
+  try {
+    return decodeURIComponent(hash.replace(/^#/, ''));
+  } catch {
+    return hash.replace(/^#/, '');
+  }
+}
+
+function buildTree(headings: TocHeading[]): TocNode[] {
+  const root: TocNode[] = [];
+  const stack: { level: number; children: TocNode[] }[] = [{ level: 0, children: root }];
+  for (const heading of headings) {
+    const node: TocNode = { ...heading, children: [] };
+    while (stack.length > 1 && heading.level <= stack[stack.length - 1].level) {
+      stack.pop();
+    }
+    stack[stack.length - 1].children.push(node);
+    stack.push({ level: heading.level, children: node.children });
+  }
+  return root;
+}
+
+function TocList({ nodes, activeId }: { nodes: TocNode[]; activeId: string | null }) {
+  return (
+    <ol className="toc-list">
+      {nodes.map((node, index) => (
+        <li
+          key={`${node.id}-${index}`}
+          className={node.id === activeId ? 'toc-list-item is-active-li' : 'toc-list-item'}
+        >
+          <a
+            className={node.id === activeId ? 'toc-link is-active-link' : 'toc-link'}
+            href={`#${node.id}`}
+          >
+            {node.text}
+          </a>
+          {node.children.length > 0 && <TocList nodes={node.children} activeId={activeId} />}
+        </li>
+      ))}
+    </ol>
+  );
+}
 
 export function TableOfContents() {
-  const tocbotRef = useRef<typeof tocbotModule | null>(null);
+  const [headings, setHeadings] = useState<TocHeading[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const mobileListRef = useRef<HTMLDivElement>(null);
+  const desktopRef = useRef<HTMLDivElement>(null);
 
+  // 本文はツイート埋め込みで複数の .prose に分割されるため、全体を包むラッパーを見る
   useEffect(() => {
-    const initTocbot = async () => {
-      // 本文はツイート埋め込みで複数の .prose に分割されるため、全体を包むラッパーを見る
-      const content = document.querySelector('.article-content-wrapper');
-      if (!content) return;
+    const content = document.querySelector('.article-content-wrapper');
+    if (!content) return;
 
-      const headings = content.querySelectorAll('h1, h2, h3');
-      if (headings.length === 0) return;
-
-      // Ensure all headings have IDs
-      headings.forEach((heading, index) => {
-        if (!heading.id) {
-          heading.id = `heading-${index}`;
-        }
+    const elements = content.querySelectorAll('h1, h2, h3');
+    const items: TocHeading[] = [];
+    elements.forEach((element, index) => {
+      // 旧コンバータ時代の content_html は見出しに ID が無いためフォールバックを振る
+      if (!element.id) {
+        element.id = `heading-${index}`;
+      }
+      // 見出し内のアンカー要素（heading-anchor の # と comrak の空 anchor）はラベルに含めない
+      const text = Array.from(element.childNodes)
+        .filter(
+          (node) =>
+            !(
+              node instanceof Element &&
+              (node.classList.contains('heading-anchor') || node.classList.contains('anchor'))
+            ),
+        )
+        .map((node) => node.textContent ?? '')
+        .join('')
+        .trim();
+      items.push({
+        id: element.id,
+        text,
+        level: Number(element.tagName.charAt(1)),
       });
-
-      // Dynamic import tocbot
-      const tocbot = (await import('tocbot')).default;
-      tocbotRef.current = tocbot;
-
-      tocbot.init({
-        tocSelector: '.toc',
-        contentSelector: '.article-content-wrapper',
-        headingSelector: 'h1, h2, h3',
-        scrollSmooth: false,
-        headingsOffset: 100,
-        scrollSmoothOffset: 0,
-      });
-    };
-
-    // Wait for layout to stabilize
-    const timer = setTimeout(() => {
-      void initTocbot();
-    }, 300);
-
-    return () => {
-      clearTimeout(timer);
-      tocbotRef.current?.destroy();
-    };
+    });
+    setHeadings(items);
   }, []);
 
-  return <div className="toc" />;
+  // スクロール位置からアクティブ見出しを追従する
+  useEffect(() => {
+    if (headings.length === 0) return;
+
+    let rafId = 0;
+    const update = () => {
+      rafId = 0;
+
+      // ページ最下部で止まった場合、スクロールでは到達できない見出しでも
+      // hash が指していればそちらを優先してアクティブにする
+      const atBottom =
+        window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 2;
+      if (atBottom) {
+        const hashId = decodeHashId(window.location.hash);
+        if (hashId && headings.some((h) => h.id === hashId)) {
+          setActiveId(hashId);
+          return;
+        }
+      }
+
+      let currentId: string | null = null;
+      for (const heading of headings) {
+        const element = document.getElementById(heading.id);
+        if (!element) continue;
+        if (element.getBoundingClientRect().top <= HEADINGS_OFFSET) {
+          currentId = heading.id;
+        } else {
+          break;
+        }
+      }
+      setActiveId(currentId ?? headings[0].id);
+    };
+
+    const onScroll = () => {
+      if (rafId) return;
+      rafId = requestAnimationFrame(update);
+    };
+
+    update();
+    document.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    return () => {
+      if (rafId) cancelAnimationFrame(rafId);
+      document.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+    };
+  }, [headings]);
+
+  // アクティブ項目が目次ペインの表示範囲外に出たらペイン内スクロールで追従する
+  // （scrollIntoView はページ側まで動かすことがあるため scrollTop を直接調整する）
+  useEffect(() => {
+    const pane = desktopRef.current;
+    const link = pane?.querySelector('.is-active-link');
+    if (!pane || !link) return;
+
+    const paneRect = pane.getBoundingClientRect();
+    const linkRect = link.getBoundingClientRect();
+    if (linkRect.top < paneRect.top) {
+      pane.scrollTop += linkRect.top - paneRect.top;
+    } else if (linkRect.bottom > paneRect.bottom) {
+      pane.scrollTop += linkRect.bottom - paneRect.bottom;
+    }
+  }, [activeId]);
+
+  // クリック直後にアクティブを確定させる（スクロール追従を待つとちらつくため）
+  const handleTocClick = (event: MouseEvent) => {
+    const link = (event.target as Element).closest('a');
+    if (!link) return;
+    setActiveId(decodeHashId(link.getAttribute('href') ?? ''));
+  };
+
+  // 見出しへ移動したらモーダルを閉じて本文を見せる。背景クリックでも閉じる
+  const handleDialogClick = (event: MouseEvent) => {
+    handleTocClick(event);
+    if (event.target === dialogRef.current || (event.target as Element).closest('a')) {
+      dialogRef.current?.close();
+    }
+  };
+
+  const tree = buildTree(headings);
+
+  return (
+    <>
+      <button
+        type="button"
+        className="toc-mobile-trigger"
+        aria-label="目次を開く"
+        onClick={() => {
+          dialogRef.current?.showModal();
+          // dialog は最初のリンクへ自動フォーカスし、block リンクの
+          // フォーカスリングが下線のように見えるため、リスト全体へ移す
+          mobileListRef.current?.focus();
+        }}
+      >
+        目次
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden>
+          <path d="M4 6l4 4 4-4" />
+        </svg>
+      </button>
+      <dialog ref={dialogRef} className="toc-mobile-dialog" onClick={handleDialogClick}>
+        {/* biome-ignore lint/a11y/noNoninteractiveTabindex: dialog 内の初期フォーカス受け皿 */}
+        <div ref={mobileListRef} tabIndex={-1} className="toc toc-mobile-list">
+          {tree.length > 0 && <TocList nodes={tree} activeId={activeId} />}
+        </div>
+      </dialog>
+      <div ref={desktopRef} className="toc toc-desktop" onClick={handleTocClick}>
+        {tree.length > 0 && <TocList nodes={tree} activeId={activeId} />}
+      </div>
+    </>
+  );
 }

--- a/apps/web/src/components/__fixtures__/articleFullHtml.ts
+++ b/apps/web/src/components/__fixtures__/articleFullHtml.ts
@@ -8,7 +8,7 @@
  * のうえで、このファイルのテンプレートリテラル部分を差し替える。
  */
 export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプル記事です。本文には <strong>太字</strong>、<em>斜体</em>、<del>取り消し線</del>、<code>inline code</code>、<a href="https://zenn.dev" target="_blank" rel="noopener noreferrer">外部リンク</a>、<a href="/shuntaka/articles/sample">内部リンク</a> といったインライン要素を含みます。</p>
-<h2 id="テキストとリスト">テキストとリスト<a href="#テキストとリスト" aria-label="Link to heading 'テキストとリスト'" data-heading-content="テキストとリスト" class="anchor"></a></h2>
+<h2 id="テキストとリスト"><a class="heading-anchor" href="#テキストとリスト" aria-label="この見出しへのリンクをコピー">#</a>テキストとリスト<a href="#テキストとリスト" aria-label="Link to heading 'テキストとリスト'" data-heading-content="テキストとリスト" class="anchor"></a></h2>
 <ul>
 <li>箇条書きリスト</li>
 <li>2 つ目の項目
@@ -25,7 +25,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 <li><input type="checkbox" checked="" disabled="" /> 完了したタスク</li>
 <li><input type="checkbox" disabled="" /> 未完了のタスク</li>
 </ul>
-<h2 id="テーブルと引用">テーブルと引用<a href="#テーブルと引用" aria-label="Link to heading 'テーブルと引用'" data-heading-content="テーブルと引用" class="anchor"></a></h2>
+<h2 id="テーブルと引用"><a class="heading-anchor" href="#テーブルと引用" aria-label="この見出しへのリンクをコピー">#</a>テーブルと引用<a href="#テーブルと引用" aria-label="Link to heading 'テーブルと引用'" data-heading-content="テーブルと引用" class="anchor"></a></h2>
 <table>
 <thead>
 <tr>
@@ -53,7 +53,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 引用のサンプルです。</p>
 </blockquote>
 <hr />
-<h2 id="コードブロック">コードブロック<a href="#コードブロック" aria-label="Link to heading 'コードブロック'" data-heading-content="コードブロック" class="anchor"></a></h2>
+<h2 id="コードブロック"><a class="heading-anchor" href="#コードブロック" aria-label="この見出しへのリンクをコピー">#</a>コードブロック<a href="#コードブロック" aria-label="Link to heading 'コードブロック'" data-heading-content="コードブロック" class="anchor"></a></h2>
 <p>言語指定なし</p>
 <pre style="background-color:#2b303b;"><code><span style="color:#c0c5ce;">ls -al
 </span></code></pre>
@@ -70,7 +70,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 </span><span style="color:#c0c5ce;">    println!(&quot;</span><span style="color:#d08770;">{}</span><span style="color:#c0c5ce;">&quot;, converter.</span><span style="color:#96b5b4;">convert</span><span style="color:#c0c5ce;">(&quot;</span><span style="color:#a3be8c;"># Hello</span><span style="color:#c0c5ce;">&quot;));
 </span><span style="color:#c0c5ce;">}
 </span></code></pre>
-<h2 id="メッセージ">メッセージ<a href="#メッセージ" aria-label="Link to heading 'メッセージ'" data-heading-content="メッセージ" class="anchor"></a></h2>
+<h2 id="メッセージ"><a class="heading-anchor" href="#メッセージ" aria-label="この見出しへのリンクをコピー">#</a>メッセージ<a href="#メッセージ" aria-label="Link to heading 'メッセージ'" data-heading-content="メッセージ" class="anchor"></a></h2>
 <div class="message "><p>デフォルトのメッセージです。補足情報や注意喚起に使います。</p>
 </div>
 <div class="message info"><p>info メッセージです。</p>
@@ -81,7 +81,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 </div>
 <div class="message error"><p>error メッセージです。</p>
 </div>
-<h2 id="アコーディオン">アコーディオン<a href="#アコーディオン" aria-label="Link to heading 'アコーディオン'" data-heading-content="アコーディオン" class="anchor"></a></h2>
+<h2 id="アコーディオン"><a class="heading-anchor" href="#アコーディオン" aria-label="この見出しへのリンクをコピー">#</a>アコーディオン<a href="#アコーディオン" aria-label="Link to heading 'アコーディオン'" data-heading-content="アコーディオン" class="anchor"></a></h2>
 <details><summary>実装の詳細を見る</summary><div class="details-content"><p>折りたたみの中にも Markdown を書けます。</p>
 <ul>
 <li>リスト項目</li>
@@ -90,9 +90,9 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 <pre lang="bash" style="background-color:#2b303b;"><code><span style="color:#8fa1b3;">bun</span><span style="color:#c0c5ce;"> run storybook
 </span></code></pre>
 </div></details>
-<h2 id="画像">画像<a href="#画像" aria-label="Link to heading '画像'" data-heading-content="画像" class="anchor"></a></h2>
+<h2 id="画像"><a class="heading-anchor" href="#画像" aria-label="この見出しへのリンクをコピー">#</a>画像<a href="#画像" aria-label="Link to heading '画像'" data-heading-content="画像" class="anchor"></a></h2>
 <p><img src="https://res.cloudinary.com/dkerzyk09/image/upload/v1767101809/blog/og/shuntaka.png" alt="shuntaka.dev の OGP 画像" /></p>
-<h2 id="github-埋め込み">GitHub 埋め込み<a href="#github-埋め込み" aria-label="Link to heading 'GitHub 埋め込み'" data-heading-content="GitHub 埋め込み" class="anchor"></a></h2>
+<h2 id="github-埋め込み"><a class="heading-anchor" href="#github-埋め込み" aria-label="この見出しへのリンクをコピー">#</a>GitHub 埋め込み<a href="#github-埋め込み" aria-label="Link to heading 'GitHub 埋め込み'" data-heading-content="GitHub 埋め込み" class="anchor"></a></h2>
 <p>1 行指定</p>
 <div class="github-embed-card">
 <div class="github-embed-header">
@@ -206,7 +206,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 </span><span style="color:#c0c5ce;">PostgreSQLを起動</span></pre>
 </div>
 </div>
-<h2 id="リンクカード">リンクカード<a href="#リンクカード" aria-label="Link to heading 'リンクカード'" data-heading-content="リンクカード" class="anchor"></a></h2>
+<h2 id="リンクカード"><a class="heading-anchor" href="#リンクカード" aria-label="この見出しへのリンクをコピー">#</a>リンクカード<a href="#リンクカード" aria-label="Link to heading 'リンクカード'" data-heading-content="リンクカード" class="anchor"></a></h2>
 <div class="link-card-wrapper"><a href="https://shuntaka.dev" target="_blank" rel="noopener noreferrer" class="link-card" target="_blank" rel="noopener noreferrer"><div class="link-card-content"><div class="link-card-text"><div class="link-card-title">shuntaka.dev</div><div class="link-card-description">shuntaka.devは、技術・開発・ガジェットについてshuntakaが思ったことをシェアするブログです。</div></div><div class="link-card-image"><img src="https://res.cloudinary.com/dkerzyk09/image/upload/v1767101809/blog/og/shuntaka.png" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div></div><div class="link-card-footer"><img class="link-card-favicon" src="https://shuntaka.dev/icons/icon.png" alt="" onerror="this.style.display='none'"><span class="link-card-domain">shuntaka.dev</span></div></a></div>
 <div class="link-card-wrapper"><a href="https://shuntaka.dev/shuntaka/articles/20251224-reflecting-on-2025" target="_blank" rel="noopener noreferrer" class="link-card" target="_blank" rel="noopener noreferrer"><div class="link-card-content"><div class="link-card-text"><div class="link-card-title">2025年の振り返り</div><div class="link-card-description">皆様2025年お疲れさまでした！毎年恒例の振り返りをしました！</div></div><div class="link-card-image"><img src="https://res.cloudinary.com/dkerzyk09/image/upload/v1767101809/blog/og/shuntaka.png" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div></div><div class="link-card-footer"><img class="link-card-favicon" src="https://shuntaka.dev/icons/icon.png" alt="" onerror="this.style.display='none'"><span class="link-card-domain">shuntaka.dev</span></div></a></div>
 <div class="link-card-wrapper"><a href="https://shuntaka.dev/shuntaka/articles/20260108-shuntaka-blog-rearchitecture" target="_blank" rel="noopener noreferrer" class="link-card" target="_blank" rel="noopener noreferrer"><div class="link-card-content"><div class="link-card-text"><div class="link-card-title">Rust(axum) on Lambda × Aurora DSQL × Next.js on Vercelで個人ブログをリーアーキした話</div><div class="link-card-description">2020年にNode.js on Lambda × DynamoDB × Next.js on Vercelで運用していたブログのアーキテクチャを刷新しました！</div></div><div class="link-card-image"><img src="https://res.cloudinary.com/dkerzyk09/image/upload/s--z-0zbcS9--/c_fit,co_rgb:525457,l_text:notesansjpmid.otf_48_bold:Rust%28axum%29%20on%20Lambda%20%C3%97%20Aurora%20DSQL%20%C3%97%20Next.js%20on%20Vercel%E3%81%A7%E5%80%8B%E4%BA%BA%E3%83%96%E3%83%AD%E3%82%B0%E3%82%92%E3%83%AA%E3%83%BC%E3%82%A2%E3%83%BC%E3%82%AD%E3%81%97%E3%81%9F%E8%A9%B1,w_600/v1/blog/og/ogp.webp" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div></div><div class="link-card-footer"><img class="link-card-favicon" src="https://shuntaka.dev/icons/icon.png" alt="" onerror="this.style.display='none'"><span class="link-card-domain">shuntaka.dev</span></div></a></div>
@@ -216,7 +216,7 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 #527
 この記法でSpeakerDeckで表示したいスライドの番号を指定し、表示します。
 @[speakerdeck](f005615e42d84c9b8bdb7fd722cbb...</div></div><div class="link-card-image"><img src="https://opengraph.githubassets.com/ad0bc4a3380f0940d2e82cce8f544cb2b51eae79ef186b2ac3b2dfb6333da8c4/zenn-dev/zenn-editor/pull/528" alt="" loading="lazy" onerror="this.parentElement.style.display='none'"></div></div><div class="link-card-footer"><img class="link-card-favicon" src="https://github.githubassets.com/favicons/favicon.svg" alt="" onerror="this.style.display='none'"><span class="link-card-domain">github.com</span></div></a></div>
-<h2 id="x-ポスト埋め込み">X ポスト埋め込み<a href="#x-ポスト埋め込み" aria-label="Link to heading 'X ポスト埋め込み'" data-heading-content="X ポスト埋め込み" class="anchor"></a></h2>
+<h2 id="x-ポスト埋め込み"><a class="heading-anchor" href="#x-ポスト埋め込み" aria-label="この見出しへのリンクをコピー">#</a>X ポスト埋め込み<a href="#x-ポスト埋め込み" aria-label="Link to heading 'X ポスト埋め込み'" data-heading-content="X ポスト埋め込み" class="anchor"></a></h2>
 <p>通常</p>
 <div data-tweet-id="2005455430907216136"></div>
 <p>画像</p>
@@ -227,9 +227,9 @@ export const ARTICLE_FULL_HTML = `<p>この記事は Storybook 用のサンプ�
 <div data-tweet-id="2007325737725084022"></div>
 <p>引用 + 画像</p>
 <div data-tweet-id="2007605987881169264"></div>
-<h2 id="speakerdeck-埋め込み">SpeakerDeck 埋め込み<a href="#speakerdeck-埋め込み" aria-label="Link to heading 'SpeakerDeck 埋め込み'" data-heading-content="SpeakerDeck 埋め込み" class="anchor"></a></h2>
+<h2 id="speakerdeck-埋め込み"><a class="heading-anchor" href="#speakerdeck-埋め込み" aria-label="この見出しへのリンクをコピー">#</a>SpeakerDeck 埋め込み<a href="#speakerdeck-埋め込み" aria-label="Link to heading 'SpeakerDeck 埋め込み'" data-heading-content="SpeakerDeck 埋め込み" class="anchor"></a></h2>
 <div class="block-embed-service-speakerdeck"><iframe class="speakerdeck-iframe" frameborder="0" src="https://speakerdeck.com/player/ceec399cc51849d0889601c597dd030b?slide=1" allowfullscreen="true" style="border: 0px; background: padding-box padding-box rgba(0, 0, 0, 0.1); margin: 0px; padding: 0px; border-radius: 6px; box-shadow: rgba(0, 0, 0, 0.2) 0px 5px 40px; width: 100%; height: auto; aspect-ratio: 560/420;" data-ratio="1.3"></iframe></div>
-<h2 id="脚注">脚注<a href="#脚注" aria-label="Link to heading '脚注'" data-heading-content="脚注" class="anchor"></a></h2>
+<h2 id="脚注"><a class="heading-anchor" href="#脚注" aria-label="この見出しへのリンクをコピー">#</a>脚注<a href="#脚注" aria-label="Link to heading '脚注'" data-heading-content="脚注" class="anchor"></a></h2>
 <p>本文中に脚注<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup>を書けます。名前付きの脚注<sup class="footnote-ref"><a href="#fn-note" id="fnref-note" data-footnote-ref>2</a></sup>や、リンクを含む脚注<sup class="footnote-ref"><a href="#fn-2" id="fnref-2" data-footnote-ref>3</a></sup>も使えます。</p>
 <section class="footnotes" data-footnotes>
 <span class="footnotes-title">脚注</span>

--- a/bun.lock
+++ b/bun.lock
@@ -95,7 +95,6 @@
         "react-dom": "^19.2.8",
         "react-tweet": "^3.3.1",
         "rss": "^1.2.2",
-        "tocbot": "^4.36.8",
       },
       "devDependencies": {
         "@next/env": "16.2.11",
@@ -2391,8 +2390,6 @@
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
-
-    "tocbot": ["tocbot@4.36.8", "", {}, "sha512-TpN+Z2YP4DTboeZ3GkUjzkjmG5NhJhXTVuH9EWQ/F4HgONVje9GZ8eNZE4kk88umV5o7hm3faS+eF/7qYwsP2w=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 

--- a/docs/source/98_tasks/2026-07-22-toc-heading-anchor-rework/index.md
+++ b/docs/source/98_tasks/2026-07-22-toc-heading-anchor-rework/index.md
@@ -1,0 +1,76 @@
+<!-- cspell:ignore tocbot backfill -->
+
+# 目次の刷新（tocbot 撤去）+ 見出しアンカー（# リンクコピー）追加
+
+- 起票日: 2026-07-22
+- 対象: `apps/web`, `apps/blog-api/markdown`, `tools/content-html-backfill`
+- ステータス: 対応済み（prd の backfill のみ残）
+
+## 起票理由
+
+目次まわりに複数の問題が重なっていた。
+
+1. **目次のインデントが分かりにくい**: tocbot が生成する入れ子 `ol` の左パディングを Tailwind preflight がリセットしており、階層の違いがマーカーサイズ（8px/6px/4px）でしか表現されていなかった
+2. **hash 付き URL での自動スクロールが機能しない**: `ArticleContent` の初期 hash スクロール処理が `location.hash`（パーセントエンコード済み）をデコードせずに `getElementById` へ渡しており、日本語見出し ID では常に `null`。普段はブラウザネイティブのフラグメントスクロールが隠していたが、ロード完了後にコンテンツがストリーミングされるケースで露見する
+3. **目次クリック後にハイライトが外れる**: tocbot の `updateToc` が `location.hash`（エンコード済み）と DOM の `href`（未エンコード）を比較するため、日本語 ID では照合に失敗し、クリック直後のスクロールイベントでアクティブ表示が全部剥がれる（本番で再現確認済み）
+4. **モバイルで目次が出ない**: 1024px 以下は `right-sidebar` ごと `display: none` だった
+5. **ローカル（dev DB）で目次リンクが `#heading-N` になる**: dev DB の `content_html` が旧コンバータ（見出し ID 生成なし）時代の保存値のままで、フロントのフォールバック ID が振られていた。コード差ではなく保存データの世代差
+6. **見出しリンクのコピー手段がない**: 見出し先頭に `#` を置き、クリックで共有用 URL をコピーしたい
+
+## 設計方針
+
+| 論点                     | 決定                                                                                                                                                                                                                                                                                                                                         |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| tocbot の扱い            | 撤去して自前実装（約 120 行）。日本語 ID の encode/decode バグ・singleton 制約（モバイル用に DOM 複製が必要）・`window.onhashchange` 等のグローバル上書きが理由                                                                                                                                                                              |
+| アクティブ追従           | rAF スロットルの scroll リスナーで「オフセット 100px を越えた最後の見出し」を選択。ページ最下部ではデコード済み hash の見出しを優先（スクロール到達不能な見出し対策）                                                                                                                                                                        |
+| モバイル目次             | 1024px 以下は右上に sticky 固定した「目次」ボタン（`right-sidebar` を `display: contents` にして `.article-body` 基準で貼り付け）。タップで native `<dialog>` をボタン直下に表示し、項目タップ・背景タップで閉じる。`showModal()` の自動フォーカスがリンクに当たるとリングが下線に見えるため、`tabindex="-1"` のリスト全体へフォーカスを移す |
+| 階層の表現               | ファイルツリー風の連続罫線（角丸 L 字コネクタ）を CSS で描画。`├──` などの文字だと行間 1.7 で縦線が途切れて見えるため文字は使わない                                                                                                                                                                                                          |
+| 見出しアンカーの実装場所 | markdown クレート（Rust）の後処理で `<a class="heading-anchor" href="#id">#</a>` を見出し先頭に挿入。コピー動作はフロント（`ArticleContent`）で実装                                                                                                                                                                                          |
+| コピーの挙動             | クリックで `preventDefault` → `history.pushState` で hash のみ更新（ジャンプなし）→ エンコード済み絶対 URL をクリップボードへ → `Copied!` フロート表示                                                                                                                                                                                       |
+| 既存記事への反映         | `tools/content-html-backfill` を `--all` で実行して `content_html` を再生成（`updated_at` は変わらない）                                                                                                                                                                                                                                     |
+
+## 実装フェーズ
+
+- [x] Phase A: 目次インデントの CSS 改善（階層ごとの段下げ）
+- [x] Phase B: `ArticleContent` の hash デコード修正
+- [x] Phase C: tocbot 撤去 → 自前 TOC（デスクトップ追従 + モバイルアコーディオン）
+- [x] Phase D: 見出しアンカー（Rust 後処理 + フロントのコピー処理 + CSS）
+- [x] Phase E: Storybook フィクスチャ再生成・検証
+- [x] Phase F: dev DB へ backfill 実行
+- [ ] Phase G: API デプロイ後、prd へ backfill 実行
+
+## backfill 手順
+
+markdown クレート変更を含む API を**デプロイした後**に実行する（保存値と API 生成値の世代を揃えるため）。
+
+```sh
+cd tools/content-html-backfill
+
+# wasm を最新のコンバータでビルド
+bun run build:wasm
+
+TAILNET=$(tailscale status --json | jq -r '.MagicDNSSuffix')
+
+# dry-run で差分件数を確認（新規 / 一致 / 差分あり）
+bun run backfill -- --endpoint "mysql://root@tidb.${TAILNET}:4000/blog_dev" --all --dry-run
+
+# 実行（一致はスキップされる）
+bun run backfill -- --endpoint "mysql://root@tidb.${TAILNET}:4000/blog_dev" --all
+```
+
+prd は endpoint の database を `blog_prd` に変えて同じ手順。
+
+## 作業ログ
+
+### 2026-07-22
+
+- 目次インデント改善: `.toc ol ol a` / `.toc ol ol ol a` に段下げを追加（Tailwind preflight が `ol` の padding を消すため明示指定）
+- hash スクロール不全の原因特定: `location.hash` はエンコード済みで返る。`decodeURIComponent` を挟んで修正
+- tocbot のハイライト剥がれを本番で再現（下部見出しクリック → 150ms 後に `is-active-li` が全消失）。tocbot 内部の `updateToc` がエンコード済み hash と未エンコード href を比較しているのが原因で、修正不能と判断し撤去
+- `TableOfContents` を自前実装に置換。tocbot を `package.json` から削除
+- 見出しアンカーを `add_heading_anchors`（markdown クレートの後処理）として実装。comrak が見出し末尾に付ける空の `a.anchor` はそのまま残している（不可視・無害）
+- Storybook フィクスチャを `cargo run -p markdown --example storybook_fixture` で再生成
+- dev DB へ backfill 実行: 134 件処理（更新 100 / 一致スキップ 34 / 失敗 0）。dev で目次リンクが `#heading-N` になっていた問題はこれで解消（旧コンバータ世代の保存値に見出し ID が無かったのが原因）
+- モバイル目次を上部 sticky 固定に変更。`position: sticky` の基準を記事全体を含む `.article-body` に取らせるため、ラッパー `.right-sidebar` を `display: contents` で消す方式にした
+- モバイル目次をアコーディオンから「右上固定の目次ボタン + ボタン直下のモーダル（native `<dialog>`）」へ変更。`showModal()` が最初のリンクへ自動フォーカスしてリングが全幅の下線に見えるバグは、`tabindex="-1"` のリスト全体へフォーカスを移して解消
+- 目次の階層表現を四角マーカー + 縦レールからファイルツリー風の連続罫線（角丸 L 字コネクタ、CSS 描画）へ変更。`├──` 文字案は行間で縦線が途切れるため不採用。レールが最後の項目より下へはみ出す問題もレール廃止で解消

--- a/docs/source/98_tasks/index.md
+++ b/docs/source/98_tasks/index.md
@@ -7,6 +7,7 @@
 | 起票日     | タイトル                                                                                                                                                          |
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 0000-00-00 | [タイトル](0000-00-00-topic/index.md)                                                                                                                             |
+| 2026-07-22 | [目次の刷新（tocbot 撤去）+ 見出しアンカー（# リンクコピー）追加](2026-07-22-toc-heading-anchor-rework/index.md)                                                  |
 | 2026-07-18 | [ベクトル検索ページネーションの破綻分析と pre-filter exact 方式への再設計](2026-07-18-vector-search-pagination-redesign/index.md)                                 |
 | 2026-07-18 | [PLaMo Embedding の投入後メモリ滞留 (glibc malloc) を jemalloc で解消](2026-07-18-plamo-embedding-jemalloc/index.md)                                              |
 | 2026-07-17 | [apps/web: 日本語 Web フォント撤去（Zenn 方式へ移行）](2026-07-17-web-system-font-migration/index.md)                                                             |


### PR DESCRIPTION
## 概要

- 目次（TOC）を tocbot から自前実装へ刷新し、日本語見出しIDで起きていた自動スクロール不全・クリック後にハイライトが外れるバグを解消
- モバイル（1024px以下）に目次を追加。右上に sticky 固定した「目次」ボタンからボタン直下のモーダルで表示
- 見出し先頭に `#` アンカーを追加し、クリックで共有用 URL をコピーできるようにする（Rust コンバータ + フロント）

## 変更詳細

### apps/web
- `TableOfContents.tsx`: tocbot を撤去して自前実装に置換
  - アクティブ追従は rAF スロットルの scroll リスナー。ページ最下部ではデコード済み hash の見出しを優先（スクロール到達不能な見出し対策）
  - tocbot は `location.hash`（エンコード済み）と DOM の href（未エンコード）を比較するため日本語IDで照合に失敗し、クリック直後にハイライトが全部剥がれていた（本番で再現確認済み）
  - モバイルは native `<dialog>`。`showModal()` の自動フォーカスでリンクにリングが出る問題は `tabindex="-1"` のリスト全体へフォーカスを移して回避
- `ArticleContent.tsx`: hash スクロールを `decodeURIComponent` で修正（日本語見出しIDでは `getElementById` が常に null だった）。見出しアンカーのクリックでリンクコピー + `Copied!` フロート表示
- `globals.css`: 目次の階層をファイルツリー風の連続罫線（角丸 L 字コネクタ、CSS 描画）で表現。見出しアンカーのスタイル追加
- Storybook フィクスチャを新コンバータ出力で再生成
- `package.json` / `bun.lock`: tocbot を削除

### apps/blog-api/markdown
- `add_heading_anchors`: 見出し先頭に `<a class="heading-anchor" href="#id">#</a>` を挿入する後処理を追加（テスト2件追加、60 tests pass）

### docs
- `docs/source/98_tasks/2026-07-22-toc-heading-anchor-rework/`: 経緯・設計方針・backfill 手順を記録

## テスト

- [x] `cargo test -p markdown`（60 pass）/ `cargo clippy`
- [x] `bun run lint` / `bun run spell-check` / `bun run type-check` / web テスト（39 pass）
- [x] Storybook + ローカル dev + 本番相当でブラウザ検証（デスクトップ追従・最下部クリック・モバイルモーダル・リンクコピー・hash 付き URL ロード）
- [x] dev DB へ backfill 実行済み（134件処理: 更新100 / 一致スキップ34 / 失敗0）

## 残作業（マージ後）

- API デプロイ後に prd (`blog_prd`) へ backfill 実行（手順は 98_tasks 参照）
