### PR TITLE
fix: support sentencepiece on Python 3.13

### DIFF
--- a/cluster/manifests/plamo-embedding/Dockerfile
+++ b/cluster/manifests/plamo-embedding/Dockerfile
@@ -17,7 +17,7 @@ RUN pip install --no-cache-dir \
       torch==2.5.1 \
     && pip install --no-cache-dir \
       transformers==4.46.0 \
-      sentencepiece==0.2.0 \
+      sentencepiece==0.2.1 \
       fastapi==0.115.4 \
       uvicorn==0.32.0 \
       pydantic==2.9.2


### PR DESCRIPTION
## 変更概要

- Python 3.13 上で PLaMo Embedding イメージをビルドできるようにする
- Python 3.13 用 wheel が提供される `sentencepiece 0.2.1` へ更新する

## 変更内容

- `cluster/manifests/plamo-embedding/Dockerfile`
  - `sentencepiece==0.2.0` を `sentencepiece==0.2.1` へ更新

## 背景

`python:3.13-slim` では `sentencepiece 0.2.0` の対応 wheel がなく、ソースビルドへフォールバックして `cmake` / `pkg-config` 不足で失敗していた。`sentencepiece 0.2.1` は Python 3.13 用の manylinux wheel を提供している。

## テスト

- [x] `linux/amd64` 向け Docker image のbuild成功
- [x] GHCRの検証タグへのpush成功
- [x] 検証イメージで Python `3.13.15`、sentencepiece `0.2.1`、torch `2.5.1+cpu` のimport・バージョン確認
- [x] push前のlint・zizmor成功
- [x] 検証用GHCRタグを確認後に削除
