### PR TITLE
feat: プレビューの記事一覧の日付を git コミット日時ベースに変更

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -320,6 +320,7 @@
     "pymysql",
     "pypi",
     "qlapi",
+    "quotepath",
     "rdbms",
     "rearchitecture",
     "relabelings",

--- a/docs/source/01_開発ドキュメント/01_development.md
+++ b/docs/source/01_開発ドキュメント/01_development.md
@@ -833,7 +833,7 @@ bun run backfill -- --endpoint mysql://root@tidb.$TAILNET:4000/blog_dev --all --
 
 ブログと同じ変換ロジック（`apps/blog-api/markdown` crate を wasm 化したもの）で Markdown をローカルプレビューする Neovim プラグイン。バッファ変更のライブ反映、カーソル行割合ベースのスクロール同期、リンクカード・GitHub 埋め込みの実フェッチ（URL 単位キャッシュ）、frontmatter の除去（本番の webhook と同じ扱い）に対応する。スタイルは `apps/web/src/app/globals.css` をそのまま配信し、本番と同じ `article-body` レイアウト（コンテナ幅 1200px + 右サイドバー目次）で表示する。目次は `TableOfContents.tsx` を移植したもので、スクロール追従と 1024px 以下のモーダル目次も本番と同じ挙動になる。
 
-プレビュー画面は左に記事一覧サイドバー、右上に pc / mobile のビューポート切り替えを持つ。記事一覧はプレビュー中ファイルと同じディレクトリ（`setup({ articles_dir = ... })` で上書き可）の `*.md` を frontmatter の title 付きで列挙し、更新日・作成日・ファイル名でソートできる。一覧をクリックするとブラウザ側の表示が切り替わり、Neovim 側も `:edit` で追従する。逆に Neovim で別の markdown バッファへ移った場合もプレビューが追従する。mobile 表示は iframe の幅を 390px に切り替えるため、media query も本番同様に効く。タブの favicon は本番アイコンの色相を変えたもので、本番タブと見分けられる。
+プレビュー画面は左に記事一覧サイドバー、右上に pc / mobile のビューポート切り替えを持つ。記事一覧はプレビュー中ファイルと同じディレクトリ（`setup({ articles_dir = ... })` で上書き可）の `*.md` を frontmatter の title 付きで列挙し、更新日・作成日・ファイル名でソートできる。日付は git のコミット日時（更新 = 最終コミット、作成 = 初回コミット。mtime だと clone や checkout でも変わってノイズになるため）で、未コミットのファイルだけファイルシステムの日時になる。一覧をクリックするとブラウザ側の表示が切り替わり、Neovim 側も `:edit` で追従する。逆に Neovim で別の markdown バッファへ移った場合もプレビューが追従する。mobile 表示は iframe の幅を 390px に切り替えるため、media query も本番同様に効く。タブの favicon は本番アイコンの色相を変えたもので、本番タブと見分けられる。
 
 wasm は markdown-wasm のコミット済み `pkg/` を相対 import で参照するため、導入マシンは Neovim 0.10+ と bun があれば動く（`bun install` も不要。markdown crate 変更時の再ビルドは markdown-wasm 側で行う）。
 

--- a/tools/shuntaka-preview.nvim/CLAUDE.md
+++ b/tools/shuntaka-preview.nvim/CLAUDE.md
@@ -34,7 +34,7 @@ bun run serve
 - `src/index.ts` — エントリポイント。Bun.serve (HTTP + WebSocket) と stdin NDJSON ループ。記事一覧クリック (WS open) はパス検証後に stdout 通知 + ファイル内容の即時レンダリング
 - `src/protocol.ts` — Lua↔サーバー↔ブラウザ間メッセージの型定義（唯一の型ソース）
 - `src/markdown.ts` — markdown-wasm のローダーを使った 2 パス変換（URL 列挙 → fetch → リソース注入）。成功はプロセス寿命、失敗は 30 秒 TTL でキャッシュ
-- `src/articles.ts` — frontmatter の除去/title 抽出（blog-api の ArticleFrontmatter::parse と同じ切り出し方）と記事一覧の列挙
+- `src/articles.ts` — frontmatter の除去/title 抽出（blog-api の ArticleFrontmatter::parse と同じ切り出し方）と記事一覧の列挙。日付は git log 1 回で集めた初回/最終コミット日時（未コミットのみ fs 日時にフォールバック）
 - `src/template.ts` — shell ページ（記事一覧 + pc/mobile 切り替え + iframe）と view ページ（本番と同じ article-body レイアウト）、globals.css の取り込み（Tailwind ディレクティブのみ除去）
 - `static/client.js` — shell 側。WS 受信を iframe に注入し、記事一覧の描画・ソート・pc/mobile 切り替えを行う
 - `static/toc.js` — view (iframe) 側。apps/web の TableOfContents.tsx を移植した目次（スクロール追従・モバイルモーダル込み）

--- a/tools/shuntaka-preview.nvim/src/articles.test.ts
+++ b/tools/shuntaka-preview.nvim/src/articles.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -64,5 +65,39 @@ describe('listArticles', () => {
 
   test('存在しないディレクトリは空配列', () => {
     expect(listArticles('/no/such/dir')).toEqual([]);
+  });
+
+  test('git 管理下では初回/最終コミット日時を使い、未コミットのファイルは fs 日時に落ちる', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'shuntaka-preview-git-'));
+    const git = (args: string[], dateEnv?: string) =>
+      execFileSync('git', ['-C', dir, ...args], {
+        env: {
+          ...process.env,
+          ...(dateEnv ? { GIT_AUTHOR_DATE: dateEnv, GIT_COMMITTER_DATE: dateEnv } : {}),
+        },
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+    git(['init', '-q']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'test']);
+
+    const createdDate = '2026-01-01T00:00:00Z';
+    const updatedDate = '2026-02-01T00:00:00Z';
+    writeFileSync(join(dir, 'a.md'), '---\ntitle: "記事A"\n---\nv1');
+    git(['add', '.']);
+    git(['commit', '-q', '-m', 'add'], createdDate);
+    writeFileSync(join(dir, 'a.md'), '---\ntitle: "記事A"\n---\nv2');
+    git(['add', '.']);
+    git(['commit', '-q', '-m', 'update'], updatedDate);
+    // mtime はコミット日時より新しいが、git 管理下なのでコミット日時が優先される
+    writeFileSync(join(dir, 'draft.md'), '# 未コミットの下書き');
+
+    const entries = listArticles(dir);
+    const a = entries.find((e) => e.name === 'a.md');
+    expect(a?.createdAt).toBe(Date.parse(createdDate));
+    expect(a?.updatedAt).toBe(Date.parse(updatedDate));
+
+    const draft = entries.find((e) => e.name === 'draft.md');
+    expect(draft?.updatedAt).toBeGreaterThan(Date.parse(updatedDate));
   });
 });

--- a/tools/shuntaka-preview.nvim/src/articles.ts
+++ b/tools/shuntaka-preview.nvim/src/articles.ts
@@ -1,12 +1,13 @@
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { execFileSync, type ExecFileSyncOptionsWithStringEncoding } from 'node:child_process';
+import { readFileSync, readdirSync, realpathSync, statSync } from 'node:fs';
 import { join, resolve, sep } from 'node:path';
 
 export type ArticleEntry = {
   path: string;
   name: string;
   title: string;
-  createdAt: number; // epoch ms (birthtime)
-  updatedAt: number; // epoch ms (mtime)
+  createdAt: number; // epoch ms (初回コミット日時。git 管理外はファイルの birthtime)
+  updatedAt: number; // epoch ms (最終コミット日時。git 管理外はファイルの mtime)
 };
 
 // blog-api の ArticleFrontmatter::parse と同じ切り出し方（先頭 --- 〜 \n---）で
@@ -45,12 +46,76 @@ export function isPathInDir(path: string, dir: string): boolean {
   return resolve(path).startsWith(resolve(dir) + sep);
 }
 
+// git log を 1 回だけ流して、dir 配下の各ファイルの最終コミット (updated) と
+// 初回コミット (created) の日時を集める。mtime/birthtime は clone や checkout でも
+// 変わってノイズになるため、git 管理下では常にコミット日時を使う。
+// git リポジトリでなければ null (呼び出し側でファイルシステムの日時にフォールバック)
+export function gitTimes(
+  dir: string,
+): Map<string, { createdAt: number; updatedAt: number }> | null {
+  try {
+    const opts: ExecFileSyncOptionsWithStringEncoding = {
+      encoding: 'utf-8',
+      maxBuffer: 64 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    };
+    const root = execFileSync('git', ['-C', dir, 'rev-parse', '--show-toplevel'], opts).trim();
+    // --name-only のパスは repo root 相対。\x01 をコミット日時の行マーカーにする
+    const log = execFileSync(
+      'git',
+      [
+        '-C',
+        dir,
+        '-c',
+        'core.quotepath=false',
+        'log',
+        '--format=%x01%ct',
+        '--name-only',
+        '--',
+        '.',
+      ],
+      opts,
+    );
+    const times = new Map<string, { createdAt: number; updatedAt: number }>();
+    let commitAt = 0;
+    for (const line of log.split('\n')) {
+      if (line.startsWith('\x01')) {
+        commitAt = Number(line.slice(1)) * 1000;
+        continue;
+      }
+      if (line === '') {
+        continue;
+      }
+      const path = join(root, line);
+      const entry = times.get(path);
+      if (entry) {
+        // log は新しい順なので、後に出るコミットほど古い = created を上書きしていく
+        entry.createdAt = commitAt;
+      } else {
+        times.set(path, { createdAt: commitAt, updatedAt: commitAt });
+      }
+    }
+    return times;
+  } catch {
+    return null;
+  }
+}
+
 export function listArticles(dir: string): ArticleEntry[] {
   let names: string[];
   try {
     names = readdirSync(dir);
   } catch {
     return [];
+  }
+  const committed = gitTimes(dir);
+  // git の返すパスは symlink 解決済み (macOS の /var → /private/var 等) のため、
+  // ルックアップ用に dir も realpath へ正規化する
+  let lookupDir = dir;
+  try {
+    lookupDir = realpathSync(dir);
+  } catch {
+    // 解決できなければそのまま
   }
   const entries: ArticleEntry[] = [];
   for (const name of names) {
@@ -64,12 +129,17 @@ export function listArticles(dir: string): ArticleEntry[] {
         continue;
       }
       const text = readFileSync(path, 'utf-8');
+      // 未コミットの新規ファイルは git に日時が無いのでファイルシステムの日時を使う
+      const times = committed?.get(join(lookupDir, name)) ?? {
+        createdAt: Math.round(st.birthtimeMs || st.ctimeMs),
+        updatedAt: Math.round(st.mtimeMs),
+      };
       entries.push({
         path,
         name,
         title: extractTitle(text) ?? name.replace(/\.md$/, ''),
-        createdAt: Math.round(st.birthtimeMs || st.ctimeMs),
-        updatedAt: Math.round(st.mtimeMs),
+        createdAt: times.createdAt,
+        updatedAt: times.updatedAt,
       });
     } catch {
       // 読めないファイルは一覧から外す


### PR DESCRIPTION
## 概要

- プレビューの記事一覧サイドバーの更新日・作成日を、ファイルシステムの mtime/birthtime から git のコミット日時 (更新 = 最終コミット、作成 = 初回コミット) に変更
- mtime は clone や checkout でも変わるため、何もしていなくても更新検知されるノイズがあった

## 実装

- `git log --format=%x01%ct --name-only` を 1 回流して dir 配下全ファイルの初回/最終コミット日時を収集 (記事 114 件で 1 プロセス起動のみ)
- git リポジトリでないディレクトリと未コミットの新規ファイルは従来どおりファイルシステムの日時にフォールバック
- git の返すパスは symlink 解決済み (macOS の /var → /private/var) のため、ルックアップ側も realpath で正規化

## テスト

- [x] 単体テスト 20 件 (一時ディレクトリに git repo を作り、コミット日時固定で 初回/最終コミット日時・未コミットフォールバックを検証)
- [x] 実記事リポジトリ (114 記事) で日付が期待どおり取れることを確認
- [x] サーバー E2E / ルート lint / test

https://claude.ai/code/session_01MLWNqQ9BQ3xNeYb8TLcHH6
