### PR TITLE
feat: Next.js 16.3のISR改善に対応

### DIFF
--- a/.github/actions/bundle-size/api-stub.ts
+++ b/.github/actions/bundle-size/api-stub.ts
@@ -1,12 +1,27 @@
 /**
  * bundle-size workflow 用の blog-api スタブ。
- * next build 時の SSG (sitemap / feed / 記事一覧 prerender) が要求する
- * エンドポイントに空データを返す。レスポンス形は apps/web/src/lib/api.ts に合わせる。
+ * next build 時の SSG (sitemap / feed / 記事一覧・詳細 / moments prerender) が要求する
+ * エンドポイントに固定データを返す。レスポンス形は apps/web/src/lib/api.ts に合わせる。
  *
  * usage: bun .github/actions/bundle-size/api-stub.ts (PORT で上書き可、デフォルト 8080)
  */
 
 const port = Number(process.env.PORT || 8080);
+
+const article = {
+  articleId: 'bundle-size-stub',
+  title: 'Bundle Size Stub',
+  slug: 'bundle-size-stub',
+  content: 'Bundle size report fixture.',
+  contentHtml: '<p>Bundle size report fixture.</p>',
+  description: 'Bundle size report fixture.',
+  thumbnail: null,
+  ogpUrl: 'https://example.com/bundle-size-stub.png',
+  tags: [],
+  publishedAt: '2026-01-01T00:00:00Z',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
 
 const server = Bun.serve({
   port,
@@ -21,15 +36,24 @@ const server = Bun.serve({
     // GET /users/:userName/articles → ArticlesPage
     if (/^\/users\/[^/]+\/articles$/.test(pathname)) {
       return Response.json({
-        articles: [],
-        totalCount: 0,
+        articles: [article],
+        totalCount: 1,
         page: 1,
         perPage: 20,
-        totalPages: 0,
+        totalPages: 1,
       });
     }
 
-    // GET /users/:userName/articles/:slug → 404 (getArticleBySlug は null を返す)
+    // GET /users/:userName/moments → MomentsPage
+    if (/^\/users\/[^/]+\/moments$/.test(pathname)) {
+      return Response.json({ moments: [], nextCursor: null });
+    }
+
+    // GET /users/:userName/articles/:slug → Article
+    if (/^\/users\/[^/]+\/articles\/bundle-size-stub$/.test(pathname)) {
+      return Response.json(article);
+    }
+
     return new Response('Not Found', { status: 404 });
   },
 });

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -5,6 +5,20 @@ import type { NextConfig } from 'next';
 loadEnvConfig(process.cwd());
 
 const nextConfig: NextConfig = {
+  cacheComponents: true,
+  partialPrefetching: true,
+  cacheLife: {
+    blog: {
+      stale: 30,
+      revalidate: 30,
+      expire: 86400,
+    },
+    sitemap: {
+      stale: 60,
+      revalidate: 60,
+      expire: 86400,
+    },
+  },
   // dev サーバーへ localhost 以外のオリジン (Tailscale Funnel 等) からアクセスする場合に
   // .env.local の ALLOWED_DEV_ORIGINS (カンマ区切り) で許可する。本番ビルドには影響しない
   allowedDevOrigins: process.env.ALLOWED_DEV_ORIGINS?.split(','),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
     "@microsoft/clarity": "^1.0.2",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
-    "next": "^16.2.11",
+    "next": "^16.3.0",
     "nprogress": "^0.2.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
@@ -25,7 +25,7 @@
     "rss": "^1.2.2"
   },
   "devDependencies": {
-    "@next/env": "16.2.11",
+    "@next/env": "16.3.0",
     "@storybook/addon-themes": "^10.5.3",
     "@storybook/nextjs-vite": "^10.5.3",
     "@tailwindcss/postcss": "^4.3.3",

--- a/apps/web/src/app/[userName]/articles/[slug]/page.tsx
+++ b/apps/web/src/app/[userName]/articles/[slug]/page.tsx
@@ -5,15 +5,13 @@ import { ArticleContent } from '@/components/ArticleContent';
 import { BaseLayout } from '@/components/BaseLayout';
 import { ArticleJsonLd } from '@/components/JsonLd';
 import { TableOfContents } from '@/components/TableOfContents';
-import { getArticleBySlug } from '@/lib/api';
-import { SITE_URL } from '@/lib/constants';
-
-export const dynamicParams = true;
-export const revalidate = 30;
+import { getCachedArticleBySlug, getCachedArticles } from '@/lib/cachedApi';
+import { SITE_URL, USER_NAME } from '@/lib/constants';
 
 export async function generateStaticParams() {
-  // ビルド時は静的生成しない（リクエスト時にオンデマンドで生成）
-  return [];
+  // Cache Components のビルド検証用に最新記事だけ生成し、残りは初回アクセス時に生成する
+  const { articles } = await getCachedArticles(USER_NAME, { page: 1, perPage: 1 });
+  return articles.map(({ slug }) => ({ userName: USER_NAME, slug }));
 }
 
 interface ArticlePageProps {
@@ -25,7 +23,7 @@ interface ArticlePageProps {
 
 export async function generateMetadata({ params }: ArticlePageProps): Promise<Metadata> {
   const { userName, slug } = await params;
-  const article = await getArticleBySlug(userName, slug);
+  const article = await getCachedArticleBySlug(userName, slug);
 
   if (!article) {
     return { title: 'Article Not Found' };
@@ -74,7 +72,7 @@ function formatDate(dateString: string | null): string {
 
 export default async function ArticlePage({ params }: ArticlePageProps) {
   const { userName, slug } = await params;
-  const article = await getArticleBySlug(userName, slug);
+  const article = await getCachedArticleBySlug(userName, slug);
 
   if (!article) {
     notFound();

--- a/apps/web/src/app/feed/route.ts
+++ b/apps/web/src/app/feed/route.ts
@@ -1,5 +1,5 @@
 import RSS from 'rss';
-import { getArticles } from '@/lib/api';
+import { getCachedArticles } from '@/lib/cachedApi';
 import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL, USER_NAME } from '@/lib/constants';
 
 export async function GET() {
@@ -11,7 +11,7 @@ export async function GET() {
     language: 'ja',
   });
 
-  const { articles } = await getArticles(USER_NAME, { perPage: 20 });
+  const { articles } = await getCachedArticles(USER_NAME, { perPage: 20 });
 
   articles.forEach((article) => {
     feed.item({

--- a/apps/web/src/app/moments/preview/page.tsx
+++ b/apps/web/src/app/moments/preview/page.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = {
   },
 };
 
+// プレビューは検索パラメータの内容全体が揃ってから 1 枚を描画する
+export const instant = false;
+
 /** 写真 URL は moments の配信ドメイン（prd / dev）のみ許可する */
 const ALLOWED_IMAGE_HOSTS = new Set(['images.shuntaka.dev', 'images.shuntaka.tech']);
 

--- a/apps/web/src/app/page/[page]/page.tsx
+++ b/apps/web/src/app/page/[page]/page.tsx
@@ -1,12 +1,15 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { ArticleListView } from '@/components/ArticleListView';
-import { getArticles } from '@/lib/api';
+import { getCachedArticles } from '@/lib/cachedApi';
 import { ARTICLES_PER_PAGE, SITE_URL, USER_NAME } from '@/lib/constants';
 
 interface PageProps {
   params: Promise<{ page: string }>;
 }
+
+// ページ番号の検証と範囲外判定を完了してから描画する
+export const instant = false;
 
 function parsePage(raw: string): number | null {
   if (!/^[1-9]\d*$/.test(raw)) return null;
@@ -30,8 +33,8 @@ export default async function PostsPaginationPage({ params }: PageProps) {
   const page = parsePage(rawPage);
   if (page === null) notFound();
 
-  // 範囲外ページ判定用の全件フェッチ。sitemap と同じ URL のため Next の fetch dedup が効く
-  const probe = await getArticles(USER_NAME, { perPage: 'all' });
+  // 範囲外ページ判定用に全件取得する
+  const probe = await getCachedArticles(USER_NAME, { perPage: 'all' });
   if (probe.articles.length <= (page - 1) * ARTICLES_PER_PAGE) notFound();
 
   return <ArticleListView page={page} baseHref="/" />;

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,15 +1,17 @@
 import type { MetadataRoute } from 'next';
-import { getArticles } from '@/lib/api';
+import { cacheLife } from 'next/cache';
+import { getCachedArticles } from '@/lib/cachedApi';
 import { SITE_URL, USER_NAME } from '@/lib/constants';
-
-export const revalidate = 60;
 
 function formatDate(date: Date): string {
   return date.toISOString().split('T')[0];
 }
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const { articles } = await getArticles(USER_NAME, { perPage: 'all' });
+async function getSitemap(): Promise<MetadataRoute.Sitemap> {
+  'use cache';
+  cacheLife('sitemap');
+
+  const { articles } = await getCachedArticles(USER_NAME, { perPage: 'all' });
 
   const articleUrls: MetadataRoute.Sitemap = articles.map((article) => ({
     url: `${SITE_URL}/${USER_NAME}/articles/${article.slug}`,
@@ -27,4 +29,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
     ...articleUrls,
   ];
+}
+
+export default function sitemap(): Promise<MetadataRoute.Sitemap> {
+  return getSitemap();
 }

--- a/apps/web/src/components/ArticleListView.tsx
+++ b/apps/web/src/components/ArticleListView.tsx
@@ -9,7 +9,7 @@ import { SearchProvider } from '@/components/SearchProvider';
 import { SearchTriggerButton } from '@/components/SearchTriggerButton';
 import { TagFilterModal } from '@/components/TagFilterModal';
 import { TagFilterProvider } from '@/components/TagFilterProvider';
-import { getArticles, getTagFacets } from '@/lib/api';
+import { getCachedArticles, getCachedTagFacets } from '@/lib/cachedApi';
 import { ARTICLES_PER_PAGE, USER_NAME } from '@/lib/constants';
 
 interface ArticleListViewProps {
@@ -18,15 +18,15 @@ interface ArticleListViewProps {
 }
 
 export async function ArticleListView({ page, baseHref }: ArticleListViewProps) {
-  let articles: Awaited<ReturnType<typeof getArticles>>['articles'] = [];
+  let articles: Awaited<ReturnType<typeof getCachedArticles>>['articles'] = [];
   let totalPages = 1;
-  let initialFacets: Awaited<ReturnType<typeof getTagFacets>>['facets'] = [];
+  let initialFacets: Awaited<ReturnType<typeof getCachedTagFacets>>['facets'] = [];
   let error: string | null = null;
 
   try {
     const [pageResult, facetsResult] = await Promise.all([
-      getArticles(USER_NAME, { page, perPage: ARTICLES_PER_PAGE }),
-      getTagFacets(USER_NAME),
+      getCachedArticles(USER_NAME, { page, perPage: ARTICLES_PER_PAGE }),
+      getCachedTagFacets(USER_NAME),
     ]);
     articles = pageResult.articles;
     totalPages = pageResult.totalPages;

--- a/apps/web/src/components/MomentsView.tsx
+++ b/apps/web/src/components/MomentsView.tsx
@@ -1,17 +1,17 @@
 import { BaseLayout } from '@/components/BaseLayout';
 import { MomentsInfiniteFeed } from '@/components/MomentsInfiniteFeed';
 import { PageReady } from '@/components/PageReady';
-import { getMoments } from '@/lib/api';
+import { getCachedMoments } from '@/lib/cachedApi';
 import { USER_NAME } from '@/lib/constants';
 
 export async function MomentsView() {
-  let initialMoments: Awaited<ReturnType<typeof getMoments>>['moments'] = [];
+  let initialMoments: Awaited<ReturnType<typeof getCachedMoments>>['moments'] = [];
   let initialCursor: string | null = null;
   let error: string | null = null;
 
   try {
     // 1 ページ目のみサーバーで取得し、以降はクライアントの無限スクロールで継ぎ足す
-    const page = await getMoments(USER_NAME);
+    const page = await getCachedMoments(USER_NAME);
     initialMoments = page.moments;
     initialCursor = page.nextCursor;
   } catch (e) {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -166,7 +166,7 @@ export async function getArticles(
   const url = `${API_BASE_URL}/users/${userName}/articles${query}`;
   const fetchOpts = opts.noCache
     ? { cache: 'no-store' as const, signal: opts.signal }
-    : { next: { revalidate: 30 }, signal: opts.signal };
+    : { signal: opts.signal };
 
   const res = await fetch(url, fetchOpts);
 
@@ -194,7 +194,7 @@ export async function getTagFacets(
   const url = `${API_BASE_URL}/users/${userName}/articles/tag-facets${query}`;
   const fetchOpts = opts.noCache
     ? { cache: 'no-store' as const, signal: opts.signal }
-    : { next: { revalidate: 30 }, signal: opts.signal };
+    : { signal: opts.signal };
 
   const res = await fetch(url, fetchOpts);
 
@@ -248,7 +248,7 @@ export async function getMoments(
   const url = `${API_BASE_URL}/users/${userName}/moments${query}`;
   const fetchOpts = opts.noCache
     ? { cache: 'no-store' as const, signal: opts.signal }
-    : { next: { revalidate: 30 }, signal: opts.signal };
+    : { signal: opts.signal };
 
   const res = await fetch(url, fetchOpts);
 
@@ -260,9 +260,7 @@ export async function getMoments(
 }
 
 export async function getArticleBySlug(userName: string, slug: string): Promise<Article | null> {
-  const res = await fetch(`${API_BASE_URL}/users/${userName}/articles/${slug}`, {
-    next: { revalidate: 30 },
-  });
+  const res = await fetch(`${API_BASE_URL}/users/${userName}/articles/${slug}`);
 
   if (res.status === 404) {
     return null;

--- a/apps/web/src/lib/cachedApi.ts
+++ b/apps/web/src/lib/cachedApi.ts
@@ -1,0 +1,38 @@
+import { cacheLife } from 'next/cache';
+import {
+  getArticleBySlug,
+  getArticles,
+  getMoments,
+  getTagFacets,
+  type ArticlesQueryOptions,
+  type MomentsQueryOptions,
+  type TagFacetsOptions,
+} from './api';
+
+type CachedArticlesQueryOptions = Omit<ArticlesQueryOptions, 'noCache' | 'signal'>;
+type CachedTagFacetsOptions = Omit<TagFacetsOptions, 'noCache' | 'signal'>;
+type CachedMomentsQueryOptions = Omit<MomentsQueryOptions, 'noCache' | 'signal'>;
+
+export async function getCachedArticles(userName: string, opts: CachedArticlesQueryOptions = {}) {
+  'use cache';
+  cacheLife('blog');
+  return getArticles(userName, opts);
+}
+
+export async function getCachedTagFacets(userName: string, opts: CachedTagFacetsOptions = {}) {
+  'use cache';
+  cacheLife('blog');
+  return getTagFacets(userName, opts);
+}
+
+export async function getCachedMoments(userName: string, opts: CachedMomentsQueryOptions = {}) {
+  'use cache';
+  cacheLife('blog');
+  return getMoments(userName, opts);
+}
+
+export async function getCachedArticleBySlug(userName: string, slug: string) {
+  'use cache';
+  cacheLife('blog');
+  return getArticleBySlug(userName, slug);
+}

--- a/bun.lock
+++ b/bun.lock
@@ -107,7 +107,7 @@
         "@microsoft/clarity": "^1.0.2",
         "@vercel/analytics": "^2.0.1",
         "@vercel/speed-insights": "^2.0.0",
-        "next": "^16.2.11",
+        "next": "^16.3.0",
         "nprogress": "^0.2.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -115,7 +115,7 @@
         "rss": "^1.2.2",
       },
       "devDependencies": {
-        "@next/env": "16.2.11",
+        "@next/env": "16.3.0",
         "@storybook/addon-themes": "^10.5.3",
         "@storybook/nextjs-vite": "^10.5.3",
         "@tailwindcss/postcss": "^4.3.3",
@@ -588,53 +588,57 @@
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
 
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
 
@@ -688,23 +692,23 @@
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
-    "@next/env": ["@next/env@16.2.11", "", {}, "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA=="],
+    "@next/env": ["@next/env@16.3.0", "", {}, "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.11", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.2.11", "", { "os": "darwin", "cpu": "x64" }, "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.2.11", "", { "os": "linux", "cpu": "arm64" }, "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.2.11", "", { "os": "linux", "cpu": "x64" }, "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.2.11", "", { "os": "win32", "cpu": "arm64" }, "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.11", "", { "os": "win32", "cpu": "x64" }, "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -2132,7 +2136,7 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "next": ["next@16.2.11", "", { "dependencies": { "@next/env": "16.2.11", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.2.11", "@next/swc-darwin-x64": "16.2.11", "@next/swc-linux-arm64-gnu": "16.2.11", "@next/swc-linux-arm64-musl": "16.2.11", "@next/swc-linux-x64-gnu": "16.2.11", "@next/swc-linux-x64-musl": "16.2.11", "@next/swc-win32-arm64-msvc": "16.2.11", "@next/swc-win32-x64-msvc": "16.2.11", "sharp": "^0.34.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ=="],
+    "next": ["next@16.3.0", "", { "dependencies": { "@next/env": "16.3.0", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.23", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0", "@next/swc-darwin-x64": "16.3.0", "@next/swc-linux-arm64-gnu": "16.3.0", "@next/swc-linux-arm64-musl": "16.3.0", "@next/swc-linux-x64-gnu": "16.3.0", "@next/swc-linux-x64-musl": "16.3.0", "@next/swc-win32-arm64-msvc": "16.3.0", "@next/swc-win32-x64-msvc": "16.3.0", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A=="],
 
     "node-fetch": ["node-fetch@2.6.9", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg=="],
 
@@ -2376,7 +2380,7 @@
 
     "shadcn": ["shadcn@4.13.1", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "kleur": "^4.1.5", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "undici": "^7.27.2", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-pSNPND8mVWGBytdd8l4Cksg7MyRZOsv28HpvNCtFtLwZoxLSGM6v3NMUpmpbOaIoreopS/UOpQvnCyttOHVLAQ=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+    "sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" }, "peerDependencies": { "@types/node": "*" }, "optionalPeers": ["@types/node"] }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -2762,8 +2766,6 @@
 
     "@feature-sliced/filesystem/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
-
     "@mapbox/node-pre-gyp/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "@modelcontextprotocol/sdk/@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
@@ -3060,7 +3062,7 @@
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+    "next/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "normalize-package-data/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
 
@@ -3102,7 +3104,7 @@
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "sharp/semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+    "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -3553,6 +3555,8 @@
     "micro/raw-body/http-errors": ["http-errors@1.7.3", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.1.1", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.0" } }, "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw=="],
 
     "micro/raw-body/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
+    "next/postcss/nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/docs/source/97_survey/2026-08-09-next-16-3-bundle-size-reduction/index.md
+++ b/docs/source/97_survey/2026-08-09-next-16-3-bundle-size-reduction/index.md
@@ -1,0 +1,143 @@
+<!-- cspell:ignore Turbopack first-load client-browser moduleFactories PostCSS -->
+
+# Next.js 16.3 更新でクライアント JS が 104 KiB 減った理由
+
+- 対象: `apps/web`（Next.js 16.2.11 → 16.3.0、Turbopack production build）
+- 調査日: 2026-08-09
+- きっかけ: [PR #748](https://github.com/shuntaka9576/shuntaka-dev/pull/748) の Bundle Size report で大幅な減少を検出した
+
+## 結論
+
+Bundle Size report の減少は、ISR、`use cache`、Partial Prefetching への移行でアプリコードが減ったためではない。**Next.js 16.3に含まれるTurbopackのclient bundle修正がほぼ全量を占める**。
+
+主因は次の2点だった。
+
+1. Next.js 16.2.11では、本来ブラウザに不要な`next/dist/server`配下の実装がclient bundleへ混入していた。16.3のbrowser variant分離で解消され、共有JSを約56 KiB削減した
+2. 16.2.11では同じ19モジュールを並び順だけ変えて持つ24.3 KiBのチャンクが3ファイル生成されていた。16.3のモジュール順序正規化で同一チャンクとして扱われ、余分な2ファイル、計48.6 KiBが消えた
+
+概算すると、CIで観測したTotal unique JSの削減は次の内訳で説明できる。
+
+```text
+104.3 KiB減 ≒ server-onlyコード・runtimeの削減 55.7 KiB
+              + 重複チャンク2ファイルの削減 48.6 KiB
+```
+
+## CIで観測した変化
+
+[Bundle Size report](https://github.com/shuntaka9576/shuntaka-dev/pull/748#issuecomment-5214304370) は、`TURBOPACK_STATS=1`で生成した`route-bundle-stats.json`と実チャンクの非圧縮サイズを比較している。
+
+| 指標                     | Base (16.2.11) | PR (16.3.0) |                差分 |
+| ------------------------ | -------------: | ----------: | ------------------: |
+| 全ルート共通JS           |      547.1 KiB |   490.3 KiB |  -56.8 KiB (-10.4%) |
+| 全ルートのユニークJS合計 |      649.1 KiB |   544.7 KiB | -104.3 KiB (-16.1%) |
+
+ルート固有JSは、全ルート共通チャンクを除いた残りである。
+
+| ルート                        |     Base |       PR |               差分 |
+| ----------------------------- | -------: | -------: | -----------------: |
+| `/`, `/page/[page]`           | 56.9 KiB | 32.5 KiB | -24.4 KiB (-42.8%) |
+| `/[userName]/articles/[slug]` | 33.4 KiB | 10.2 KiB | -23.1 KiB (-69.4%) |
+| `/about`                      | 28.8 KiB |  4.5 KiB | -24.3 KiB (-84.3%) |
+| `/moments`                    |  6.9 KiB |  6.8 KiB |       ほぼ変化なし |
+| `/moments/preview`            |  0.3 KiB |  0.3 KiB |           変化なし |
+
+`/about`の`-84.3%`は、ページ全体のfirst-load JSが84.3%減ったという意味ではない。共通JSを足した実質的なfirst-loadは約575.9 KiBから494.8 KiBへの減少で、約14.1%減となる。大きな割合に見えるのは、小さいルート固有部分から24.3 KiBの重複チャンクが丸ごと消えたためである。
+
+## バージョン更新とアプリ変更の切り分け
+
+Base commit `88521c7`とPR head `7f8d62d`をworktreeに分け、同じAPIスタブ、同じ環境変数でproduction buildした。さらに、Baseのソースと設定を維持したまま`next`と`@next/env`だけ16.3.0へ更新した中間条件を用意した。
+
+```console
+TURBOPACK_STATS=1 \
+  NEXT_PUBLIC_API_URL=http://localhost:43008 \
+  bun run build
+```
+
+| 条件                                 |    共有JS | ユニークJS合計 |      16.2.11からの差分 |
+| ------------------------------------ | --------: | -------------: | ---------------------: |
+| Baseソース + Next.js 16.2.11         | 547.0 KiB |      649.0 KiB |                      — |
+| Baseソース + Next.js 16.3.0のみ      | 488.8 KiB |      543.3 KiB | -58.3 KiB / -105.7 KiB |
+| PR全体（Cache Components移行を含む） | 490.3 KiB |      544.7 KiB | -56.7 KiB / -104.2 KiB |
+
+Next.jsだけを更新した時点で、PR全体よりわずかに小さくなっている。PRのアプリ・設定変更を加えると、16.3.0単純更新時より共有JSが1.5 KiB、ユニークJS合計が1.4 KiB増えた。したがって、今回の大幅削減を`use cache`や`partialPrefetching`の効果として説明することはできない。
+
+CIはLinux、切り分けはmacOSで実行したため、丸め前の値には0.1 KiB程度の差がある。削減量とチャンク構造は一致した。
+
+## 原因1: Server側実装のclient bundle混入が解消された
+
+Next.js公式のTurbopack Bundle Analyzerを両バージョンで実行し、client outputに含まれるソースモジュールを比較した。
+
+```console
+bunx next experimental-analyze --output
+```
+
+16.2.11では次のServer側モジュールがclient outputに含まれていたが、16.3.0では0になった。表はAnalyzer上の非圧縮サイズで、上位6件だけで51.8 KiBある。
+
+| 16.2.11でclient outputに入っていたモジュール                        |   削減量 |
+| ------------------------------------------------------------------- | -------: |
+| `next/dist/server/app-render/dynamic-rendering.js`                  | 20.8 KiB |
+| `next/dist/server/request/params.js`                                |  7.9 KiB |
+| `next/dist/server/request/search-params.js`                         |  7.4 KiB |
+| `next/dist/server/app-render/instant-validation/instant-samples.js` |  6.6 KiB |
+| `next/dist/compiled/@edge-runtime/cookies/index.js`                 |  4.8 KiB |
+| `next/dist/server/app-render/staged-rendering.js`                   |  4.2 KiB |
+
+Analyzerのclient JS全体では730,302 bytesから673,264 bytesへ、57,038 bytes（55.7 KiB）減った。新しいnavigation実装の増加分を含めても、Server側コードの除去が上回っている。
+
+これはNext.js 16.3の次の修正と一致する。
+
+- [#95201 Split typeof-window server requires into .browser variants](https://github.com/vercel/next.js/pull/95201): PR本文で「recent bundle size regressions」の修正と説明されている
+- [#95366 Split remaining "client-node"-only modules into .browser variants](https://github.com/vercel/next.js/pull/95366): `next/src/server`がclient-browser bundleへ入るregressionを解消している
+- [#95200 Collect modules with browser variants statically](https://github.com/vercel/next.js/pull/95200): `.browser` siblingを自動検出し、browser向けmodule aliasを生成する
+
+## 原因2: 同一モジュール集合の重複チャンクが統合された
+
+16.2.11のproduction artifactには、いずれも24,878 bytesで、**同じ19個のmodule factoryを持つチャンクが3ファイル**あった。差はmodule factoryの並び順だけだった。
+
+- 1ファイルは全ルート共通チャンク
+- 1ファイルは`/`と`/page/[page]`が追加ロード
+- 1ファイルは記事詳細と`/about`が追加ロード
+
+つまり、該当ルートは同じモジュール集合を共有チャンクとルート固有チャンクから二重に受け取っていた。また、ユニークJS合計では同内容の余分な2ファイルを別ファイルとして数えていた。
+
+16.3.0ではこの2ファイルが消えた。
+
+- 各該当ルート: 約24.3 KiB減
+- ユニークJS合計: `24,878 bytes × 2 = 49,756 bytes`、約48.6 KiB減
+
+これは[#94961 Sort modules in chunks to reduce duplicates](https://github.com/vercel/next.js/pull/94961)の修正内容と一致する。Turbopackが同じchunk item集合を異なる順番で配置するとcontent hashが変わり、重複ファイルとして配信される問題に対し、module順を正規化して同じファイル名へ収束させている。
+
+## 小さい要因: Turbopack runtime自体の縮小
+
+Next.js 16.3の公式記事にも[Smaller runtime size](https://nextjs.org/blog/next-16-3-turbopack#smaller-runtime-size)として、WebAssembly、Worker、top-level async用コードを必要な場合だけ配信する変更が記載されている。
+
+このアプリの`turbopack-*.js`は10,580 bytesから9,652 bytesへ928 bytes（約0.9 KiB）減った。改善は確認できるが、104.3 KiB削減の主因ではない。
+
+対応するupstream PRは次のとおり。
+
+- [#94376 Only ship top-level async support in the runtime when needed](https://github.com/vercel/next.js/pull/94376)
+- [#94372 Remove worker helpers from the default runtime](https://github.com/vercel/next.js/pull/94372)
+- [#94373 Remove WebAssembly helpers from the default runtime](https://github.com/vercel/next.js/pull/94373)
+
+## ISR / Partial Prefetchingとの関係
+
+今回のPRで導入したCache Components、`use cache`、`cacheLife`、Partial Prefetchingは、再生成、キャッシュ、navigation時のshell配信を改善する。一方、上のA/B結果では、それらを入れる前のNext.js 16.3.0単純更新だけで削減が完了している。
+
+したがって、同じアップデートで次の2種類の改善が同時に得られたが、原因は分けて考える必要がある。
+
+- ISR / navigation改善: Cache ComponentsとPartial Prefetchingの新しい実行モデル
+- client bundle削減: Turbopackのbrowser variant分離、重複チャンク除去、runtime縮小
+
+## 計測上の注意
+
+- Bundle Size reportは非圧縮JSを計測している。gzip / Brotli後の転送量やJavaScript実行時間を直接表すものではない
+- `Shared JS`は全ルートのチャンク集合の積集合、`Total unique JS`は和集合、ルート固有JSは共有集合を除いた値である。Turbopackのre-chunkingにより共有・固有の分類は変わり得る
+- `route-bundle-stats.json`のファイルサイズ比較とBundle Analyzerのmodule内訳は役割が異なる。前者をCIの判定値、後者を原因特定に使用した
+- チャンク名はcontent hashなので環境やbuildで変わる。今回の根拠はファイル名ではなく、サイズ、route参照関係、module factory集合で確認した
+
+## 参考
+
+- [Next.js 16.3](https://nextjs.org/blog/next-16-3)
+- [Turbopack: What's New in Next.js 16.3](https://nextjs.org/blog/next-16-3-turbopack)
+- [Next.js v16.3.0 release notes](https://github.com/vercel/next.js/releases/tag/v16.3.0)
+- [PR #748 Bundle Size report](https://github.com/shuntaka9576/shuntaka-dev/pull/748#issuecomment-5214304370)

--- a/docs/source/97_survey/index.md
+++ b/docs/source/97_survey/index.md
@@ -7,6 +7,7 @@
 | 調査日     | タイトル                                                                                                                           |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | 0000-00-00 | [タイトル](0000-00-00-topic/index.md)                                                                                              |
+| 2026-08-09 | [Next.js 16.3 更新でクライアント JS が 104 KiB 減った理由](2026-08-09-next-16-3-bundle-size-reduction/index.md)                    |
 | 2026-07-28 | [MiniPC クラスタの消費電力実測と電気料金への影響](2026-07-28-minipc-power-measurement/index.md)                                    |
 | 2026-07-23 | [`SELECT * FROM articles` が 0.4〜1.1s かかる原因（転送律速）](2026-07-23-tidb-articles-select-star-transfer-latency/index.md)     |
 | 2026-07-19 | [TiDB ベクトル検索の最小教材 — コサイン類似度 / exact / TiFlash / HNSW / 再帰 CTE](2026-07-19-tidb-vector-search-101/index.md)     |


### PR DESCRIPTION
## 概要

- Next.js / `@next/env` を現行 stable の 16.3.0 へ更新
- Cache Components と Partial Prefetching を有効化し、16.3 の Better ISR を記事詳細で利用
- 既存の 30 秒 ISR と sitemap の 60 秒更新を `use cache` / `cacheLife` へ移行

## 変更内容

- `cacheComponents: true` と `partialPrefetching: true` を追加
- ブログデータ用 30 秒、sitemap 用 60 秒の Cache Life profile を定義
- Server Component / Route Handler 向けの cached API wrapper を追加し、旧 `fetch(..., { next: { revalidate } })` を置き換え
- 記事詳細は最新記事 1 件だけをビルド時生成し、それ以外の URL は loading shell を即時返してバックグラウンド生成する構成へ変更
- 検索パラメータ依存の moments preview とページ番号の範囲判定は `instant = false` で従来のブロッキング動作を明示

## 動作確認

- `bun install --frozen-lockfile`
- `bun outdated --filter @shuntaka-dev/web`（Next.js は更新候補なし）
- `bun run lint`
- `bun run type-check`
- `cd apps/web && bun test src/`（39 tests passed）
- `cd apps/web && NEXT_PUBLIC_API_URL=https://api.shuntaka.dev bun run build`
  - 記事詳細の fallback route が `Partial Prerender` として出力されることを確認
  - sitemap が 60 秒 revalidate の static route として出力されることを確認
- 未生成の記事 URL を production server で2回取得
  - 初回: `x-nextjs-postponed: 1`（loading shell）
  - 2回目: `x-nextjs-cache: HIT`（バックグラウンド生成済み）
