### PR TITLE
docs: shuntaka-preview.nvim の lazy.nvim 導入例を config での rtp 追加に修正

### DIFF
--- a/docs/source/01_開発ドキュメント/01_development.md
+++ b/docs/source/01_開発ドキュメント/01_development.md
@@ -837,17 +837,15 @@ bun run build:wasm
 git add pkg
 ```
 
-lazy.nvim はモノレポのサブディレクトリを直接プラグイン扱いできないため、`init` で runtimepath に追加する。
+lazy.nvim はモノレポのサブディレクトリを直接プラグイン扱いできないため、`config` の require 直前で runtimepath に追加する（`init` での追加はスペック追加後の初回セッションでインストールが init フェーズより後に走るため間に合わない）。
 
 ```lua
 {
   "shuntaka9576/shuntaka-dev",
   name = "shuntaka-preview.nvim",
   cmd = { "ShuntakaPreview", "ShuntakaPreviewStop" },
-  init = function(plugin)
+  config = function(plugin)
     vim.opt.rtp:append(plugin.dir .. "/tools/shuntaka-preview.nvim")
-  end,
-  config = function()
     require("shuntaka-preview").setup({})
   end,
 }

--- a/tools/shuntaka-preview.nvim/CLAUDE.md
+++ b/tools/shuntaka-preview.nvim/CLAUDE.md
@@ -45,7 +45,7 @@ bun run serve
 
 - wasm の公開 API は `collectResourceUrls` / `convertMarkdownWithResources` の 2 つ（2 パス方式）。wasm 内で同期 HTTP ができないため、fetch は TS 側で行う。content-html-backfill と同じパターン
 - `pkg/` はコミットする方針（content-html-backfill は毎回ビルドするので gitignore、こちらは導入マシンに Rust toolchain を要求しないため）。`build:wasm` が wasm-pack の自動生成する `pkg/.gitignore` を削除する
-- lazy.nvim はモノレポのサブディレクトリを直接扱えないため、spec の `init` で `vim.opt.rtp:append(plugin.dir .. "/tools/shuntaka-preview.nvim")` する。`plugin/` ディレクトリは作らず、コマンド登録は `setup()` で行う
+- lazy.nvim はモノレポのサブディレクトリを直接扱えないため、spec の `config` で require の直前に `vim.opt.rtp:append(plugin.dir .. "/tools/shuntaka-preview.nvim")` する（`init` での追加は初回インストールセッションで間に合わない）。`plugin/` ディレクトリは作らず、コマンド登録は `setup()` で行う
 - プレビューは記事ページのラッパー構造 (`article-content > article-content-wrapper > .prose`) のみ再現。article-header や目次等のサイト chrome、X ポスト埋め込み (react-tweet) は対象外
 - ダークモードは `data-theme` を触らず `prefers-color-scheme` 任せ（本番の未設定時デフォルトと同じ挙動）
 


### PR DESCRIPTION
## 概要

- shuntaka-preview.nvim の lazy.nvim 導入例を `config` での rtp 追加に修正 (#725 のフォローアップ)

## 背景

`init` での rtp append はスペック追加後の初回セッションでプラグインのインストールが init フェーズより後に走るため間に合わず、`config` の require が module not found で失敗する。require 直前 (`config`) で append する方式に改め、headless Neovim + lazy.nvim で実クローンに対しロード成功を確認済み。

対象: `docs/source/01_開発ドキュメント/01_development.md` の導入例と `tools/shuntaka-preview.nvim/CLAUDE.md` の Design Notes。

https://claude.ai/code/session_01MLWNqQ9BQ3xNeYb8TLcHH6
