### PR TITLE
chore(renovate): patch/minor のPR作成を月曜午前の週1バッチに変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -52,7 +52,12 @@
   ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["patch", "minor", "major"],
+      "description": "patch/minor は月曜午前の週1バッチでPR作成（平日の割り込み削減。脆弱性対応は vulnerabilityAlerts で即時のまま）",
+      "matchUpdateTypes": ["patch", "minor"],
+      "schedule": ["before 9am on monday"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
       "schedule": ["at any time"]
     },
     {


### PR DESCRIPTION
## 概要

Renovate の patch/minor 更新PRが平日随時作成されて捌くのが大変なため、非major更新のPR作成を月曜午前（Asia/Tokyo, before 9am）の週1バッチに変更する。

## 変更内容

- `matchUpdateTypes: [patch, minor]` の schedule を `at any time` から `before 9am on monday` に変更
- major は従来どおり `at any time`（頻度が低く、個別レビューしたいため）
- 脆弱性対応 (`vulnerabilityAlerts`) は従来どおり即時作成のまま

## 補足

今回は対象外としたが、以下も別途検討の余地あり。

- `Group root dependencies` の `matchFileNames: ["./package.json"]` はパスにマッチしておらず機能していない（turbo / prettier / secretlint が個別PRになったのはこのため）。`"package.json"` に直すとルート依存が1本にまとまる
- apps/admin-web / apps/admin-api のグループ未定義
- patch/minor の automerge 化（その場合 `ignoreTests: true` はCIを待たずマージする挙動になるため要削除）