### PR TITLE
feat: 買い物リストに購入済み状態を追加

### DIFF
--- a/apps/admin-api/src/db/types.ts
+++ b/apps/admin-api/src/db/types.ts
@@ -126,6 +126,7 @@ export interface TodoShoppingItemsTable {
   name: string;
   normalized_name: string;
   quantity: string | null;
+  completed_at: Date | null;
   created_at: ColumnType<Date, never, never>;
   updated_at: ColumnType<Date, never, never>;
 }

--- a/apps/admin-api/src/routes/todo.ts
+++ b/apps/admin-api/src/routes/todo.ts
@@ -22,6 +22,7 @@ import {
   updateMealBodySchema,
   updateMorningAchievementBodySchema,
   updateQuickItemBodySchema,
+  updateShoppingItemBodySchema,
   updateTodoItemBodySchema,
   updateTodoSettingsBodySchema,
 } from '../schemas/todo.js';
@@ -145,11 +146,21 @@ const createShoppingRoute = createRoute({
   },
 });
 
+const updateShoppingRoute = createRoute({
+  method: 'patch',
+  path: '/todo/shopping/{id}',
+  request: {
+    params: shoppingItemIdParamSchema,
+    body: { content: { 'application/json': { schema: updateShoppingItemBodySchema } } },
+  },
+  responses: { 204: { description: '買い物項目の購入済み状態を更新' } },
+});
+
 const deleteShoppingRoute = createRoute({
   method: 'delete',
   path: '/todo/shopping/{id}',
   request: { params: shoppingItemIdParamSchema },
-  responses: { 204: { description: '購入済み・不要な項目を除外' } },
+  responses: { 204: { description: '不要な買い物項目を削除' } },
 });
 
 const normalizeShoppingName = (name: string): string =>
@@ -287,6 +298,7 @@ export const todoRoutes = createRouter()
           itemId: row.shopping_item_id,
           name: row.name,
           quantity: row.quantity,
+          completedAt: row.completed_at?.toISOString() ?? null,
         })),
       },
       200,
@@ -547,8 +559,9 @@ export const todoRoutes = createRouter()
         name: body.name,
         normalized_name: normalizedName,
         quantity,
+        completed_at: null,
       })
-      .onDuplicateKeyUpdate({ name: body.name, quantity })
+      .onDuplicateKeyUpdate({ name: body.name, quantity, completed_at: null })
       .execute();
     const row = await db
       .selectFrom('todo_shopping_items')
@@ -556,7 +569,29 @@ export const todoRoutes = createRouter()
       .where('user_id', '=', userId)
       .where('normalized_name', '=', normalizedName)
       .executeTakeFirstOrThrow();
-    return c.json({ itemId: row.shopping_item_id, name: row.name, quantity: row.quantity }, 201);
+    return c.json(
+      {
+        itemId: row.shopping_item_id,
+        name: row.name,
+        quantity: row.quantity,
+        completedAt: row.completed_at?.toISOString() ?? null,
+      },
+      201,
+    );
+  })
+  .openapi(updateShoppingRoute, async (c) => {
+    const { id } = c.req.valid('param');
+    const { completed } = c.req.valid('json');
+    const result = await getDb()
+      .updateTable('todo_shopping_items')
+      .set({ completed_at: completed ? new Date() : null })
+      .where('shopping_item_id', '=', id)
+      .where('user_id', '=', c.get('userId'))
+      .executeTakeFirst();
+    if (result.numUpdatedRows === 0n) {
+      throw new HTTPException(404, { message: 'shopping item not found' });
+    }
+    return c.body(null, 204);
   })
   .openapi(deleteShoppingRoute, async (c) => {
     const { id } = c.req.valid('param');

--- a/apps/admin-api/src/schemas/todo.test.ts
+++ b/apps/admin-api/src/schemas/todo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { updateMorningAchievementBodySchema } from './todo.js';
+import { updateMorningAchievementBodySchema, updateShoppingItemBodySchema } from './todo.js';
 
 describe('updateMorningAchievementBodySchema', () => {
   it('育児負荷・自由時間・使い方を許可する', () => {
@@ -22,5 +22,16 @@ describe('updateMorningAchievementBodySchema', () => {
         note: '',
       }).success,
     ).toBe(false);
+  });
+});
+
+describe('updateShoppingItemBodySchema', () => {
+  it('購入済み・未購入の切り替えを許可する', () => {
+    expect(updateShoppingItemBodySchema.safeParse({ completed: true }).success).toBe(true);
+    expect(updateShoppingItemBodySchema.safeParse({ completed: false }).success).toBe(true);
+  });
+
+  it('boolean 以外の完了状態を拒否する', () => {
+    expect(updateShoppingItemBodySchema.safeParse({ completed: 'true' }).success).toBe(false);
   });
 });

--- a/apps/admin-api/src/schemas/todo.ts
+++ b/apps/admin-api/src/schemas/todo.ts
@@ -32,6 +32,7 @@ export const createShoppingItemBodySchema = z.object({
   name: z.string().trim().min(1).max(500),
   quantity: z.string().trim().max(255).optional(),
 });
+export const updateShoppingItemBodySchema = z.object({ completed: z.boolean() });
 export const shoppingItemIdParamSchema = z.object({ id: z.string().length(26) });
 
 export const todoDashboardQuerySchema = z.object({ date: localDateSchema.optional() });
@@ -100,6 +101,7 @@ export const shoppingItemSchema = z.object({
   itemId: z.string(),
   name: z.string(),
   quantity: z.string().nullable(),
+  completedAt: z.string().nullable(),
 });
 
 export const quickItemSchema = z.object({

--- a/apps/admin-web/src/entities/todo/index.ts
+++ b/apps/admin-web/src/entities/todo/index.ts
@@ -7,6 +7,7 @@ export {
   type MealType,
   type QuickTodoCategory,
   type QuickTodoItem,
+  type ShoppingItem,
   type TodoDashboard,
   type TodoPeriod,
 } from './model/todo';

--- a/apps/admin-web/src/entities/todo/model/todo.ts
+++ b/apps/admin-web/src/entities/todo/model/todo.ts
@@ -5,6 +5,7 @@ import { client } from '@/shared/api';
 export type TodoDashboard = InferResponseType<typeof client.api.todo.$get, 200>;
 export type DailyTodoItem = TodoDashboard['checklist'][number];
 export type QuickTodoItem = TodoDashboard['quickTodos'][number];
+export type ShoppingItem = TodoDashboard['shopping'][number];
 export type QuickTodoCategory = QuickTodoItem['category'];
 export type TodoPeriod = DailyTodoItem['period'];
 export type MealType = 'breakfast' | 'lunch' | 'dinner';

--- a/apps/admin-web/src/pages/todo/ui/todo-page.tsx
+++ b/apps/admin-web/src/pages/todo/ui/todo-page.tsx
@@ -11,6 +11,7 @@ import {
   type MealType,
   type QuickTodoCategory,
   type QuickTodoItem,
+  type ShoppingItem,
   type TodoDashboard,
   type TodoPeriod,
 } from '@/entities/todo';
@@ -463,6 +464,17 @@ export function TodoPage({
     onSuccess: () => queryClient.invalidateQueries({ queryKey: todoKeys.all }),
   });
 
+  const toggleShopping = useMutation({
+    mutationFn: async (item: ShoppingItem) => {
+      const response = await client.api.todo.shopping[':id'].$patch({
+        param: { id: item.itemId },
+        json: { completed: item.completedAt === null },
+      });
+      if (!response.ok) throw new Error('買い物項目の購入状態の更新に失敗しました');
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: todoKeys.all }),
+  });
+
   const submitShopping = (event: FormEvent) => {
     event.preventDefault();
     if (shoppingName.trim() !== '') addShopping.mutate();
@@ -482,7 +494,8 @@ export function TodoPage({
     generate.error ??
     updateMeal.error ??
     addShopping.error ??
-    deleteShopping.error;
+    deleteShopping.error ??
+    toggleShopping.error;
 
   return (
     <div className="space-y-5">
@@ -674,19 +687,37 @@ export function TodoPage({
             <ul className="divide-y">
               {data.shopping.map((item) => (
                 <li key={item.itemId} className="flex items-center justify-between gap-3 py-2">
-                  <span className="text-sm">
+                  <span
+                    className={
+                      item.completedAt === null
+                        ? 'text-sm'
+                        : 'text-sm text-muted-foreground line-through'
+                    }
+                  >
                     {item.name}
                     {item.quantity === null ? '' : `（${item.quantity}）`}
                   </span>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    disabled={deleteShopping.isPending}
-                    onClick={() => deleteShopping.mutate(item.itemId)}
-                  >
-                    完了・除外
-                  </Button>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={item.completedAt === null ? 'outline' : 'secondary'}
+                      aria-pressed={item.completedAt !== null}
+                      disabled={toggleShopping.isPending || deleteShopping.isPending}
+                      onClick={() => toggleShopping.mutate(item)}
+                    >
+                      {item.completedAt === null ? '購入済み' : '元に戻す'}
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="destructive"
+                      disabled={toggleShopping.isPending || deleteShopping.isPending}
+                      onClick={() => deleteShopping.mutate(item.itemId)}
+                    >
+                      削除
+                    </Button>
+                  </div>
                 </li>
               ))}
             </ul>

--- a/docs/source/98_tasks/2026-08-18-web-todo/index.md
+++ b/docs/source/98_tasks/2026-08-18-web-todo/index.md
@@ -7,7 +7,7 @@
 
 ## 目的
 
-毎朝の決まった行動を当日分のチェックリストとして生成し、完了状態を記録する。あわせて、直近3日分の朝・昼・夜の献立と、現在必要な買い物を同じ画面で管理する。
+毎朝の決まった行動を当日分のチェックリストとして生成し、完了状態を記録する。あわせて、直近3日分の朝・昼・夜の献立と、買い物の必要・購入済み状態を同じ画面で管理する。
 
 チェックリスト本文は個人的な内容を含むため、公開リポジトリへ初期値・fixture・seed として置かない。認証後の設定画面から登録し、TiDB のみに保存する。
 
@@ -20,6 +20,8 @@
 3. 買い物リスト
 
 買い物が0件なら `買い物リスト：なし` と表示する。献立の空欄は `未定` として扱う。
+
+買い物項目は`購入済み`ボタンで打ち消し線を付け、リストへ残したままカゴへ入れた品を判別できる。`元に戻す`で未購入へ戻せ、不要になった項目は別の`削除`ボタンで取り除く。同名の品を再追加した場合は数量を更新して未購入へ戻す。
 
 Markdown由来の日次チェックリストとは別に、`やるべきこと`と`ブログネタ`の2分類を持つ簡単なTODOを表示する。簡単なTODOは日付で複製せず継続リストとして保持するため、未完了項目は翌日以降もそのまま持ち越される。追加、完了チェック、未完了への戻し、削除ができる。
 
@@ -57,7 +59,7 @@ Markdown由来の日次チェックリストとは別に、`やるべきこと`�
 | `todo_template_items`       | 朝・寝る前の階層テンプレート。個人的な本文はここだけに保存 |
 | `todo_daily_items`          | 日付ごとのスナップショットと完了時刻                       |
 | `todo_meals`                | 日付 × 朝昼夜の献立。未定は行を持たない                    |
-| `todo_shopping_items`       | 現在必要な買い物。同名は正規化して1件にまとめる            |
+| `todo_shopping_items`       | 買い物と購入済み時刻。同名は正規化して1件にまとめる        |
 | `todo_quick_items`          | 未完了なら翌日以降も持ち越す簡単なTODO                     |
 | `todo_morning_achievements` | 日付ごとの育児負荷、自由時間・使い方、自由記述             |
 
@@ -68,7 +70,7 @@ Markdown由来の日次チェックリストとは別に、`やるべきこと`�
 - `apps/admin-web`: `/todo`、`/todo/calendar`、`/todo/settings`、Markdown階層パーサー
 - `apps/admin-api`: 認証必須のtodo API、日次生成処理
 - `iac/aws/lib/admin/admin-stack.ts`: 5分間隔のEventBridgeルール
-- `tools/dsql-cli/dsl-tidb/schema/12_*.sql`〜`18_*.sql`: TiDB DDL
+- `tools/dsql-cli/dsl-tidb/schema/12_*.sql`〜`19_*.sql`: TiDB DDL
 
 ## 検証
 
@@ -105,15 +107,16 @@ for file in schema/12_todo_settings.sql \
   schema/15_todo_meals.sql \
   schema/16_todo_shopping_items.sql \
   schema/17_todo_quick_items.sql \
-  schema/18_todo_morning_achievements.sql; do
+  schema/18_todo_morning_achievements.sql \
+  schema/19_todo_shopping_items_completed_at.sql; do
   sed 's|${SCHEMA}|blog_dev|g' "$file"
 done | mysql -h "tidb.${TAILNET}" -P 4000 -u root -p
 
 mysql -h "tidb.${TAILNET}" -P 4000 -u root -p -D blog_dev \
-  -e "SHOW TABLES LIKE 'todo_%';"
+  -e "SHOW TABLES LIKE 'todo_%'; SHOW COLUMNS FROM todo_shopping_items LIKE 'completed_at';"
 ```
 
-7テーブルが表示されることを確認する。DDLは`CREATE TABLE IF NOT EXISTS`だけなので再実行でき、既存テーブルへの変更はない。
+7テーブルと`completed_at`カラムが表示されることを確認する。`19_todo_shopping_items_completed_at.sql`は既存テーブル向けの差分DDLなので、同じDBへは1回だけ適用する。
 
 ### 2. devデプロイ・動作確認
 
@@ -143,7 +146,7 @@ aws events describe-rule --name d-st-todo-generation \
 4. 簡単なTODOを2分類で追加でき、未完了項目が日付をまたいでも残り、完了・削除できる
 5. 朝活実績の育児負荷、自由時間、主な使い方、自由記述が数タップで保存できる
 6. カレンダーの月移動、過去日選択、完了件数・朝活実績有無の表示が動く
-7. 献立の保存・未定への戻し、買い物の同名集約・除外が動く
+7. 献立の保存・未定への戻し、買い物の同名集約・購入済み表示・未購入への戻し・削除が動く
 8. 設定した時刻の次の5分境界以降に、翌日分が1回だけ生成される
 
 DB側の確認は本文を端末へ表示しない集計だけにする。
@@ -198,12 +201,13 @@ for file in schema/12_todo_settings.sql \
   schema/15_todo_meals.sql \
   schema/16_todo_shopping_items.sql \
   schema/17_todo_quick_items.sql \
-  schema/18_todo_morning_achievements.sql; do
+  schema/18_todo_morning_achievements.sql \
+  schema/19_todo_shopping_items_completed_at.sql; do
   sed 's|${SCHEMA}|blog_prd|g' "$file"
 done | mysql -h "tidb.${TAILNET}" -P 4000 -u root -p
 
 mysql -h "tidb.${TAILNET}" -P 4000 -u root -p -D blog_prd \
-  -e "SHOW TABLES LIKE 'todo_%';"
+  -e "SHOW TABLES LIKE 'todo_%'; SHOW COLUMNS FROM todo_shopping_items LIKE 'completed_at';"
 ```
 
 ### 5. tagprリリースPRを人間がマージ
@@ -266,6 +270,8 @@ aws events disable-rule --name p-st-todo-generation
 
 ## 実施ログ
 
+- 2026-08-23: `bun run dump:prd`の初回実行は`article_embedding_chunks`読み出し中の接続切断で失敗したが、再実行で32MBの本番バックアップと全テーブルの件数検証が完了。その後`blog_prd.todo_shopping_items`へ`completed_at DATETIME(6) NULL`を追加し、既存の買い物1件が保持されていることを確認
+- 2026-08-23: `blog_dev.todo_shopping_items`へ`completed_at DATETIME(6) NULL`を追加適用。`SHOW COLUMNS`で定義を確認し、適用時点の買い物項目は0件だった
 - 2026-08-18: `blog_dev`へtodo用5テーブルをDDL適用。`SHOW TABLES LIKE 'todo_%'`で全テーブルを確認
 - 2026-08-18: ローカル認証バイパスを追加。ルート`.env.local`をadmin-apiが直接読むようにし、`/api/me`と`/api/todo`が200になることを確認
 - 2026-08-18: Playwrightで`http://localhost:43002/todo`を確認。ログイン画面へ遷移せず、チェックリスト・直近の献立・買い物リストの3セクションが表示された

--- a/tools/dsql-cli/dsl-tidb/schema/19_todo_shopping_items_completed_at.sql
+++ b/tools/dsql-cli/dsl-tidb/schema/19_todo_shopping_items_completed_at.sql
@@ -1,0 +1,3 @@
+-- 購入済み項目をリストに残したまま判別できるよう、完了時刻を保持する。
+ALTER TABLE `${SCHEMA}`.`todo_shopping_items`
+  ADD COLUMN `completed_at` DATETIME(6) NULL AFTER `quantity`;


### PR DESCRIPTION
## 概要

- 買い物項目を削除せずに「購入済み」へ切り替え、品名と数量を打ち消し線で表示できるようにする
- 購入済み状態を元に戻す操作と、不要な項目を削除する操作を分離する
- 購入済み時刻を TiDB に永続化し、同名項目の再追加時は未購入へ戻す

## 変更内容

### admin-web

- 買い物項目の型に `completedAt` を追加
- `購入済み` / `元に戻す` ボタンから購入状態を更新
- 購入済み項目へ打ち消し線と補助色を適用
- 既存の削除操作を独立した `削除` ボタンとして維持

### admin-api

- `PATCH /todo/shopping/{id}` を追加し、認証ユーザーの購入状態を更新
- ダッシュボードと買い物項目作成レスポンスへ `completedAt` を追加
- 同名項目を再追加した場合に `completed_at` をクリア
- 購入状態更新リクエストのスキーマテストを追加

### DB・ドキュメント

- `todo_shopping_items.completed_at` を追加する差分DDLを追加
- `blog_dev` と `blog_prd` へ差分DDLを適用済み
- 本番反映前にバックアップを取得し、既存の買い物項目が保持されることを確認
- Todo手順書へ仕様、DDL適用方法、実施ログを追記

## テスト

- [x] `bun --filter @shuntaka-dev/admin-api type-check`
- [x] `bun --filter @shuntaka-dev/admin-api test`（18件成功）
- [x] `bun --filter @shuntaka-dev/admin-web build`
- [x] `bun --filter @shuntaka-dev/admin-web test`（1件成功）
- [x] `bun run lint`
- [x] pre-commitのsecretlint・gitleaks
- [x] pre-pushのlint・zizmor
- [x] `blog_dev` / `blog_prd` の `completed_at` 定義と既存件数を確認
