### PR TITLE
chore: Renovate PRにskip-changelogラベルを付与

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "timezone": "Asia/Tokyo",
   "dependencyDashboard": false,
   "ignoreTests": true,
+  "addLabels": ["skip-changelog"],
   "automerge": false,
   "automergeSchedule": ["every 1 hour after 00:00 and before 23:59 every day"],
   "major": {


### PR DESCRIPTION
## 概要

- Renovate が作成するすべての PR に `skip-changelog` ラベルを自動付与する
- `addLabels` を使用し、ほかの Renovate ラベル設定と合成可能にする

## 変更内容

- `renovate.json`: トップレベルの `addLabels` に `skip-changelog` を追加

## テスト

- [x] `bunx --bun renovate-config-validator renovate.json`
- [x] pre-commit（secretlint / gitleaks）
- [x] pre-push（lint / type-check / spell-check / zizmor）
